### PR TITLE
Replace Profile with People in mobile bottom navigation

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from "react-router-dom";
-import { Calendar, BarChart2, User, Plus, LayoutList } from "lucide-react";
+import { Calendar, BarChart2, Users, Plus, LayoutList } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -7,9 +7,10 @@ interface BottomNavigationProps {
   tripId: string | undefined;
   onQuickAddClick: () => void;
   onDetailsClick: () => void;
+  onPeopleClick: () => void;
 }
 
-const BottomNavigation = ({ tripId, onQuickAddClick, onDetailsClick }: BottomNavigationProps) => {
+const BottomNavigation = ({ tripId, onQuickAddClick, onDetailsClick, onPeopleClick }: BottomNavigationProps) => {
   const timelineItem = {
     title: "Timeline",
     icon: Calendar,
@@ -20,12 +21,6 @@ const BottomNavigation = ({ tripId, onQuickAddClick, onDetailsClick }: BottomNav
     title: "Budget",
     icon: BarChart2,
     href: tripId ? `/trip/${tripId}/budget` : "/trips",
-  };
-
-  const profileItem = {
-    title: "Profile",
-    icon: User,
-    href: "/profile",
   };
 
   return (
@@ -102,30 +97,14 @@ const BottomNavigation = ({ tripId, onQuickAddClick, onDetailsClick }: BottomNav
           }}
         </NavLink>
 
-        {/* Fifth item: Profile */}
-        <NavLink
-          to={profileItem.href}
-          className={({ isActive }) =>
-            cn(
-              "flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors",
-              isActive
-                ? "text-earth-700"
-                : "text-sand-600 hover:text-earth-600"
-            )
-          }
+        {/* Fifth item: People */}
+        <button
+          onClick={onPeopleClick}
+          className="flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors text-sand-600 hover:text-earth-600"
         >
-          {({ isActive }) => {
-            const Icon = profileItem.icon;
-            return (
-              <>
-                <Icon className={cn("h-5 w-5", isActive && "stroke-[2.5]")} />
-                <span className={cn("text-[10px]", isActive && "font-semibold")}>
-                  {profileItem.title}
-                </span>
-              </>
-            );
-          }}
-        </NavLink>
+          <Users className="h-5 w-5" />
+          <span className="text-[10px]">People</span>
+        </button>
       </div>
     </nav>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,6 +30,7 @@ export interface SidebarHandle {
   openActivityDialog: () => void;
   openReservationDialog: () => void;
   openSidebarSheet: () => void;
+  openTravelerDialog: () => void;
 }
 
 export const tripNavItems = [
@@ -71,6 +72,7 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
     openActivityDialog: () => sidebar.setActivityOpen(true),
     openReservationDialog: () => sidebar.setReservationOpen(true),
     openSidebarSheet: () => sidebar.setIsOpen(true),
+    openTravelerDialog: () => sidebar.setTravelerOpen(true),
   }));
 
   const {

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -193,6 +193,7 @@ const TripDetails = () => {
         tripId={tripId}
         onQuickAddClick={() => setQuickAddOpen(true)}
         onDetailsClick={() => sidebarRef.current?.openSidebarSheet()}
+        onPeopleClick={() => sidebarRef.current?.openTravelerDialog()}
       />
 
       {/* Quick Add Sheet */}


### PR DESCRIPTION
Updated the mobile bottom bar to show 'People' instead of 'Profile' as the far right option. When tapped, it now opens the Travelers dialog showing all trip participants.

Changes:
- Added openTravelerDialog method to Sidebar's SidebarHandle interface
- Updated BottomNavigation to use Users icon and People button
- Wired up onPeopleClick to open the Travelers dialog