### PR TITLE
Set up Supabase MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist-ssr
 .env.local
 .env.*.local
 
+# MCP configuration (may contain project-specific settings)
+.mcp.json
+
 # Cache directories that should not be watched
 .cache
 .bun


### PR DESCRIPTION
Added .mcp.json to .gitignore to keep MCP server configuration out of version control since it may contain project-specific settings.