### PR TITLE
Refactor traveler sharing: separate save and send actions

### DIFF
--- a/src/components/trip/travelers/TravelerDialog.tsx
+++ b/src/components/trip/travelers/TravelerDialog.tsx
@@ -11,7 +11,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Traveler } from "@/hooks/useTravelers";
 import { cn } from "@/lib/utils";
-import { Eye, Edit, Share2, Trash2 } from "lucide-react";
+import { Eye, Edit, Send, Trash2 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { shareTrip } from "@/services/tripSharingService";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
@@ -188,14 +188,21 @@ export default function TravelerDialog({
   const [sending, setSending] = useState(false);
   const canShare = useMemo(() => emailIsValid(watchedEmail) && !isOwner, [watchedEmail, isOwner]);
 
-  const handleShareEmail = async () => {
+  const handleSaveAndSend = async () => {
     if (!canShare) return;
+
+    // Validate form before proceeding
+    const isValid = await form.trigger();
+    if (!isValid) return;
+
     try {
       setSending(true);
 
       // 1) Idempotent create/update of the traveler row
+      const idToUse =
+        ((isEditing && (traveler as any)?.id) ? (traveler as any).id : createdShareId) || undefined;
       const payload = {
-        ...(isEditing && (traveler as any)?.id ? { id: (traveler as any).id } : {}),
+        ...(idToUse ? { id: idToUse } : {}),
         first_name: form.getValues("first_name"),
         last_name: form.getValues("last_name") || undefined,
         shared_with_email: watchedEmail.trim(),
@@ -212,7 +219,7 @@ export default function TravelerDialog({
         }
       }
 
-      // 2) Capture created/located id so subsequent Save becomes UPDATE
+      // 2) Capture created/located id
       if ((upserted as any)?.id) {
         setCreatedShareId((upserted as any).id);
       } else {
@@ -241,16 +248,18 @@ export default function TravelerDialog({
       );
 
       if (ok) {
-        toast.success("Traveler added & email sent");
-        queryClient.invalidateQueries({ queryKey: ["travelers", tripId] });
-
-        // 4) Reset dirty state so Save doesn't try to re-insert
-        const current = form.getValues();
-        form.reset(current);
+        toast.success(isEditing ? "Traveler updated & invite sent" : "Traveler added & invite sent");
+      } else {
+        toast.success(isEditing ? "Traveler updated (email could not be sent)" : "Traveler added (email could not be sent)");
       }
+
+      queryClient.invalidateQueries({ queryKey: ["travelers", tripId] });
+      onOpenChange(false);
+      form.reset();
+      setCreatedShareId(null);
     } catch (err) {
-      console.error("Error sending share email:", err);
-      toast.error("Failed to send share email");
+      console.error("Error in save & send:", err);
+      toast.error("Failed to save traveler");
     } finally {
       setSending(false);
     }
@@ -388,26 +397,14 @@ export default function TravelerDialog({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Email (for sharing)</FormLabel>
-                  <div className="flex items-center gap-2">
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="email"
-                        placeholder="email@example.com (optional)"
-                        disabled={isOwner}
-                      />
-                    </FormControl>
-                    <Button
-                      type="button"
-                      size="sm"
-                      onClick={handleShareEmail}
-                      disabled={!canShare || sending}
-                      className={cn("shrink-0 bg-earth-600 text-white hover:bg-earth-700 shadow-sm")}
-                    >
-                      <Share2 className="h-4 w-4 mr-1" />
-                      Share Trip
-                    </Button>
-                  </div>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="email@example.com (optional)"
+                      disabled={isOwner}
+                    />
+                  </FormControl>
                   {!emailIsValid(watchedEmail) && watchedEmail && (
                     <p className="text-xs text-red-600 mt-1">Please enter a valid email address</p>
                   )}
@@ -496,7 +493,21 @@ export default function TravelerDialog({
                 disabled={upsertMutation.isPending || isOwner || !form.formState.isDirty}
                 className="flex-1 bg-earth-600 hover:bg-earth-700 text-white"
               >
-                {upsertMutation.isPending ? "Saving..." : isEditing ? "Update" : "Add"}
+                {upsertMutation.isPending ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSaveAndSend}
+                disabled={!canShare || sending || upsertMutation.isPending || isOwner}
+                className={cn(
+                  "flex-1",
+                  canShare
+                    ? "bg-earth-600 hover:bg-earth-700 text-white"
+                    : "bg-gray-200 text-gray-400 cursor-not-allowed"
+                )}
+              >
+                <Send className="h-4 w-4 mr-1.5" />
+                {sending ? "Sending..." : "Save & Send"}
               </Button>
             </div>
           </form>


### PR DESCRIPTION
## Summary
Refactored the traveler dialog to separate the save and send invite actions into two distinct buttons, improving UX clarity and allowing users to save traveler information independently from sending invitations.

## Key Changes
- **Split action buttons**: Replaced the combined "Share Trip" button with separate "Save" and "Save & Send" buttons
  - "Save" button: Saves traveler information only
  - "Save & Send" button: Saves traveler and sends email invitation
- **Updated icon**: Changed from `Share2` to `Send` icon for the invite action
- **Improved form validation**: Added form validation check before sending invitations via `form.trigger()`
- **Enhanced state management**: 
  - Properly handle `createdShareId` for both new and edited travelers
  - Reset form and close dialog after successful save & send
  - Clear `createdShareId` on dialog close
- **Better user feedback**: Updated toast messages to distinguish between edit and add operations, and handle cases where email sending fails but traveler is saved
- **Simplified email input UI**: Removed the inline button from the email field, making the form layout cleaner

## Implementation Details
- The `handleSaveAndSend` function now validates the entire form before attempting to save and send
- Email invitations are only sent when the "Save & Send" button is clicked, not on regular saves
- The dialog closes automatically after a successful save & send operation
- Error handling distinguishes between save failures and email sending failures

https://claude.ai/code/session_015Spf8sgZQYuHXFmbyNqz3v