### PR TITLE
Change People button to show travelers list instead of add dialog

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -31,6 +31,7 @@ export interface SidebarHandle {
   openReservationDialog: () => void;
   openSidebarSheet: () => void;
   openTravelerDialog: () => void;
+  openTravelersPanel: () => void;
 }
 
 export const tripNavItems = [
@@ -73,6 +74,7 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
     openReservationDialog: () => sidebar.setReservationOpen(true),
     openSidebarSheet: () => sidebar.setIsOpen(true),
     openTravelerDialog: () => sidebar.setTravelerOpen(true),
+    openTravelersPanel: () => sidebar.handleSubitemClick('travelers'),
   }));
 
   const {

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -193,7 +193,7 @@ const TripDetails = () => {
         tripId={tripId}
         onQuickAddClick={() => setQuickAddOpen(true)}
         onDetailsClick={() => sidebarRef.current?.openSidebarSheet()}
-        onPeopleClick={() => sidebarRef.current?.openTravelerDialog()}
+        onPeopleClick={() => sidebarRef.current?.openTravelersPanel()}
       />
 
       {/* Quick Add Sheet */}


### PR DESCRIPTION
Updated the mobile bottom bar People button to open the TravelersPanel which displays all trip participants in a list view, rather than opening the TravelerDialog which is just a form for adding/editing a single person.

Changes:
- Added openTravelersPanel method to Sidebar's SidebarHandle interface
- Method opens the secondary panel with 'travelers' key
- Updated TripDetails to call openTravelersPanel instead of openTravelerDialog
- Users can now see all trip participants when tapping People button