### PR TITLE
Fix issue where Stripe upgrade buttons fail to load

### DIFF
--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -21,7 +21,7 @@ function getStripe(): Stripe {
 
 function getSupabase(): SupabaseClient {
   if (!supabase) {
-    const supabaseUrl = process.env.VITE_SUPABASE_URL;
+    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
     if (!supabaseUrl || !supabaseServiceKey) {
       throw new Error('Supabase configuration is missing');
@@ -79,7 +79,8 @@ router.post('/api/stripe/create-checkout', async (req: Request, res: Response) =
       return res.status(500).json({ error: 'Stripe is not configured. Please contact support.' });
     }
 
-    if (!process.env.VITE_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+    if (!supabaseUrl || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
       console.error('Supabase environment variables are not configured');
       return res.status(500).json({ error: 'Server configuration error. Please contact support.' });
     }


### PR DESCRIPTION
Update server-side Supabase URL environment variable lookup to include both SUPABASE_URL and VITE_SUPABASE_URL for compatibility.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b7f6d9f6-8a59-4d93-891e-8ab2aa486df0
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 6c9065e1-3540-4bfa-a728-ad4f44792130