### PR TITLE
Allow trip preview for pending share invites via RLS-safe function

### DIFF
--- a/src/services/tripSharingService.ts
+++ b/src/services/tripSharingService.ts
@@ -312,6 +312,7 @@ export const getSharedTrips = async () => {
     );
 
     // Get owner information for each shared trip
+    // Also fetch trip preview for pending invites where RLS blocks trip data
     const processedData = await Promise.all(filteredData.map(async (share: any) => {
       // Fetch the owner's profile information
       const { data: ownerData } = await supabase
@@ -350,9 +351,31 @@ export const getSharedTrips = async () => {
         ownerName = emailPrefix.charAt(0).toUpperCase() + emailPrefix.slice(1);
       }
 
+      // For pending invites where trips is null (RLS blocks full trip data),
+      // fetch basic trip preview via SECURITY DEFINER function
+      let tripData = share.trips;
+      if (!tripData && share.share_status === 'pending') {
+        const { data: preview } = await supabase.rpc('get_pending_trip_preview', {
+          p_share_id: share.id
+        });
+        if (preview && preview.length > 0) {
+          // Map the preview data to match expected trip structure
+          tripData = {
+            trip_id: preview[0].trip_id,
+            destination: preview[0].destination,
+            primary_destination: preview[0].primary_destination,
+            arrival_date: preview[0].arrival_date,
+            departure_date: preview[0].departure_date,
+            cover_image_url: preview[0].cover_image_url,
+            // Mark as preview so UI knows not to expect full data
+            _is_preview: true
+          };
+        }
+      }
+
       return {
         ...share,
-        trips: share.trips || null,
+        trips: tripData,
         owner_name: ownerName,
         owner_email: ownerEmail
       };

--- a/supabase/migrations/20260202000000_pending_invite_trip_preview.sql
+++ b/supabase/migrations/20260202000000_pending_invite_trip_preview.sql
@@ -1,0 +1,54 @@
+-- Allow recipients to see basic trip info for pending invites
+-- so they can display in MyTrips with Accept/Decline buttons.
+
+CREATE OR REPLACE FUNCTION get_pending_trip_preview(p_share_id uuid)
+RETURNS TABLE (
+  trip_id uuid,
+  destination text,
+  primary_destination text,
+  arrival_date date,
+  departure_date date,
+  cover_image_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+DECLARE
+  user_email text;
+  v_trip_id uuid;
+BEGIN
+  user_email := LOWER(auth.jwt() ->> 'email');
+
+  IF user_email IS NULL OR user_email = '' THEN
+    RETURN;
+  END IF;
+
+  -- Get trip_id from share, verifying the caller is the recipient and status is pending
+  SELECT ts.trip_id INTO v_trip_id
+  FROM trip_shares ts
+  WHERE ts.id = p_share_id
+    AND LOWER(ts.shared_with_email) = user_email
+    AND ts.share_status = 'pending'
+    AND ts.shared_by_user_id <> COALESCE(ts.shared_with_user_id, '00000000-0000-0000-0000-000000000000'::uuid);
+
+  IF v_trip_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Return basic trip info for display purposes
+  RETURN QUERY
+  SELECT
+    t.trip_id,
+    t.destination,
+    t.primary_destination,
+    t.arrival_date,
+    t.departure_date,
+    t.cover_image_url
+  FROM trips t
+  WHERE t.trip_id = v_trip_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_pending_trip_preview(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
This PR enables users to see basic trip information for pending share invitations, even when Row-Level Security (RLS) policies would normally block access to the full trip data. A new SECURITY DEFINER function safely exposes only essential trip preview fields to invitation recipients.

## Changes
- **New migration**: Added `get_pending_trip_preview()` PostgreSQL function that:
  - Verifies the caller is the intended recipient of a pending share invitation
  - Returns only basic trip fields (destination, dates, cover image)
  - Uses SECURITY DEFINER to bypass RLS restrictions safely
  - Grants execute permission to authenticated users

- **Updated tripSharingService.ts**: Modified `getSharedTrips()` to:
  - Call the new RPC function when `share.trips` is null and status is 'pending'
  - Map preview data to match expected trip structure
  - Add `_is_preview` flag so UI can handle incomplete data appropriately
  - Maintain backward compatibility for trips with full data access

## Implementation Details
- The function validates that the caller's email matches `shared_with_email` and the share status is 'pending'
- Only essential fields needed for UI display are returned (no sensitive trip details)
- The `_is_preview` flag allows the frontend to distinguish between full trip data and preview-only data
- RLS policies remain unchanged; this function provides a controlled exception for the specific use case of pending invitations

https://claude.ai/code/session_01WYWgdPRBjDqVF6f5fkxn6i