### PR TITLE
Remove Stripe key prefix from checkout debug response

### DIFF
--- a/server/routes/stripe.ts
+++ b/server/routes/stripe.ts
@@ -82,7 +82,6 @@ router.post('/api/stripe/create-checkout', async (req: Request, res: Response) =
       hasStripeKey,
       hasSupabaseUrl,
       hasServiceRoleKey,
-      stripeKeyPrefix: process.env.STRIPE_SECRET_KEY?.substring(0, 7) || 'missing', // Shows sk_live_ or sk_test_
     });
 
     if (!hasStripeKey) {


### PR DESCRIPTION
## Summary
Removed the `stripeKeyPrefix` field from the debug response in the Stripe checkout endpoint. This field was exposing the first 7 characters of the Stripe secret key, which is unnecessary for debugging purposes and represents a minor security concern.

## Changes
- Removed `stripeKeyPrefix` property from the debug response object in `/api/stripe/create-checkout`
- This field was previously showing the key prefix (e.g., `sk_live_` or `sk_test_`) for debugging, but is no longer needed

## Security Consideration
While the prefix alone doesn't expose the full secret key, removing unnecessary key material from debug responses follows security best practices of minimizing sensitive data exposure.

https://claude.ai/code/session_01NkoB3dTAerVE3rQAx8ozCv