### PR TITLE
Fix mobile chat input causing layout shift when keyboard opens

### DIFF
--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -133,7 +133,21 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
   return (
     <>
       <Drawer open={open} onOpenChange={handleOpenChange}>
-        <DrawerContent className="h-[100dvh] max-h-[100dvh] flex flex-col rounded-none [&>div:first-child]:hidden">
+        <DrawerContent
+          className="flex flex-col rounded-none [&>div:first-child]:hidden"
+          style={{
+            // Use fixed positioning filling the screen
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            // Prevent scroll chaining that causes content to escape bounds
+            overscrollBehavior: 'contain',
+            // Contain all content within bounds
+            overflow: 'hidden',
+          }}
+        >
           {/* Header with safe area padding for PWA/notch */}
           <DrawerHeader
             className="border-b border-sand-200 pb-3 flex-shrink-0"
@@ -212,8 +226,8 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
                 </div>
               )}
 
-              {/* Messages area - scrollable */}
-              <div className="flex-1 min-h-0 overflow-y-auto">
+              {/* Messages area - scrollable with contained scroll behavior */}
+              <div className="flex-1 min-h-0 overflow-y-auto" style={{ overscrollBehavior: 'contain' }}>
                 <ChatMessageList
                   messages={messages}
                   isLoading={isLoading}
@@ -242,7 +256,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
 
               {/* Input - with safe area padding for PWA bottom inset */}
               <div
-                className="flex-shrink-0"
+                className="flex-shrink-0 bg-white"
                 style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
               >
                 <ChatInput

--- a/src/components/trip/ai-assistant/ChatInput.tsx
+++ b/src/components/trip/ai-assistant/ChatInput.tsx
@@ -30,6 +30,18 @@ const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [message]);
 
+  // Handle focus to prevent browser auto-scroll issues on mobile
+  const handleFocus = useCallback(() => {
+    // Prevent the browser from auto-scrolling the entire page
+    // Use a small timeout to let the keyboard appear first
+    setTimeout(() => {
+      if (textareaRef.current) {
+        // Scroll the textarea into view within its container only
+        textareaRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    }, 100);
+  }, []);
+
   const handleSend = useCallback(() => {
     const trimmed = message.trim();
     // Can send if has message OR has attachment
@@ -117,6 +129,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             value={message}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
             placeholder={attachment ? 'Add a message (optional)...' : placeholder}
             disabled={disabled || isSending}
             rows={1}


### PR DESCRIPTION
- Replace h-[100dvh] with fixed positioning (top/bottom/left/right: 0)
  to prevent viewport resize issues when mobile keyboard appears
- Add overscrollBehavior: contain to drawer and messages area to
  prevent scroll chaining that causes content to escape bounds
- Add overflow: hidden to drawer container to contain all content
- Add handleFocus to ChatInput that uses scrollIntoView with
  block: nearest to prevent aggressive browser auto-scroll
- Add bg-white to input container for proper layering

Fixes issue where tapping chat input on mobile PWA caused the output
field to shift up and extend above the safe area region.

https://claude.ai/code/session_013VziyBmrTvNs4nEoKKFp2f