### PR TITLE
Fix Stripe checkout 500 error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,22 @@ OPENAI_API_KEY=your_openai_api_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 
 # =============================================================================
+# STRIPE CONFIGURATION (required for Pro subscriptions)
+# =============================================================================
+
+# Stripe Secret Key
+# Get from: https://dashboard.stripe.com/apikeys
+# Use test key (sk_test_...) for development, live key (sk_live_...) for production
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key_here
+
+# Stripe Webhook Secret
+# Get from: https://dashboard.stripe.com/webhooks
+# Create a webhook endpoint pointing to: https://your-domain/api/stripe/webhook
+# Listen for events: checkout.session.completed, customer.subscription.updated,
+#                   customer.subscription.deleted, invoice.payment_succeeded, invoice.payment_failed
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
+
+# =============================================================================
 # OPTIONAL VARIABLES
 # =============================================================================
 
@@ -71,6 +87,8 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 #   - VITE_GOOGLE_MAPS_API_KEY
 #   - OPENAI_API_KEY (for AI assistant)
 #   - SUPABASE_SERVICE_ROLE_KEY (for server-side operations)
+#   - STRIPE_SECRET_KEY (for Pro subscriptions)
+#   - STRIPE_WEBHOOK_SECRET (for payment webhooks)
 #
 # Optional Replit Secrets:
 #   - OPENAI_CHAT_MODEL (defaults to gpt-4o-mini)

--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -21,7 +21,7 @@ function getStripe(): Stripe {
 
 function getSupabase(): SupabaseClient {
   if (!supabase) {
-    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseUrl = process.env.VITE_SUPABASE_URL;
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
     if (!supabaseUrl || !supabaseServiceKey) {
       throw new Error('Supabase configuration is missing');
@@ -79,7 +79,7 @@ router.post('/api/stripe/create-checkout', async (req: Request, res: Response) =
       return res.status(500).json({ error: 'Stripe is not configured. Please contact support.' });
     }
 
-    if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    if (!process.env.VITE_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
       console.error('Supabase environment variables are not configured');
       return res.status(500).json({ error: 'Server configuration error. Please contact support.' });
     }


### PR DESCRIPTION
The stripe.ts route was looking for SUPABASE_URL but the app only has VITE_SUPABASE_URL configured. Changed to use VITE_SUPABASE_URL to match the pattern used in ai-chat.ts. Also added Stripe env vars to .env.example.