### PR TITLE
Fix image removal flow to prevent auto-saving empty URLs

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -112,8 +112,13 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
 
   const handleRemove = () => {
     setPreview('');
-    onChange('');
-    onRemove?.();
+    // If onRemove is provided, let parent handle the removal logic
+    // Otherwise fall back to calling onChange with empty string
+    if (onRemove) {
+      onRemove();
+    } else {
+      onChange('');
+    }
   };
 
   // --- position helpers ---

--- a/src/components/trip/create/ImageSection.tsx
+++ b/src/components/trip/create/ImageSection.tsx
@@ -34,6 +34,14 @@ const ImageSection: React.FC<ImageSectionProps> = ({
   const [isSearching, setIsSearching] = useState(false);
   const [results, setResults] = useState<UnsplashHit[]>([]);
 
+  // Local state to allow removing image without auto-saving
+  const [localImageUrl, setLocalImageUrl] = useState(coverImageUrl);
+
+  // Sync local state when prop changes (e.g., dialog reopens)
+  React.useEffect(() => {
+    setLocalImageUrl(coverImageUrl);
+  }, [coverImageUrl]);
+
   const searchUnsplash = async () => {
     if (!keywords.trim()) {
       toast.error("Enter a destination or vibe (e.g., 'Santorini sunset')");
@@ -62,8 +70,26 @@ const ImageSection: React.FC<ImageSectionProps> = ({
   };
 
   const selectUnsplash = (url: string) => {
+    setLocalImageUrl(url);
     onImageChange(url);
     toast.success('Cover image selected');
+  };
+
+  // Handle image removal - only update local state, don't save empty URL
+  const handleLocalRemove = () => {
+    setLocalImageUrl('');
+    // Switch to upload tab so user can pick a new image
+    // (Unsplash tab with hideUploader=true won't show anything when empty)
+    setTab('upload');
+  };
+
+  // Handle new image from upload - this should save
+  const handleUploadChange = (url: string) => {
+    if (url) {
+      setLocalImageUrl(url);
+      onImageChange(url);
+    }
+    // If url is empty (from remove), don't call onImageChange - let handleLocalRemove handle it
   };
 
   return (
@@ -117,11 +143,12 @@ const ImageSection: React.FC<ImageSectionProps> = ({
           )}
 
           {/* When an Unsplash image is selected, show preview + position only */}
-          {coverImageUrl && (
+          {localImageUrl && (
             <div className="pt-1">
               <ImageUpload
-                value={coverImageUrl}
-                onChange={onImageChange}
+                value={localImageUrl}
+                onChange={handleUploadChange}
+                onRemove={handleLocalRemove}
                 objectPosition={objectPosition}
                 onPositionChange={onPositionChange}
                 hideUploader={true}
@@ -133,8 +160,9 @@ const ImageSection: React.FC<ImageSectionProps> = ({
         {/* Upload */}
         <TabsContent value="upload">
           <ImageUpload
-            value={coverImageUrl}
-            onChange={onImageChange}
+            value={localImageUrl}
+            onChange={handleUploadChange}
+            onRemove={handleLocalRemove}
             objectPosition={objectPosition}
             onPositionChange={onPositionChange}
             hideUploader={false}


### PR DESCRIPTION
## Summary
This PR fixes the image removal behavior in the trip creation form to prevent automatically saving empty image URLs when users remove a cover image. It introduces local state management to allow users to remove images without triggering immediate saves, improving the UX when users want to change their cover image selection.

## Key Changes

- **ImageUpload component**: Modified `handleRemove()` to prioritize the `onRemove` callback when provided, allowing parent components to handle removal logic. Falls back to calling `onChange('')` only when `onRemove` is not provided.

- **ImageSection component**: 
  - Added `localImageUrl` state to track the image URL independently from the parent's `coverImageUrl` prop
  - Syncs local state when the prop changes (e.g., when dialog reopens)
  - Created `handleLocalRemove()` to clear the local image and switch to the upload tab without saving an empty URL
  - Created `handleUploadChange()` to distinguish between upload changes (which should save) and removals (which shouldn't)
  - Updated both the Unsplash preview and upload tabs to use local state and the new handlers

## Implementation Details

The key insight is that image removal and image selection are now handled differently:
- **Selection** (from Unsplash or upload): Immediately updates local state and calls `onImageChange()` to save
- **Removal**: Only clears local state and switches UI context, without calling `onImageChange()` to avoid saving an empty URL

This allows users to remove an image and select a new one in a single interaction without creating an intermediate "no image" state in the database.