### PR TITLE
Fix iPhone PWA safe-area insets for sidebar and secondary panels

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -296,7 +296,10 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
       {/* Keeping Sheet component for potential future use but not showing trigger */}
       <div className="md:hidden">
         <Sheet open={isOpen} onOpenChange={setIsOpen}>
-          <SheetContent side="left" className="p-0 w-[280px]">
+          <SheetContent
+            side="left"
+            className="w-[280px] px-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+          >
             <SheetHeader className="sr-only">
               <SheetTitle>Navigation Menu</SheetTitle>
               <SheetDescription>Access trip timeline, budget, and settings</SheetDescription>

--- a/src/components/trip/SecondaryPanel.tsx
+++ b/src/components/trip/SecondaryPanel.tsx
@@ -183,9 +183,9 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
     <Sheet open onOpenChange={(open) => !open && onClose()}>
       <SheetContent
         side="left"
-        className="p-0 w-full flex flex-col h-full"
+        className="w-full flex flex-col h-full px-0 pt-[env(safe-area-inset-top)] pb-0"
       >
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
           {panel}
         </div>
       </SheetContent>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,32 @@
 @tailwind utilities;
 
 @layer utilities {
+  /* iOS Safe Area Utilities for PWA/Home Screen apps */
+  .safe-pt {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+  .safe-pb {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .safe-pl {
+    padding-left: env(safe-area-inset-left, 0px);
+  }
+  .safe-pr {
+    padding-right: env(safe-area-inset-right, 0px);
+  }
+  .safe-p {
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+  }
+  .safe-mt {
+    margin-top: env(safe-area-inset-top, 0px);
+  }
+  .safe-mb {
+    margin-bottom: env(safe-area-inset-bottom, 0px);
+  }
+
   .no-scrollbar::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
When the app is installed as a PWA on iPhone (saved to home screen),
the sidebar panels were being cut off by the home indicator pill and
Dynamic Island. This adds proper safe-area-inset padding to:

- SecondaryPanel mobile Sheet (travelers, accommodations, etc.)
- Sidebar mobile Sheet

Also adds reusable safe-area utility classes (.safe-pt, .safe-pb, etc.)
for future use.