### PR TITLE
Add XSS protection for blob URL validation in ChatView

### DIFF
--- a/src/components/trip/chat/ChatView.tsx
+++ b/src/components/trip/chat/ChatView.tsx
@@ -166,6 +166,14 @@ export default function ChatView({ tripId, canEdit = true }: Props) {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Validate that a URL is a safe blob URL (prevents XSS via URL injection)
+  const isSafeBlobUrl = (url: string | null): url is string => {
+    if (!url) return false;
+    // Blob URLs created by URL.createObjectURL() always start with "blob:"
+    // and are safe to use in img src attributes
+    return url.startsWith('blob:');
+  };
+
   // Fetch import usage on mount
   useEffect(() => {
     const fetchUsage = async () => {
@@ -460,7 +468,7 @@ export default function ChatView({ tripId, canEdit = true }: Props) {
               </p>
 
               {/* Live preview (image or first page of PDF) */}
-              {previewUrl ? (
+              {isSafeBlobUrl(previewUrl) ? (
                 <div className="mt-3 relative">
                   <img
                     src={previewUrl}


### PR DESCRIPTION
## Summary
Added security validation for blob URLs used in image preview rendering to prevent potential XSS attacks through URL injection.

## Changes
- **Added `isSafeBlobUrl()` type guard function** that validates URLs are legitimate blob URLs created by `URL.createObjectURL()` before using them in `img src` attributes
  - Checks that URL is not null/falsy
  - Verifies URL starts with `blob:` prefix (the only safe blob URL format)
  - Returns a TypeScript type predicate for type safety

- **Updated preview rendering logic** to use the new validation function instead of a simple truthy check on `previewUrl`
  - Changed condition from `{previewUrl ? (` to `{isSafeBlobUrl(previewUrl) ? (`
  - Ensures only validated blob URLs are rendered in the image preview

## Implementation Details
This prevents a potential XSS vulnerability where a malicious actor could inject arbitrary URLs (e.g., `javascript:` or `data:` URLs) into the preview. By restricting to only blob URLs created by the browser's `URL.createObjectURL()` API, we ensure the image source is always a safe, same-origin resource.