### PR TITLE
Add real-time viewing status indicators for shared trips

### DIFF
--- a/src/components/trip/TimelineView.tsx
+++ b/src/components/trip/TimelineView.tsx
@@ -13,6 +13,7 @@ import { useTransportationEvents } from '@/hooks/use-transportation-events';
 import { useSessionKeepAlive } from '@/hooks/useSessionKeepAlive';
 import { AIAssistantPanel } from './ai-assistant';
 import { useWeather } from '@/hooks/useWeather';
+import ViewingStatusAvatars from './timeline/ViewingStatusAvatars';
 
 interface TimelineViewProps {
   tripId: string;
@@ -198,7 +199,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
 
       {/* Timeline Content - Left side, 60% width on desktop, full width on mobile */}
       <div className="w-full md:w-[60%] px-1 md:px-4 space-y-8">
-        <div className="flex justify-between items-center mb-6 pt-4 md:pt-0">
+        <div className="flex justify-between items-center mb-2 pt-4 md:pt-0">
           <h2 className="text-2xl font-bold text-earth-500">Trip Timeline</h2>
           <div className="flex gap-2">
             <Button
@@ -215,6 +216,10 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
               className="bg-earth-500 hover:bg-earth-600 text-white text-xs sm:text-sm px-2 sm:px-4"
             />
           </div>
+        </div>
+
+        <div className="mb-4">
+          <ViewingStatusAvatars tripId={tripId} />
         </div>
 
         <ShareTripDialog

--- a/src/components/trip/timeline/ViewingStatusAvatars.tsx
+++ b/src/components/trip/timeline/ViewingStatusAvatars.tsx
@@ -1,0 +1,204 @@
+import React, { useMemo } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { useTripViewingStatus } from "@/hooks/useTripViewingStatus";
+import { useTravelers, Traveler } from "@/hooks/useTravelers";
+
+interface ViewingStatusAvatarsProps {
+  tripId: string;
+  maxShow?: number;
+}
+
+type ViewingCategory = "active" | "viewed" | "never";
+
+interface TravelerWithViewStatus extends Traveler {
+  viewingCategory: ViewingCategory;
+  lastViewed?: string;
+}
+
+const ViewingStatusAvatars: React.FC<ViewingStatusAvatarsProps> = ({
+  tripId,
+  maxShow = 8,
+}) => {
+  const { travelers, loading: travelersLoading } = useTravelers(tripId);
+  const { viewingStatuses, isLoading: statusLoading } = useTripViewingStatus(tripId);
+
+  // Combine travelers with their viewing status
+  const travelersWithStatus = useMemo(() => {
+    if (!travelers || travelers.length === 0) return [];
+
+    return travelers.map((traveler): TravelerWithViewStatus => {
+      // Find viewing status for this traveler by matching shared_with_user_id
+      const status = viewingStatuses.find((vs) => {
+        // Match by shared_with_user_id (auth.users.id)
+        return traveler.shared_with_user_id && vs.user_id === traveler.shared_with_user_id;
+      });
+
+      let viewingCategory: ViewingCategory = "never";
+      let lastViewed: string | undefined;
+
+      if (status) {
+        if (status.currently_viewing) {
+          viewingCategory = "active";
+        } else {
+          viewingCategory = "viewed";
+        }
+        lastViewed = status.last_viewed_at;
+      }
+
+      return {
+        ...traveler,
+        viewingCategory,
+        lastViewed,
+      };
+    }).sort((a, b) => {
+      // Sort: active first, then viewed, then never
+      const order: Record<ViewingCategory, number> = { active: 0, viewed: 1, never: 2 };
+      return order[a.viewingCategory] - order[b.viewingCategory];
+    });
+  }, [travelers, viewingStatuses]);
+
+  // All travelers with their status (could filter current user if desired)
+  const displayTravelers = travelersWithStatus;
+
+  if (travelersLoading || statusLoading) {
+    return null;
+  }
+
+  if (displayTravelers.length === 0) {
+    return null;
+  }
+
+  const getInitials = (firstName?: string | null, lastName?: string | null) => {
+    const f = (firstName ?? "").trim();
+    const l = (lastName ?? "").trim();
+    const a = f ? f[0].toUpperCase() : "";
+    const b = l ? l[0].toUpperCase() : "";
+    return a + b || a || "?";
+  };
+
+  const getBorderColor = (category: ViewingCategory): string => {
+    switch (category) {
+      case "active":
+        return "ring-green-500"; // Green for actively viewing
+      case "viewed":
+        return "ring-gray-400"; // Grey for has viewed
+      case "never":
+        return "ring-gray-800"; // Black/dark for never viewed
+    }
+  };
+
+  const getStatusText = (category: ViewingCategory, lastViewed?: string): string => {
+    switch (category) {
+      case "active":
+        return "Currently viewing";
+      case "viewed":
+        if (lastViewed) {
+          const date = new Date(lastViewed);
+          const now = new Date();
+          const diffMs = now.getTime() - date.getTime();
+          const diffMins = Math.floor(diffMs / 60000);
+          const diffHours = Math.floor(diffMs / 3600000);
+          const diffDays = Math.floor(diffMs / 86400000);
+
+          if (diffMins < 1) return "Just now";
+          if (diffMins < 60) return `${diffMins}m ago`;
+          if (diffHours < 24) return `${diffHours}h ago`;
+          if (diffDays === 1) return "Yesterday";
+          return date.toLocaleDateString();
+        }
+        return "Viewed";
+      case "never":
+        return "Not yet viewed";
+    }
+  };
+
+  const visible = displayTravelers.slice(0, maxShow);
+  const overflowCount = Math.max(0, displayTravelers.length - maxShow);
+
+  // Count by status for summary
+  const activeCount = displayTravelers.filter((t) => t.viewingCategory === "active").length;
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-2">
+        <div className="flex -space-x-2">
+          {visible.map((t) => {
+            const initials = getInitials(t.first_name, t.last_name);
+            const displayName = [t.first_name, t.last_name].filter(Boolean).join(" ");
+            const statusText = getStatusText(t.viewingCategory, t.lastViewed);
+            const borderColor = getBorderColor(t.viewingCategory);
+
+            return (
+              <Tooltip key={t.id}>
+                <TooltipTrigger asChild>
+                  <Avatar
+                    className={`h-8 w-8 ring-2 ${borderColor} hover:z-10 cursor-default transition-all ${
+                      t.viewingCategory === "active" ? "ring-[3px]" : ""
+                    }`}
+                  >
+                    {t.avatar_url && (
+                      <AvatarImage src={t.avatar_url} alt={displayName} />
+                    )}
+                    <AvatarFallback
+                      className={`text-xs font-medium text-white ${
+                        t.is_owner ? "bg-earth-600" : "bg-sand-500"
+                      }`}
+                    >
+                      {initials}
+                    </AvatarFallback>
+                  </Avatar>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-sm">
+                    <p className="font-medium">
+                      {displayName}
+                      {t.is_owner ? " (Owner)" : ""}
+                    </p>
+                    <p className={`text-xs ${
+                      t.viewingCategory === "active"
+                        ? "text-green-600"
+                        : t.viewingCategory === "viewed"
+                        ? "text-gray-500"
+                        : "text-gray-400"
+                    }`}>
+                      {statusText}
+                    </p>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+
+          {overflowCount > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-400 text-xs font-medium text-white ring-2 ring-white hover:z-10">
+                  +{overflowCount}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-sm">
+                  {overflowCount} more traveler{overflowCount > 1 ? "s" : ""}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+
+        {activeCount > 0 && (
+          <span className="text-xs text-gray-500">
+            {activeCount === 1 ? "1 viewing" : `${activeCount} viewing`}
+          </span>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+};
+
+export default ViewingStatusAvatars;

--- a/src/hooks/useTravelers.ts
+++ b/src/hooks/useTravelers.ts
@@ -8,6 +8,7 @@ export interface Traveler {
   first_name: string;
   last_name?: string;
   shared_with_email?: string;
+  shared_with_user_id?: string | null;
   permission_level?: "edit" | "read";
   created_at: string;
   is_owner?: boolean;
@@ -39,6 +40,7 @@ export function useTravelers(tripId: string) {
         first_name: traveler.first_name || 'Traveler',
         last_name: traveler.last_name || '',
         shared_with_email: traveler.shared_with_email,
+        shared_with_user_id: (traveler as any).shared_with_user_id || null,
         permission_level: (traveler as any).permission_level || 'read',
         created_at: traveler.created_at,
         is_owner: traveler.is_owner || false,

--- a/src/hooks/useTripViewingStatus.ts
+++ b/src/hooks/useTripViewingStatus.ts
@@ -1,0 +1,257 @@
+import { useEffect, useRef, useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+
+export interface ViewingStatus {
+  id: string;
+  trip_id: string;
+  user_id: string;
+  last_viewed_at: string;
+  currently_viewing: boolean;
+  presence_updated_at: string;
+}
+
+export interface ViewingStatusWithProfile extends ViewingStatus {
+  profile?: {
+    full_name: string | null;
+    avatar_url: string | null;
+  };
+  tripShare?: {
+    first_name: string;
+    last_name: string | null;
+    shared_with_email: string | null;
+    is_owner: boolean;
+  };
+}
+
+// Presence is considered stale after 2 minutes without update
+const PRESENCE_STALE_MS = 2 * 60 * 1000;
+// Update presence every 30 seconds while viewing
+const PRESENCE_UPDATE_INTERVAL_MS = 30 * 1000;
+
+export function useTripViewingStatus(tripId: string) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const presenceIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const hasMarkedViewingRef = useRef(false);
+
+  // Fetch all viewing statuses for this trip with user profiles
+  const { data: viewingStatuses = [], isLoading } = useQuery({
+    queryKey: ["trip-view-status", tripId],
+    queryFn: async () => {
+      if (!tripId) return [];
+
+      // Get viewing statuses
+      const { data: statuses, error } = await supabase
+        .from("trip_view_status")
+        .select("*")
+        .eq("trip_id", tripId);
+
+      if (error) {
+        console.error("Error fetching viewing statuses:", error);
+        throw error;
+      }
+
+      if (!statuses || statuses.length === 0) return [];
+
+      // Get user IDs to fetch profiles
+      const userIds = statuses.map((s) => s.user_id);
+
+      // Fetch profiles for these users
+      const { data: profiles } = await supabase
+        .from("profiles")
+        .select("id, full_name, avatar_url")
+        .in("id", userIds);
+
+      // Fetch trip_shares for these users (for names and owner status)
+      const { data: tripShares } = await supabase
+        .from("trip_shares")
+        .select("shared_with_user_id, first_name, last_name, shared_with_email, is_owner")
+        .eq("trip_id", tripId)
+        .in("shared_with_user_id", userIds);
+
+      // Combine the data
+      const now = new Date();
+      return statuses.map((status) => {
+        const profile = profiles?.find((p) => p.id === status.user_id);
+        const tripShare = tripShares?.find((ts) => ts.shared_with_user_id === status.user_id);
+
+        // Check if presence is stale
+        const presenceUpdatedAt = new Date(status.presence_updated_at);
+        const isStale = now.getTime() - presenceUpdatedAt.getTime() > PRESENCE_STALE_MS;
+
+        return {
+          ...status,
+          // Override currently_viewing if presence is stale
+          currently_viewing: status.currently_viewing && !isStale,
+          profile: profile ? {
+            full_name: profile.full_name,
+            avatar_url: profile.avatar_url,
+          } : undefined,
+          tripShare: tripShare ? {
+            first_name: tripShare.first_name,
+            last_name: tripShare.last_name,
+            shared_with_email: tripShare.shared_with_email,
+            is_owner: tripShare.is_owner,
+          } : undefined,
+        } as ViewingStatusWithProfile;
+      });
+    },
+    enabled: !!tripId,
+    staleTime: 10_000,
+    refetchInterval: 60_000, // Refetch every minute to check for stale presence
+  });
+
+  // Mark current user as viewing
+  const markAsViewing = useCallback(async () => {
+    if (!tripId || !user?.id) return;
+
+    try {
+      const { error } = await supabase
+        .from("trip_view_status")
+        .upsert(
+          {
+            trip_id: tripId,
+            user_id: user.id,
+            currently_viewing: true,
+            last_viewed_at: new Date().toISOString(),
+            presence_updated_at: new Date().toISOString(),
+          },
+          {
+            onConflict: "trip_id,user_id",
+          }
+        );
+
+      if (error) {
+        console.error("Error marking as viewing:", error);
+      } else {
+        hasMarkedViewingRef.current = true;
+      }
+    } catch (err) {
+      console.error("Error in markAsViewing:", err);
+    }
+  }, [tripId, user?.id]);
+
+  // Update presence timestamp (heartbeat)
+  const updatePresence = useCallback(async () => {
+    if (!tripId || !user?.id || !hasMarkedViewingRef.current) return;
+
+    try {
+      const { error } = await supabase
+        .from("trip_view_status")
+        .update({
+          presence_updated_at: new Date().toISOString(),
+          currently_viewing: true,
+        })
+        .eq("trip_id", tripId)
+        .eq("user_id", user.id);
+
+      if (error) {
+        console.error("Error updating presence:", error);
+      }
+    } catch (err) {
+      console.error("Error in updatePresence:", err);
+    }
+  }, [tripId, user?.id]);
+
+  // Mark current user as not viewing
+  const markAsNotViewing = useCallback(async () => {
+    if (!tripId || !user?.id) return;
+
+    try {
+      const { error } = await supabase
+        .from("trip_view_status")
+        .update({
+          currently_viewing: false,
+          presence_updated_at: new Date().toISOString(),
+        })
+        .eq("trip_id", tripId)
+        .eq("user_id", user.id);
+
+      if (error) {
+        console.error("Error marking as not viewing:", error);
+      }
+    } catch (err) {
+      console.error("Error in markAsNotViewing:", err);
+    }
+  }, [tripId, user?.id]);
+
+  // Set up presence tracking on mount/unmount
+  useEffect(() => {
+    if (!tripId || !user?.id) return;
+
+    // Mark as viewing when component mounts
+    markAsViewing();
+
+    // Set up periodic presence update
+    presenceIntervalRef.current = setInterval(updatePresence, PRESENCE_UPDATE_INTERVAL_MS);
+
+    // Handle visibility change (tab switching)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        markAsViewing();
+      } else {
+        markAsNotViewing();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // Cleanup on unmount
+    return () => {
+      if (presenceIntervalRef.current) {
+        clearInterval(presenceIntervalRef.current);
+      }
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      // Mark as not viewing when leaving
+      markAsNotViewing();
+      hasMarkedViewingRef.current = false;
+    };
+  }, [tripId, user?.id, markAsViewing, markAsNotViewing, updatePresence]);
+
+  // Set up real-time subscription for viewing status changes
+  useEffect(() => {
+    if (!tripId) return;
+
+    const channel = supabase
+      .channel(`trip-view-status:${tripId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "trip_view_status",
+          filter: `trip_id=eq.${tripId}`,
+        },
+        () => {
+          // Invalidate query to refetch data
+          queryClient.invalidateQueries({ queryKey: ["trip-view-status", tripId] });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [tripId, queryClient]);
+
+  // Get viewing status category for a user
+  const getViewingCategory = useCallback(
+    (userId: string): "active" | "viewed" | "never" => {
+      const status = viewingStatuses.find((s) => s.user_id === userId);
+      if (!status) return "never";
+      if (status.currently_viewing) return "active";
+      return "viewed";
+    },
+    [viewingStatuses]
+  );
+
+  return {
+    viewingStatuses,
+    isLoading,
+    getViewingCategory,
+    markAsViewing,
+    markAsNotViewing,
+  };
+}

--- a/src/integrations/supabase/types/database.ts
+++ b/src/integrations/supabase/types/database.ts
@@ -887,6 +887,44 @@ export type Database = {
         }
         Relationships: []
       }
+      trip_view_status: {
+        Row: {
+          id: string
+          trip_id: string
+          user_id: string
+          last_viewed_at: string
+          currently_viewing: boolean
+          presence_updated_at: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          trip_id: string
+          user_id: string
+          last_viewed_at?: string
+          currently_viewing?: boolean
+          presence_updated_at?: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          trip_id?: string
+          user_id?: string
+          last_viewed_at?: string
+          currently_viewing?: boolean
+          presence_updated_at?: string
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trip_view_status_trip_id_fkey"
+            columns: ["trip_id"]
+            isOneToOne: false
+            referencedRelation: "trips"
+            referencedColumns: ["trip_id"]
+          }
+        ]
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/20260125200000_create_trip_view_status.sql
+++ b/supabase/migrations/20260125200000_create_trip_view_status.sql
@@ -1,0 +1,77 @@
+-- Trip View Status Migration
+-- Tracks which users have viewed or are actively viewing a trip
+-- Enables real-time presence indicators for shared trips
+
+BEGIN;
+
+-- ============================================
+-- Create the trip_view_status table
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS trip_view_status (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id UUID NOT NULL REFERENCES trips(trip_id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  -- When the user last viewed the trip
+  last_viewed_at TIMESTAMPTZ DEFAULT now(),
+  -- Whether the user is currently viewing (for real-time presence)
+  currently_viewing BOOLEAN DEFAULT false,
+  -- Timestamp for when presence was last updated (for stale detection)
+  presence_updated_at TIMESTAMPTZ DEFAULT now(),
+  created_at TIMESTAMPTZ DEFAULT now(),
+
+  -- Each user can only have one status per trip
+  UNIQUE(trip_id, user_id)
+);
+
+-- Index for efficient queries
+CREATE INDEX IF NOT EXISTS idx_trip_view_status_trip_id ON trip_view_status(trip_id);
+CREATE INDEX IF NOT EXISTS idx_trip_view_status_user_id ON trip_view_status(user_id);
+CREATE INDEX IF NOT EXISTS idx_trip_view_status_currently_viewing ON trip_view_status(trip_id, currently_viewing) WHERE currently_viewing = true;
+
+-- ============================================
+-- Enable RLS
+-- ============================================
+
+ALTER TABLE trip_view_status ENABLE ROW LEVEL SECURITY;
+
+-- ============================================
+-- RLS Policies
+-- Key requirement: Anyone on the shared list can see everyone else's status
+-- ============================================
+
+-- SELECT: Users can see view status for trips they have access to
+-- This includes the trip owner and anyone in trip_shares
+CREATE POLICY "trip_view_status_select_policy" ON trip_view_status
+  FOR SELECT TO authenticated
+  USING (
+    -- User has access to the trip (owner or shared with)
+    can_access_trip(trip_id)
+  );
+
+-- INSERT: Users can insert their own view status for trips they have access to
+CREATE POLICY "trip_view_status_insert_policy" ON trip_view_status
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = auth.uid()
+    AND can_access_trip(trip_id)
+  );
+
+-- UPDATE: Users can only update their own view status
+CREATE POLICY "trip_view_status_update_policy" ON trip_view_status
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- DELETE: Users can only delete their own view status
+CREATE POLICY "trip_view_status_delete_policy" ON trip_view_status
+  FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- ============================================
+-- Enable real-time for this table
+-- ============================================
+
+ALTER PUBLICATION supabase_realtime ADD TABLE trip_view_status;
+
+COMMIT;


### PR DESCRIPTION
## Summary
This PR adds real-time presence tracking and viewing status indicators for shared trips. Users can now see which trip collaborators are actively viewing the trip, who has viewed it previously, and who hasn't viewed it yet.

## Key Changes

- **New `ViewingStatusAvatars` component**: Displays avatars of trip collaborators with color-coded status indicators:
  - Green ring: Currently actively viewing
  - Gray ring: Has viewed previously
  - Dark gray ring: Never viewed
  - Shows last viewed timestamp in tooltips
  - Displays count of users currently viewing

- **New `useTripViewingStatus` hook**: Manages viewing status tracking with:
  - Real-time presence updates via Supabase subscriptions
  - Automatic heartbeat every 30 seconds while viewing
  - Stale presence detection (2-minute timeout)
  - Visibility change detection (pauses tracking when tab is hidden)
  - Automatic cleanup on unmount

- **New `trip_view_status` database table**: Tracks viewing activity with:
  - `currently_viewing` flag for real-time presence
  - `last_viewed_at` timestamp for historical tracking
  - `presence_updated_at` for stale detection
  - RLS policies ensuring users can only see status for trips they have access to
  - Real-time publication enabled for instant updates

- **Updated `useTravelers` hook**: Added `shared_with_user_id` field to support matching travelers with viewing status records

- **Updated `TimelineView` component**: Integrated the new `ViewingStatusAvatars` component below the timeline header

## Implementation Details

- Presence is considered stale after 2 minutes without an update, automatically marking users as not actively viewing
- The component sorts travelers by viewing status (active → viewed → never) for better UX
- Supports overflow handling with a "+N more" indicator when there are more than 8 travelers
- Uses React Query for efficient data fetching and caching with 10-second stale time
- Real-time updates via Supabase Postgres Changes subscription
- Gracefully handles loading states and empty states