### PR TITLE
Fix mobile dropdown positioning for Google Places autocomplete

### DIFF
--- a/src/components/trip/accommodation/GooglePlacesAutocomplete.tsx
+++ b/src/components/trip/accommodation/GooglePlacesAutocomplete.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Input } from "@/components/ui/input";
 import { searchPlaces, getPlaceDetails, type AutocompleteResult, type PlaceResult } from '@/utils/googleMapsLoader';
 import { ChevronDown } from 'lucide-react';
@@ -22,8 +23,33 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Update dropdown position when showing suggestions
+  useEffect(() => {
+    if (showSuggestions && containerRef.current) {
+      const updatePosition = () => {
+        const rect = containerRef.current!.getBoundingClientRect();
+        setDropdownPosition({
+          top: rect.bottom,
+          left: rect.left,
+          width: rect.width
+        });
+      };
+      updatePosition();
+
+      // Update position on scroll/resize
+      window.addEventListener('scroll', updatePosition, true);
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.removeEventListener('scroll', updatePosition, true);
+        window.removeEventListener('resize', updatePosition);
+      };
+    }
+  }, [showSuggestions]);
 
   const searchHotels = useCallback(async (query: string) => {
     if (query.length < 2) {
@@ -102,13 +128,13 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
   };
 
   const handleBlur = (e: React.FocusEvent) => {
-    // Delay hiding suggestions to allow clicking
+    // Longer timeout for mobile devices where touch events take longer to process
     setTimeout(() => {
       if (!dropdownRef.current?.contains(document.activeElement)) {
         setShowSuggestions(false);
         setSelectedIndex(-1);
       }
-    }, 150);
+    }, 300);
   };
 
   useEffect(() => {
@@ -117,8 +143,47 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
     }
   }, [autoFocus]);
 
