### PR TITLE
Update date picker to show upcoming years for trip planning

### DIFF
--- a/src/components/ui/LuxuryDateTimeRangePicker.tsx
+++ b/src/components/ui/LuxuryDateTimeRangePicker.tsx
@@ -172,6 +172,8 @@ export default function LuxuryDateTimeRangePicker({
                       mode="range"
                       numberOfMonths={1}
                       captionLayout="dropdown"
+                      fromYear={2024}
+                      toYear={2027}
                       selected={{
                         from: value.start ?? undefined,
                         to: value.end ?? undefined,


### PR DESCRIPTION
Configure LuxuryDateTimeRangePicker to display years from 2024 to 2027 in the dropdown.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 615c7ded-81bf-4c86-99a7-48e8a41da965
Replit-Commit-Checkpoint-Type: full_checkpoint