### PR TITLE
Add GDPR-compliant cookie consent banner with geo-targeting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,11 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ConsentProvider } from "@/contexts/ConsentContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import AppLayout from "@/components/layout/AppLayout";
 import PWAInstallPrompt from "@/components/PWAInstallPrompt";
+import CookieConsentBanner from "@/components/CookieConsentBanner";
 import Index from "./pages/Index";
 import CreateTrip from "./pages/CreateTrip";
 import NotFound from "./pages/NotFound";
@@ -37,11 +39,13 @@ const queryClient = new QueryClient({
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
+      <ConsentProvider>
         <AuthProvider>
           <TooltipProvider>
             <Toaster />
             <Sonner />
             <PWAInstallPrompt />
+            <CookieConsentBanner />
             <BrowserRouter>
               <AppLayout>
                 <Routes>
@@ -104,7 +108,8 @@ const App = () => {
             </BrowserRouter>
           </TooltipProvider>
         </AuthProvider>
-      </QueryClientProvider>
+      </ConsentProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronDown, ChevronUp, Cookie } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { useConsent } from '@/contexts/ConsentContext';
+
+export default function CookieConsentBanner() {
+  const { shouldShowBanner, acceptAll, acceptEssentialOnly, acceptCustom } = useConsent();
+  const [showDetails, setShowDetails] = useState(false);
+  const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
+  const [marketingEnabled, setMarketingEnabled] = useState(false);
+
+  if (!shouldShowBanner) return null;
+
+  const handleSavePreferences = () => {
+    acceptCustom({
+      analytics: analyticsEnabled,
+      marketing: marketingEnabled,
+    });
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 md:p-6">
+      <Card className="mx-auto max-w-2xl bg-white/95 backdrop-blur-sm border-sand-200 shadow-lg">
+        <div className="p-4 md:p-5">
+          {/* Main banner content */}
+          <div className="flex items-start gap-3">
+            <Cookie className="w-5 h-5 text-earth-500 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-sand-700">
+                We use cookies to enhance your experience. Essential cookies are required for the site to function.
+                You can choose to enable optional cookies for analytics and personalization.{' '}
+                <Link to="/privacy" className="text-earth-600 hover:text-earth-700 underline">
+                  Learn more
+                </Link>
+              </p>
+            </div>
+          </div>
+
+          {/* Action buttons */}
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button
+              onClick={acceptAll}
+              className="bg-earth-500 hover:bg-earth-600 text-white"
+              size="sm"
+            >
+              Accept All
+            </Button>
+            <Button
+              onClick={acceptEssentialOnly}
+              variant="outline"
+              size="sm"
+              className="border-sand-300 text-sand-700 hover:bg-sand-50"
+            >
+              Essential Only
+            </Button>
+            <button
+              onClick={() => setShowDetails(!showDetails)}
+              className="ml-auto flex items-center gap-1 text-xs text-sand-500 hover:text-sand-700 transition-colors"
+            >
+              Customize
+              {showDetails ? (
+                <ChevronUp className="w-3 h-3" />
+              ) : (
+                <ChevronDown className="w-3 h-3" />
+              )}
+            </button>
+          </div>
+
+          {/* Expandable details */}
+          {showDetails && (
+            <div className="mt-4 pt-4 border-t border-sand-200 space-y-4">
+              {/* Essential cookies - always on */}
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label className="text-sm font-medium text-sand-800">Essential Cookies</Label>
+                  <p className="text-xs text-sand-500">Required for the website to function properly</p>
+                </div>
+                <Switch checked disabled className="data-[state=checked]:bg-earth-500" />
+              </div>
+
+              {/* Analytics cookies */}
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="analytics-switch" className="text-sm font-medium text-sand-800">
+                    Analytics Cookies
+                  </Label>
+                  <p className="text-xs text-sand-500">Help us understand how you use our site</p>
+                </div>
+                <Switch
+                  id="analytics-switch"
+                  checked={analyticsEnabled}
+                  onCheckedChange={setAnalyticsEnabled}
+                  className="data-[state=checked]:bg-earth-500"
+                />
+              </div>
+
+              {/* Marketing cookies */}
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="marketing-switch" className="text-sm font-medium text-sand-800">
+                    Marketing Cookies
+                  </Label>
+                  <p className="text-xs text-sand-500">Used for personalized content and ads</p>
+                </div>
+                <Switch
+                  id="marketing-switch"
+                  checked={marketingEnabled}
+                  onCheckedChange={setMarketingEnabled}
+                  className="data-[state=checked]:bg-earth-500"
+                />
+              </div>
+
+              <Button
+                onClick={handleSavePreferences}
+                size="sm"
+                className="w-full bg-earth-500 hover:bg-earth-600 text-white"
+              >
+                Save Preferences
+              </Button>
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/contexts/ConsentContext.tsx
+++ b/src/contexts/ConsentContext.tsx
@@ -1,0 +1,235 @@
+import { createContext, useContext, useEffect, useState, useMemo, useCallback } from "react";
+
+// Cookie consent categories
+export interface ConsentPreferences {
+  essential: true; // Always true, cannot be disabled
+  analytics: boolean;
+  marketing: boolean;
+}
+
+interface ConsentContextType {
+  // Whether consent has been given (user made a choice)
+  hasConsented: boolean;
+  // Whether banner should be shown (non-US user who hasn't consented)
+  shouldShowBanner: boolean;
+  // Current consent preferences
+  preferences: ConsentPreferences;
+  // Whether we're still checking geo-location
+  isLoading: boolean;
+  // Accept all cookies
+  acceptAll: () => void;
+  // Accept only essential (reject optional)
+  acceptEssentialOnly: () => void;
+  // Accept with custom preferences
+  acceptCustom: (preferences: Omit<ConsentPreferences, 'essential'>) => void;
+  // Check if a specific category is consented
+  hasConsentFor: (category: keyof ConsentPreferences) => boolean;
+}
+
+const STORAGE_KEY = "wlx:gdpr:consent";
+const GEO_CACHE_KEY = "wlx:gdpr:geo";
+
+const defaultPreferences: ConsentPreferences = {
+  essential: true,
+  analytics: false,
+  marketing: false,
+};
+
+const ConsentContext = createContext<ConsentContextType>({
+  hasConsented: false,
+  shouldShowBanner: false,
+  preferences: defaultPreferences,
+  isLoading: true,
+  acceptAll: () => {},
+  acceptEssentialOnly: () => {},
+  acceptCustom: () => {},
+  hasConsentFor: () => false,
+});
+
+// Helper to safely access localStorage
+function getStorageItem(key: string): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function setStorageItem(key: string, value: string): void {
+  try {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Ignore storage errors (private browsing, etc.)
+  }
+}
+
+interface StoredConsent {
+  preferences: ConsentPreferences;
+  timestamp: number;
+  version: number;
+}
+
+interface GeoCache {
+  isUSBased: boolean;
+  timestamp: number;
+}
+
+// Check if user is in the US using a free geo-IP service
+async function checkIfUSBased(): Promise<boolean> {
+  // Check cache first (valid for 24 hours)
+  const cached = getStorageItem(GEO_CACHE_KEY);
+  if (cached) {
+    try {
+      const geoCache: GeoCache = JSON.parse(cached);
+      const dayInMs = 24 * 60 * 60 * 1000;
+      if (Date.now() - geoCache.timestamp < dayInMs) {
+        return geoCache.isUSBased;
+      }
+    } catch {
+      // Invalid cache, continue with API call
+    }
+  }
+
+  try {
+    // Using ipapi.co - free tier allows 1000 requests/day
+    const response = await fetch("https://ipapi.co/json/", {
+      signal: AbortSignal.timeout(5000), // 5 second timeout
+    });
+
+    if (!response.ok) {
+      throw new Error("Geo API request failed");
+    }
+
+    const data = await response.json();
+    const isUSBased = data.country_code === "US";
+
+    // Cache the result
+    const geoCache: GeoCache = {
+      isUSBased,
+      timestamp: Date.now(),
+    };
+    setStorageItem(GEO_CACHE_KEY, JSON.stringify(geoCache));
+
+    return isUSBased;
+  } catch (error) {
+    console.warn("Failed to determine user location, defaulting to showing consent banner:", error);
+    // If geo-lookup fails, err on the side of caution and show the banner
+    return false;
+  }
+}
+
+export const ConsentProvider = ({ children }: { children: React.ReactNode }) => {
+  const [hasConsented, setHasConsented] = useState(false);
+  const [preferences, setPreferences] = useState<ConsentPreferences>(defaultPreferences);
+  const [isUSBased, setIsUSBased] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load stored consent on mount
+  useEffect(() => {
+    const stored = getStorageItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed: StoredConsent = JSON.parse(stored);
+        setPreferences(parsed.preferences);
+        setHasConsented(true);
+      } catch {
+        // Invalid stored data, will show banner
+      }
+    }
+  }, []);
+
+  // Check geo-location
+  useEffect(() => {
+    let mounted = true;
+
+    async function checkGeo() {
+      const isUS = await checkIfUSBased();
+      if (mounted) {
+        setIsUSBased(isUS);
+        setIsLoading(false);
+      }
+    }
+
+    checkGeo();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // Save consent to localStorage
+  const saveConsent = useCallback((newPreferences: ConsentPreferences) => {
+    const stored: StoredConsent = {
+      preferences: newPreferences,
+      timestamp: Date.now(),
+      version: 1,
+    };
+    setStorageItem(STORAGE_KEY, JSON.stringify(stored));
+    setPreferences(newPreferences);
+    setHasConsented(true);
+  }, []);
+
+  const acceptAll = useCallback(() => {
+    saveConsent({
+      essential: true,
+      analytics: true,
+      marketing: true,
+    });
+  }, [saveConsent]);
+
+  const acceptEssentialOnly = useCallback(() => {
+    saveConsent({
+      essential: true,
+      analytics: false,
+      marketing: false,
+    });
+  }, [saveConsent]);
+
+  const acceptCustom = useCallback((customPreferences: Omit<ConsentPreferences, 'essential'>) => {
+    saveConsent({
+      essential: true,
+      ...customPreferences,
+    });
+  }, [saveConsent]);
+
+  const hasConsentFor = useCallback((category: keyof ConsentPreferences): boolean => {
+    if (category === 'essential') return true;
+    return hasConsented && preferences[category];
+  }, [hasConsented, preferences]);
+
+  // Determine if banner should show:
+  // - User hasn't consented yet
+  // - User is not in the US (or geo check failed)
+  // - Geo check has completed
+  const shouldShowBanner = !isLoading && !hasConsented && !isUSBased;
+
+  const contextValue = useMemo(
+    () => ({
+      hasConsented,
+      shouldShowBanner,
+      preferences,
+      isLoading,
+      acceptAll,
+      acceptEssentialOnly,
+      acceptCustom,
+      hasConsentFor,
+    }),
+    [hasConsented, shouldShowBanner, preferences, isLoading, acceptAll, acceptEssentialOnly, acceptCustom, hasConsentFor]
+  );
+
+  return (
+    <ConsentContext.Provider value={contextValue}>
+      {children}
+    </ConsentContext.Provider>
+  );
+};
+
+export const useConsent = () => {
+  const context = useContext(ConsentContext);
+  if (!context) {
+    throw new Error("useConsent must be used within a ConsentProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
Implements a minimal, non-invasive cookie consent system that:
- Only shows to users outside the US (via IP geolocation)
- Caches geo-location results for 24 hours to minimize API calls
- Provides opt-in consent for analytics and marketing cookies
- Essential cookies are always enabled (required for functionality)
- Stores user preferences in localStorage
- Follows the app's existing design patterns (sand/earth color palette)