+  const dropdownContent = showSuggestions && suggestions.length > 0 && (
+    <div
+      ref={dropdownRef}
+      className="bg-white border border-sand-200 rounded-md shadow-xl max-h-60 overflow-y-auto"
+      style={{
+        position: 'fixed',
+        top: dropdownPosition.top + 4,
+        left: dropdownPosition.left,
+        width: dropdownPosition.width,
+        zIndex: 9999
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+      onTouchStart={(e) => e.stopPropagation()}
+    >
+      {suggestions.map((suggestion, index) => (
+        <button
+          key={suggestion.place_id}
+          type="button"
+          className={`w-full px-3 py-2 text-left hover:bg-sand-50 active:bg-sand-100 border-b border-sand-100 last:border-b-0 touch-manipulation ${
+            index === selectedIndex ? 'bg-sand-100' : ''
+          }`}
+          onClick={() => handleSuggestionSelect(suggestion)}
+          onTouchEnd={(e) => {
+            e.preventDefault();
+            handleSuggestionSelect(suggestion);
+          }}
+          onMouseEnter={() => setSelectedIndex(index)}
+        >
+          <div className="font-medium text-sm">
+            {suggestion.structured_formatting.main_text}
+          </div>
+          <div className="text-xs text-sand-600">
+            {suggestion.structured_formatting.secondary_text}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+
   return (
-    <div className="relative">
+    <div className="relative" ref={containerRef}>
       <Input
         ref={inputRef}
         type="text"
@@ -127,7 +192,7 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
         onFocus={() => value.length >= 2 && suggestions.length > 0 && setShowSuggestions(true)}
-        className={`${className} relative z-50 pr-8`}
+        className={`${className} pr-8`}
         placeholder={placeholder}
         autoComplete="off"
       />
@@ -139,32 +204,8 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
       {!isLoading && showSuggestions && (
         <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-sand-500" />
       )}
-      
-      {showSuggestions && suggestions.length > 0 && (
-        <div 
-          ref={dropdownRef}
-          className="absolute z-[9999] w-full mt-1 bg-white border border-sand-200 rounded-md shadow-lg max-h-60 overflow-y-auto"
-        >
-          {suggestions.map((suggestion, index) => (
-            <button
-              key={suggestion.place_id}
-              type="button"
-              className={`w-full px-3 py-2 text-left hover:bg-sand-50 border-b border-sand-100 last:border-b-0 ${
-                index === selectedIndex ? 'bg-sand-100' : ''
-              }`}
-              onClick={() => handleSuggestionSelect(suggestion)}
-              onMouseEnter={() => setSelectedIndex(index)}
-            >
-              <div className="font-medium text-sm">
-                {suggestion.structured_formatting.main_text}
-              </div>
-              <div className="text-xs text-sand-600">
-                {suggestion.structured_formatting.secondary_text}
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
+
+      {dropdownContent && createPortal(dropdownContent, document.body)}
     </div>
   );
 };

--- a/src/components/trip/create/PrimaryDestinationInput.tsx
+++ b/src/components/trip/create/PrimaryDestinationInput.tsx
@@ -162,12 +162,13 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
   };
 
   const handleBlur = (e: React.FocusEvent) => {
+    // Longer timeout for mobile devices where touch events take longer to process
     setTimeout(() => {
       if (!dropdownRef.current?.contains(document.activeElement)) {
         setShowSuggestions(false);
         setSelectedIndex(-1);
       }
-    }, 150);
+    }, 300);
   };
 
   useEffect(() => {
@@ -187,15 +188,21 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
         width: dropdownPosition.width,
         zIndex: 9999
       } : undefined}
+      onMouseDown={(e) => e.preventDefault()} // Prevent blur when clicking dropdown
+      onTouchStart={(e) => e.stopPropagation()} // Prevent touch events from closing dropdown
     >
       {suggestions.map((suggestion, index) => (
         <button
           key={suggestion.place_id}
           type="button"
-          className={`w-full px-3 py-2 text-left hover:bg-gray-50 border-b border-gray-100 last:border-b-0 ${
+          className={`w-full px-3 py-2 text-left hover:bg-gray-50 active:bg-gray-100 border-b border-gray-100 last:border-b-0 touch-manipulation ${
             index === selectedIndex ? 'bg-gray-100' : ''
           }`}
           onClick={() => handleSuggestionSelect(suggestion)}
+          onTouchEnd={(e) => {
+            e.preventDefault();
+            handleSuggestionSelect(suggestion);
+          }}
           onMouseEnter={() => setSelectedIndex(index)}
         >
           <div className="flex items-center gap-2">

--- a/src/components/trip/dining/RestaurantSearchInput.tsx
+++ b/src/components/trip/dining/RestaurantSearchInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Input } from "@/components/ui/input";
 import { searchPlaces, getPlaceDetails, type AutocompleteResult, type PlaceResult } from '@/utils/googleMapsLoader';
 import { ChevronDown } from 'lucide-react';
@@ -18,8 +19,33 @@ const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Update dropdown position when showing suggestions
+  useEffect(() => {
+    if (showSuggestions && containerRef.current) {
+      const updatePosition = () => {
+        const rect = containerRef.current!.getBoundingClientRect();
+        setDropdownPosition({
+          top: rect.bottom,
+          left: rect.left,
+          width: rect.width
+        });
+      };
+      updatePosition();
+
+      // Update position on scroll/resize
+      window.addEventListener('scroll', updatePosition, true);
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.removeEventListener('scroll', updatePosition, true);
+        window.removeEventListener('resize', updatePosition);
+      };
+    }
+  }, [showSuggestions]);
 
   const searchRestaurants = useCallback(async (query: string) => {
     if (query.length < 2) {
@@ -93,13 +119,13 @@ const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
   };
 
   const handleBlur = (e: React.FocusEvent) => {
-    // Delay hiding suggestions to allow clicking
+    // Longer timeout for mobile devices where touch events take longer to process
     setTimeout(() => {
       if (!dropdownRef.current?.contains(document.activeElement)) {
         setShowSuggestions(false);
         setSelectedIndex(-1);
       }
-    }, 150);
+    }, 300);
   };
 
   useEffect(() => {
@@ -108,9 +134,48 @@ const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
     }
   }, [autoFocus]);
 
+  const dropdownContent = showSuggestions && suggestions.length > 0 && (
+    <div
+      ref={dropdownRef}
+      className="bg-white border border-sand-200 rounded-md shadow-xl max-h-60 overflow-y-auto"
+      style={{
+        position: 'fixed',
+        top: dropdownPosition.top + 4,
+        left: dropdownPosition.left,
+        width: dropdownPosition.width,
+        zIndex: 9999
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+      onTouchStart={(e) => e.stopPropagation()}
+    >
+      {suggestions.map((suggestion, index) => (
+        <button
+          key={suggestion.place_id}
+          type="button"
+          className={`w-full px-3 py-2 text-left hover:bg-sand-50 active:bg-sand-100 border-b border-sand-100 last:border-b-0 touch-manipulation ${
+            index === selectedIndex ? 'bg-sand-100' : ''
+          }`}
+          onClick={() => handleSuggestionSelect(suggestion)}
+          onTouchEnd={(e) => {
+            e.preventDefault();
+            handleSuggestionSelect(suggestion);
+          }}
+          onMouseEnter={() => setSelectedIndex(index)}
+        >
+          <div className="font-medium text-sm">
+            {suggestion.structured_formatting.main_text}
+          </div>
+          <div className="text-xs text-sand-600">
+            {suggestion.structured_formatting.secondary_text}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <div className="space-y-2">
-      <div className="relative">
+      <div className="relative" ref={containerRef}>
         <Input
           ref={inputRef}
           type="text"
@@ -132,32 +197,8 @@ const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
         {!isLoading && showSuggestions && (
           <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-sand-500" />
         )}
-        
-        {showSuggestions && suggestions.length > 0 && (
-          <div 
-            ref={dropdownRef}
-            className="absolute z-[999] w-full mt-1 bg-white border border-sand-200 rounded-md shadow-lg max-h-60 overflow-y-auto"
-          >
-            {suggestions.map((suggestion, index) => (
-              <button
-                key={suggestion.place_id}
-                type="button"
-                className={`w-full px-3 py-2 text-left hover:bg-sand-50 border-b border-sand-100 last:border-b-0 ${
-                  index === selectedIndex ? 'bg-sand-100' : ''
-                }`}
-                onClick={() => handleSuggestionSelect(suggestion)}
-                onMouseEnter={() => setSelectedIndex(index)}
-              >
-                <div className="font-medium text-sm">
-                  {suggestion.structured_formatting.main_text}
-                </div>
-                <div className="text-xs text-sand-600">
-                  {suggestion.structured_formatting.secondary_text}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
+
+        {dropdownContent && createPortal(dropdownContent, document.body)}
       </div>
     </div>
   );

--- a/src/components/trip/transportation/LocationSearchInput.tsx
+++ b/src/components/trip/transportation/LocationSearchInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Input } from "@/components/ui/input";
 import { searchPlaces, getPlaceDetails, type AutocompleteResult, type PlaceResult } from '@/utils/googleMapsLoader';
 import { ChevronDown } from 'lucide-react';
@@ -22,8 +23,33 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Update dropdown position when showing suggestions
+  useEffect(() => {
+    if (showSuggestions && containerRef.current) {
+      const updatePosition = () => {
+        const rect = containerRef.current!.getBoundingClientRect();
+        setDropdownPosition({
+          top: rect.bottom,
+          left: rect.left,
+          width: rect.width
+        });
+      };
+      updatePosition();
+
+      // Update position on scroll/resize
+      window.addEventListener('scroll', updatePosition, true);
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.removeEventListener('scroll', updatePosition, true);
+        window.removeEventListener('resize', updatePosition);
+      };
+    }
+  }, [showSuggestions]);
 
   const searchLocations = useCallback(async (query: string) => {
     if (query.length < 2) {
@@ -112,13 +138,13 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
   };
 
   const handleBlur = (e: React.FocusEvent) => {
-    // Delay hiding suggestions to allow clicking
+    // Longer timeout for mobile devices where touch events take longer to process
     setTimeout(() => {
       if (!dropdownRef.current?.contains(document.activeElement)) {
         setShowSuggestions(false);
         setSelectedIndex(-1);
       }
-    }, 150);
+    }, 300);
   };
 
   useEffect(() => {
@@ -127,9 +153,48 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
     }
   }, [autoFocus]);
 
+  const dropdownContent = showSuggestions && suggestions.length > 0 && (
+    <div
+      ref={dropdownRef}
+      className="bg-white border border-sand-200 rounded-md shadow-xl max-h-60 overflow-y-auto"
+      style={{
+        position: 'fixed',
+        top: dropdownPosition.top + 4,
+        left: dropdownPosition.left,
+        width: dropdownPosition.width,
+        zIndex: 9999
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+      onTouchStart={(e) => e.stopPropagation()}
+    >
+      {suggestions.map((suggestion, index) => (
+        <button
+          key={suggestion.place_id}
+          type="button"
+          className={`w-full px-3 py-2 text-left hover:bg-sand-50 active:bg-sand-100 border-b border-sand-100 last:border-b-0 touch-manipulation ${
+            index === selectedIndex ? 'bg-sand-100' : ''
+          }`}
+          onClick={() => handleSuggestionSelect(suggestion)}
+          onTouchEnd={(e) => {
+            e.preventDefault();
+            handleSuggestionSelect(suggestion);
+          }}
+          onMouseEnter={() => setSelectedIndex(index)}
+        >
+          <div className="font-medium text-sm">
+            {suggestion.structured_formatting.main_text}
+          </div>
+          <div className="text-xs text-sand-600">
+            {suggestion.structured_formatting.secondary_text}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <div className="space-y-2 w-full max-w-full">
-      <div className="relative">
+      <div className="relative" ref={containerRef}>
         <Input
           ref={inputRef}
           type="text"
@@ -150,32 +215,8 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
         {!isLoading && showSuggestions && (
           <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-sand-500" />
         )}
-        
-        {showSuggestions && suggestions.length > 0 && (
-          <div 
-            ref={dropdownRef}
-            className="absolute z-[999] w-full mt-1 bg-white border border-sand-200 rounded-md shadow-lg max-h-60 overflow-y-auto"
-          >
-            {suggestions.map((suggestion, index) => (
-              <button
-                key={suggestion.place_id}
-                type="button"
-                className={`w-full px-3 py-2 text-left hover:bg-sand-50 border-b border-sand-100 last:border-b-0 ${
-                  index === selectedIndex ? 'bg-sand-100' : ''
-                }`}
-                onClick={() => handleSuggestionSelect(suggestion)}
-                onMouseEnter={() => setSelectedIndex(index)}
-              >
-                <div className="font-medium text-sm">
-                  {suggestion.structured_formatting.main_text}
-                </div>
-                <div className="text-xs text-sand-600">
-                  {suggestion.structured_formatting.secondary_text}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
+
+        {dropdownContent && createPortal(dropdownContent, document.body)}
       </div>
     </div>
   );


### PR DESCRIPTION
- Add portal-based rendering to all Google Places autocomplete components
  to prevent dropdowns from being clipped by dialog overflow
- Add fixed positioning with dynamic position calculation for dropdowns
- Increase blur timeout from 150ms to 300ms for mobile touch events
- Add onMouseDown preventDefault to prevent focus loss when clicking dropdown
- Add onTouchStart stopPropagation to prevent touch events from closing dropdown
- Add onTouchEnd handler with preventDefault for reliable mobile selection
- Add touch-manipulation and active state styles for better mobile feedback

Affected components:
- PrimaryDestinationInput (city/destination search)
- LocationSearchInput (transportation location search)
- RestaurantSearchInput (restaurant search)
- GooglePlacesAutocomplete (hotel search)