### PR TITLE
Fix Supabase multiple permissive policies warning

### DIFF
--- a/supabase/migrations/20260111000000_fix_rls_performance.sql
+++ b/supabase/migrations/20260111000000_fix_rls_performance.sql
@@ -264,6 +264,7 @@ CREATE POLICY "other_expenses_delete_policy" ON other_expenses
 -- =============================================================================
 
 -- Drop existing accommodation_travelers policies
+DROP POLICY IF EXISTS "acctrav_read" ON accommodation_travelers;
 DROP POLICY IF EXISTS "acctrav_d" ON accommodation_travelers;
 DROP POLICY IF EXISTS "acctrav_i" ON accommodation_travelers;
 DROP POLICY IF EXISTS "acctrav_u" ON accommodation_travelers;
@@ -329,6 +330,7 @@ CREATE POLICY "accommodation_travelers_delete_policy" ON accommodation_travelers
 -- =============================================================================
 
 -- Drop existing day_activity_travelers policies
+DROP POLICY IF EXISTS "acttrav_read" ON day_activity_travelers;
 DROP POLICY IF EXISTS "acttrav_d" ON day_activity_travelers;
 DROP POLICY IF EXISTS "acttrav_i" ON day_activity_travelers;
 DROP POLICY IF EXISTS "acttrav_u" ON day_activity_travelers;
@@ -394,6 +396,7 @@ CREATE POLICY "day_activity_travelers_delete_policy" ON day_activity_travelers
 -- =============================================================================
 
 -- Drop existing reservation_travelers policies
+DROP POLICY IF EXISTS "rsvtrav_read" ON reservation_travelers;
 DROP POLICY IF EXISTS "rsvtrav_d" ON reservation_travelers;
 DROP POLICY IF EXISTS "rsvtrav_i" ON reservation_travelers;
 DROP POLICY IF EXISTS "rsvtrav_u" ON reservation_travelers;
@@ -459,6 +462,7 @@ CREATE POLICY "reservation_travelers_delete_policy" ON reservation_travelers
 -- =============================================================================
 
 -- Drop existing transportation_travelers policies
+DROP POLICY IF EXISTS "tptrav_read" ON transportation_travelers;
 DROP POLICY IF EXISTS "tptrav_d" ON transportation_travelers;
 DROP POLICY IF EXISTS "tptrav_i" ON transportation_travelers;
 DROP POLICY IF EXISTS "tptrav_u" ON transportation_travelers;
@@ -566,6 +570,7 @@ CREATE POLICY "trip_shares_delete_policy" ON trip_shares
 -- =============================================================================
 
 -- Drop existing trip_days policies
+DROP POLICY IF EXISTS "trip_days_select_combined" ON trip_days;
 DROP POLICY IF EXISTS "Allow delete trip days with edit permission" ON trip_days;
 DROP POLICY IF EXISTS "Allow insert trip days with edit permission" ON trip_days;
 DROP POLICY IF EXISTS "Allow update trip days with edit permission" ON trip_days;

--- a/supabase/migrations/20260111000001_drop_duplicate_policies.sql
+++ b/supabase/migrations/20260111000001_drop_duplicate_policies.sql
@@ -1,0 +1,28 @@
+-- Migration to drop duplicate RLS policies that are causing performance warnings
+-- This fixes the "Multiple Permissive Policies" warnings from Supabase linter
+--
+-- The previous migration created new consolidated policies but failed to drop
+-- the old SELECT policies, resulting in duplicate policies for the same role/action.
+
+-- =============================================================================
+-- Drop duplicate SELECT policies for *_travelers tables
+-- =============================================================================
+
+-- accommodation_travelers: Drop old "acctrav_read" policy (keeping accommodation_travelers_select_policy)
+DROP POLICY IF EXISTS "acctrav_read" ON accommodation_travelers;
+
+-- day_activity_travelers: Drop old "acttrav_read" policy (keeping day_activity_travelers_select_policy)
+DROP POLICY IF EXISTS "acttrav_read" ON day_activity_travelers;
+
+-- reservation_travelers: Drop old "rsvtrav_read" policy (keeping reservation_travelers_select_policy)
+DROP POLICY IF EXISTS "rsvtrav_read" ON reservation_travelers;
+
+-- transportation_travelers: Drop old "tptrav_read" policy (keeping transportation_travelers_select_policy)
+DROP POLICY IF EXISTS "tptrav_read" ON transportation_travelers;
+
+-- =============================================================================
+-- Drop duplicate SELECT policy for trip_days table
+-- =============================================================================
+
+-- trip_days: Drop old "trip_days_select_combined" policy (keeping trip_days_select_policy)
+DROP POLICY IF EXISTS "trip_days_select_combined" ON trip_days;


### PR DESCRIPTION
This commit addresses all 'Multiple Permissive Policies' warnings from the Supabase linter by:

1. Updated existing migration (20260111000000_fix_rls_performance.sql) to include missing DROP POLICY statements for old SELECT policies
2. Created new migration (20260111000001_drop_duplicate_policies.sql) to drop duplicate policies that were not removed in the previous migration

Affected tables and policies:
- accommodation_travelers: Dropped duplicate "acctrav_read" policy
- day_activity_travelers: Dropped duplicate "acttrav_read" policy
- reservation_travelers: Dropped duplicate "rsvtrav_read" policy
- transportation_travelers: Dropped duplicate "tptrav_read" policy
- trip_days: Dropped duplicate "trip_days_select_combined" policy

Each table now has only one SELECT policy per role/action combination, eliminating the performance overhead of executing multiple policies for the same query.