### PR TITLE
Fix chat input mobile zoom issue on iOS

### DIFF
--- a/src/components/trip/ai-assistant/ChatInput.tsx
+++ b/src/components/trip/ai-assistant/ChatInput.tsx
@@ -142,7 +142,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
             enterKeyHint="send"
             className={cn(
               'w-full resize-none rounded-xl border border-sand-200 bg-sand-50',
-              'px-4 py-2.5 text-sm text-earth-700 placeholder:text-sand-400',
+              // Use text-base (16px) to prevent iOS Safari auto-zoom on focus
+              'px-4 py-2.5 text-base text-earth-700 placeholder:text-sand-400',
               'focus:outline-none focus:ring-2 focus:ring-earth-500/20 focus:border-earth-500',
               'transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
               'max-h-[120px] overflow-y-auto'


### PR DESCRIPTION
Changed textarea font-size from text-sm (14px) to text-base (16px) to
prevent iOS Safari from auto-zooming when the input receives focus.
iOS Safari automatically zooms inputs with font-size < 16px.

https://claude.ai/code/session_014PiRkrVsxVk1tHKunc8Lfu