### PR TITLE
Add rate limiting to prevent DoS attacks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "vite_react_shadcn_ts",
@@ -56,6 +57,7 @@
         "embla-carousel-react": "^8.6.0",
         "esbuild": "0.25.11",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
         "framer-motion": "^12.29.0",
         "handlebars": "^4.7.8",
         "html-to-pdfmake": "^2.5.32",
@@ -919,6 +921,8 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
+    "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
     "extend": ["extend@3.0.2", "", {}, ""],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": "cli.js" }, ""],
@@ -1061,7 +1065,7 @@
 
     "iobuffer": ["iobuffer@5.4.0", "", {}, ""],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, ""],
+    "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, ""],
 
@@ -1874,6 +1878,8 @@
     "react-datepicker/@floating-ui/react": ["@floating-ui/react@0.27.16", "", { "dependencies": { "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "tabbable": "^6.0.0" }, "peerDependencies": { "react": ">=17.0.0", "react-dom": ">=17.0.0" } }, ""],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, ""],
+
+    "socks/ip-address": ["ip-address@10.1.0", "", {}, ""],
 
     "tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, ""],
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "embla-carousel-react": "^8.6.0",
     "esbuild": "0.25.11",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.2.1",
     "framer-motion": "^12.29.0",
     "handlebars": "^4.7.8",
     "html-to-pdfmake": "^2.5.32",

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import path from 'path';
 import fs from 'fs';
 import { createServer } from 'http';
+import rateLimit from 'express-rate-limit';
 import { registerRoutes } from './routes';
 
 const app = express();
@@ -12,6 +13,18 @@ app.use(cors());
 app.use('/api/stripe/webhook', express.raw({ type: 'application/json' }));
 
 app.use(express.json());
+
+// Rate limiting to prevent DoS attacks
+const generalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: 'Too many requests, please try again later.',
+});
+
+// Apply rate limiting to all routes
+app.use(generalLimiter);
 
 registerRoutes(app);
 


### PR DESCRIPTION
## Summary
This PR adds rate limiting middleware to the Express server to protect against Denial of Service (DoS) attacks.

## Changes
- **Dependencies**: Added `express-rate-limit@^8.2.1` package
- **Server middleware**: Implemented a general rate limiter that restricts each IP to 100 requests per 15-minute window
- **Configuration**: Rate limiter is applied globally to all routes before route registration
- **Lock file**: Updated `bun.lock` with new dependency and adjusted `ip-address` version constraint for `express-rate-limit` compatibility

## Implementation Details
- Rate limiting window: 15 minutes
- Request limit: 100 requests per IP per window
- Uses standard HTTP headers for rate limit information
- Returns a user-friendly error message when limit is exceeded
- Applied as global middleware to protect all API endpoints