### PR TITLE
Refactor boarding pass layout for mobile-first responsive design

### DIFF
--- a/src/components/trip/hero/NextTripBoardingPass.tsx
+++ b/src/components/trip/hero/NextTripBoardingPass.tsx
@@ -90,14 +90,15 @@ export function NextTripBoardingPass({
         }}
       />
 
-      {/* Decorative tear line */}
-      <div className="absolute left-0 right-0 top-[60%] md:top-auto md:left-[70%] md:right-auto md:top-0 md:bottom-0 md:w-px flex md:flex-col items-center justify-center">
-        <div className="w-full h-px md:w-px md:h-full border-t md:border-l border-dashed border-amber-300" />
+      {/* Decorative tear line - desktop only (mobile has separator in image section) */}
+      <div className="hidden md:flex absolute md:left-[70%] md:top-0 md:bottom-0 md:w-px md:flex-col items-center justify-center">
+        <div className="w-px h-full border-l border-dashed border-amber-300" />
       </div>
 
-      <div className="relative p-5 md:p-6 flex flex-col md:flex-row md:items-stretch min-h-[320px] md:min-h-[280px]">
+      {/* Desktop layout with padding */}
+      <div className="relative p-5 md:p-6 flex flex-col md:flex-row md:items-stretch min-h-[280px]">
         {/* Main Content - Left Side */}
-        <div className="flex-1 md:pr-8 pb-6 md:pb-0">
+        <div className="flex-1 md:pr-8">
           {/* Header */}
           <div className="flex items-center justify-between mb-4">
             <Badge className="bg-amber-500/20 text-amber-800 font-semibold border border-amber-300">
@@ -172,11 +173,11 @@ export function NextTripBoardingPass({
           </Button>
         </div>
 
-        {/* Right Side - Trip Image / Barcode area */}
-        <div className="md:w-[30%] flex flex-col items-center justify-center pt-6 md:pt-0 md:pl-8 border-t md:border-t-0 border-dashed border-amber-300">
-          {/* Trip Cover Image (small) */}
+        {/* Right Side - Desktop only */}
+        <div className="hidden md:flex md:w-[30%] flex-col items-center justify-center md:pl-8">
+          {/* Trip Cover Image */}
           {trip.cover_image_url && (
-            <div className="w-24 h-24 md:w-32 md:h-32 rounded-xl overflow-hidden shadow-lg mb-4 border-2 border-amber-200">
+            <div className="w-32 h-32 rounded-xl overflow-hidden shadow-lg mb-4 border-2 border-amber-200">
               <img
                 src={trip.cover_image_url}
                 alt={trip.destination}
@@ -200,6 +201,39 @@ export function NextTripBoardingPass({
           </div>
         </div>
       </div>
+
+      {/* Mobile full-width image section */}
+      {trip.cover_image_url && (
+        <div className="relative md:hidden">
+          {/* Dashed separator line */}
+          <div className="absolute top-0 left-0 right-0 border-t border-dashed border-amber-300" />
+
+          {/* Full-width image */}
+          <div className="h-48 w-full overflow-hidden">
+            <img
+              src={trip.cover_image_url}
+              alt={trip.destination}
+              className="w-full h-full object-cover"
+            />
+          </div>
+
+          {/* Barcode overlay at bottom */}
+          <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-4 flex flex-col items-center">
+            <div className="flex gap-0.5 h-10 items-end">
+              {Array.from({ length: 24 }, (_, i) => (
+                <div
+                  key={i}
+                  className="w-1 bg-white/80"
+                  style={{ height: `${Math.random() * 60 + 40}%` }}
+                />
+              ))}
+            </div>
+            <div className="text-xs font-mono text-white/80 mt-1">
+              {trip.trip_id.slice(0, 12).toUpperCase()}
+            </div>
+          </div>
+        </div>
+      )}
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
Restructured the NextTripBoardingPass component to implement a true mobile-first responsive design. The desktop layout now uses a side-by-side design with the trip image on the right, while mobile displays a full-width image section below the main content with an overlaid barcode.

## Key Changes
- **Tear line decoration**: Simplified to desktop-only (`hidden md:flex`) with cleaner styling, removing unnecessary mobile horizontal variant
- **Main content container**: Unified minimum height (`min-h-[280px]`) across breakpoints and removed mobile-specific bottom padding
- **Left side content**: Removed unnecessary `pb-6 md:pb-0` padding since the layout no longer needs mobile separation
- **Right side (desktop)**: Hidden on mobile (`hidden md:flex`), fixed image size to `w-32 h-32`, and removed the mobile border separator
- **New mobile image section**: Added full-width image display below main content with:
  - Dashed separator line at the top
  - Full-height image with proper aspect ratio
  - Barcode overlay positioned at the bottom with gradient background
  - Responsive barcode visualization with trip ID display

## Implementation Details
- Mobile and desktop layouts are now completely separate, improving code clarity and maintainability
- The barcode visualization on mobile uses a procedural bar height generation for a realistic appearance
- Gradient overlay on mobile image ensures barcode readability over the image
- All responsive utilities properly scoped to their respective breakpoints