### PR TITLE
Fix mobile chat scroll issue in AI Assistant drawer

### DIFF
--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -208,7 +208,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
               )}
 
               {/* Messages area - scrollable */}
-              <div className="flex-1 min-h-0 overflow-hidden">
+              <div className="flex-1 min-h-0 overflow-y-auto">
                 <ChatMessageList
                   messages={messages}
                   isLoading={isLoading}

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -137,7 +137,8 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="flex-1 overflow-y-auto overscroll-contain px-4 py-2 space-y-1"
+      className="flex-1 overflow-y-auto overscroll-contain px-4 py-2 space-y-1 touch-pan-y"
+      style={{ WebkitOverflowScrolling: 'touch' }}
     >
       {/* Load more indicator at top */}
       {hasMore && (


### PR DESCRIPTION
The chat message list wasn't scrollable on mobile devices (especially iOS Safari)
due to `overflow-hidden` on the parent container blocking touch scroll events.

Changes:
- Change wrapper div from `overflow-hidden` to `overflow-y-auto` in AIAssistantDrawer
- Add `touch-pan-y` class and `-webkit-overflow-scrolling: touch` to ChatMessageList
  for better mobile scroll support

https://claude.ai/code/session_01H4ctzPVYhEWG7mWTHWjpcg