### PR TITLE
Fix sidebar opening by default on mobile

### DIFF
--- a/src/hooks/useSidebarState.ts
+++ b/src/hooks/useSidebarState.ts
@@ -126,17 +126,24 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
   const [newActivity, setNewActivity] = useState<ActivityFormData>({ ...initialActivityForm });
   const [activityEdit, setActivityEdit] = useState<ActivityFormData>({ ...initialActivityForm });
 
-  // Load sidebar open state from localStorage on mount
+  // Load sidebar open state from localStorage on mount (desktop only)
   useEffect(() => {
+    const isMobile = window.innerWidth < 768;
+    if (isMobile) {
+      setIsOpen(false);
+      return;
+    }
     const savedState = localStorage.getItem('sidebarOpen');
     if (savedState !== null) {
       setIsOpen(JSON.parse(savedState));
     }
   }, []);
 
-  // Save sidebar open state to localStorage whenever it changes
+  // Save sidebar open state to localStorage whenever it changes (desktop only)
   useEffect(() => {
-    localStorage.setItem('sidebarOpen', JSON.stringify(isOpen));
+    if (window.innerWidth >= 768) {
+      localStorage.setItem('sidebarOpen', JSON.stringify(isOpen));
+    }
   }, [isOpen]);
 
   // Fetch trip basic data


### PR DESCRIPTION
The sidebar open state was persisted to localStorage globally, causing
it to restore as open on mobile when navigating to a trip. Now
localStorage persistence is skipped on mobile (< 768px) so the sidebar
always starts closed on mobile devices.

https://claude.ai/code/session_01MDYptFJajpe2cRkTbbwAEA