### PR TITLE
Fix mobile trip hero issues: destination dropdown and PWA safe-area

### DIFF
--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -24,15 +24,26 @@ const Navigation: React.FC = () => {
   useEffect(() => {
     const updateVar = () => {
       if (headerRef.current) {
+        // Use getBoundingClientRect for more accurate measurement that includes transforms
+        const rect = headerRef.current.getBoundingClientRect();
         document.documentElement.style.setProperty(
           "--app-nav-h",
-          `${headerRef.current.offsetHeight}px`
+          `${rect.height}px`
         );
       }
     };
 
-    // Initial set + react to size changes
-    updateVar();
+    // Initial set after a small delay to ensure safe-area CSS is computed
+    // This is especially important for PWA standalone mode on iOS
+    const initialTimeout = setTimeout(() => {
+      updateVar();
+      // Double-check after animation frames for PWA standalone mode
+      requestAnimationFrame(() => {
+        updateVar();
+        requestAnimationFrame(updateVar);
+      });
+    }, 50);
+
     const ro = new ResizeObserver(updateVar);
     if (headerRef.current) ro.observe(headerRef.current);
 
@@ -40,6 +51,7 @@ const Navigation: React.FC = () => {
     window.addEventListener("orientationchange", updateVar);
 
     return () => {
+      clearTimeout(initialTimeout);
       ro.disconnect();
       window.removeEventListener("resize", updateVar);
       window.removeEventListener("orientationchange", updateVar);

--- a/src/components/trip/create/PrimaryDestinationInput.tsx
+++ b/src/components/trip/create/PrimaryDestinationInput.tsx
@@ -36,6 +36,7 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
+  const [isSelecting, setIsSelecting] = useState(false); // Flag to prevent blur during selection
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -98,6 +99,7 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
   };
 
   const handleSuggestionSelect = async (suggestion: AutocompleteResult) => {
+    setIsSelecting(true); // Prevent blur from closing dropdown
     setIsLoading(true);
     try {
       const details = await getPlaceDetails(suggestion.place_id);
@@ -118,6 +120,7 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
       setSelectedIndex(-1);
     } finally {
       setIsLoading(false);
+      setIsSelecting(false);
     }
   };
 
@@ -164,11 +167,13 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
   const handleBlur = (e: React.FocusEvent) => {
     // Longer timeout for mobile devices where touch events take longer to process
     setTimeout(() => {
+      // Don't close if we're in the middle of selecting a suggestion
+      if (isSelecting) return;
       if (!dropdownRef.current?.contains(document.activeElement)) {
         setShowSuggestions(false);
         setSelectedIndex(-1);
       }
-    }, 300);
+    }, 350); // Slightly longer timeout for iOS
   };
 
   useEffect(() => {
@@ -186,28 +191,43 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
         top: dropdownPosition.top + 4, // 4px vertical offset
         left: dropdownPosition.left,
         width: dropdownPosition.width,
-        zIndex: 9999
+        zIndex: 99999, // Higher z-index to ensure it's above dialog overlay (250)
+        pointerEvents: 'auto'
       } : undefined}
       onMouseDown={(e) => e.preventDefault()} // Prevent blur when clicking dropdown
-      onTouchStart={(e) => e.stopPropagation()} // Prevent touch events from closing dropdown
+      onTouchStart={(e) => {
+        // Stop propagation but don't prevent default to allow touch events to work
+        e.stopPropagation();
+      }}
     >
       {suggestions.map((suggestion, index) => (
         <button
           key={suggestion.place_id}
           type="button"
-          className={`w-full px-3 py-2 text-left hover:bg-gray-50 active:bg-gray-100 border-b border-gray-100 last:border-b-0 touch-manipulation ${
+          className={`w-full px-4 py-3 text-left hover:bg-gray-50 active:bg-gray-100 border-b border-gray-100 last:border-b-0 touch-manipulation select-none ${
             index === selectedIndex ? 'bg-gray-100' : ''
           }`}
-          onClick={() => handleSuggestionSelect(suggestion)}
-          onTouchEnd={(e) => {
+          onClick={(e) => {
             e.preventDefault();
+            e.stopPropagation();
             handleSuggestionSelect(suggestion);
+          }}
+          onTouchEnd={(e) => {
+            // Use a small delay to ensure the touch is registered properly
+            e.preventDefault();
+            e.stopPropagation();
+            // Set selecting flag immediately to prevent blur from closing dropdown
+            setIsSelecting(true);
+            // Slight delay for iOS touch event handling
+            setTimeout(() => {
+              handleSuggestionSelect(suggestion);
+            }, 10);
           }}
           onMouseEnter={() => setSelectedIndex(index)}
         >
           <div className="flex items-center gap-2">
             <MapPin className="h-4 w-4 text-gray-500 flex-shrink-0" />
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <div className="font-medium text-sm !text-gray-900 truncate">
                 {suggestion.structured_formatting.main_text}
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -131,6 +131,24 @@
     /* Safe viewport height accounting for iOS safe areas */
     /* On iOS, this ensures content doesn't clip behind notch/status bar */
     --safe-vh: calc(1dvh - (var(--sat) + var(--sab)) / 100);
+
+    /* Default nav height - will be updated by JavaScript */
+    --app-nav-h: 56px;
+  }
+
+  /* PWA standalone mode - ensure nav height variable includes safe area */
+  /* This acts as a fallback if JavaScript measurement happens before CSS is computed */
+  @media (display-mode: standalone) {
+    :root {
+      --app-nav-h: calc(56px + env(safe-area-inset-top, 0px));
+    }
+  }
+
+  /* iOS specific: navigator.standalone detection via media query */
+  @media (display-mode: standalone), (display-mode: fullscreen) {
+    :root {
+      --app-nav-h: calc(56px + env(safe-area-inset-top, 0px));
+    }
   }
 
   /* Fallback for browsers without dvh support */


### PR DESCRIPTION
- Improve destination dropdown touch handling on mobile:
  - Add isSelecting flag to prevent blur from closing dropdown during selection
  - Increase blur timeout to 350ms for better iOS touch support
  - Increase z-index to 99999 to ensure dropdown appears above dialog overlay
  - Add explicit pointer-events: auto for better touch response
  - Increase button padding and add select-none for better touch targets

- Fix hero image appearing under navigation in PWA standalone mode:
  - Update Navigation to use getBoundingClientRect() for more accurate height measurement
  - Add timeout + requestAnimationFrame calls to ensure safe-area CSS is computed
  - Add CSS fallback in index.css that sets --app-nav-h to include safe-area-inset-top
    when in display-mode: standalone (PWA mode)