### PR TITLE
Fix iPhone sidebar cutoff by adding safe-area-inset support

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -261,8 +261,8 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
         <div
           className="fixed left-0 w-[280px] bg-white border-r border-sand-200 z-30"
           style={{
-            top: "var(--app-nav-h, 64px)",
-            height: "calc(calc(var(--app-height, 1vh) * 100) - var(--app-nav-h, 64px))",
+            top: "calc(var(--app-nav-h, 64px) + env(safe-area-inset-top, 0px))",
+            height: "calc(calc(var(--app-height, 1vh) * 100) - var(--app-nav-h, 64px) - env(safe-area-inset-top, 0px))",
           }}
         >
           {sidebarContent}

--- a/src/components/trip/SecondaryPanel.tsx
+++ b/src/components/trip/SecondaryPanel.tsx
@@ -166,9 +166,10 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
         />
         {/* secondary sidebar */}
         <div
-          className="hidden md:block fixed left-[280px] top-16 w-[320px] z-40 overflow-y-auto border-r border-sand-200 bg-white"
+          className="hidden md:block fixed left-[280px] w-[320px] z-40 overflow-y-auto border-r border-sand-200 bg-white"
           style={{
-            height: "calc(calc(var(--app-height, 1vh) * 100) - 4rem)"
+            top: "calc(4rem + env(safe-area-inset-top, 0px))",
+            height: "calc(calc(var(--app-height, 1vh) * 100) - 4rem - env(safe-area-inset-top, 0px))"
           }}
         >
           {panel}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -33,12 +33,12 @@ const sheetVariants = cva(
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top pt-[env(safe-area-inset-top)]",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom pb-[env(safe-area-inset-bottom)]",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]",
       },
     },
     defaultVariants: {
@@ -63,7 +63,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary mt-[env(safe-area-inset-top)]">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>


### PR DESCRIPTION
Add env(safe-area-inset-top) and env(safe-area-inset-bottom) to:
- Sheet component for mobile sidebar/panel safe area padding
- Desktop Sidebar top positioning and height calculation
- SecondaryPanel top positioning and height calculation

This ensures sidebars don't extend behind the notch/Dynamic Island
on iPhones when the app is saved to the home screen as a PWA.