### PR TITLE
Fix accommodations search not finding lodging or addresses

### DIFF
--- a/src/utils/googleMapsLoader.ts
+++ b/src/utils/googleMapsLoader.ts
@@ -100,7 +100,7 @@ export function getPhotoUrl(photo: PlacePhotoMeta, maxWidth: number = 640): stri
 
 export async function searchPlaces(
   input: string,
-  types: string = "establishment",
+  types: string = "",
   locationContext?: string // e.g., "Paris, France" - appended to bias results
 ): Promise<AutocompleteResult[]> {
   if (!input?.trim()) return [];

--- a/supabase/functions/google-places-proxy/index.ts
+++ b/supabase/functions/google-places-proxy/index.ts
@@ -119,19 +119,23 @@ serve(async (req)=>{
      * 2) AUTOCOMPLETE (GET)
      * ------------------------------------------------------------------*/ if (req.method === "GET") {
       const input = url.searchParams.get("input");
-      const types = url.searchParams.get("types") || "establishment";
+      const types = url.searchParams.get("types") || "";
       const language = url.searchParams.get("language") || "en";
       // Use a sessiontoken to group user keystrokes
       const sessiontoken = url.searchParams.get("sessiontoken") || crypto.randomUUID();
       if (!input) throw new Error("Missing input parameter");
       const apiParams = new URLSearchParams({
         input,
-        types,
         language,
         sessiontoken,
         key: googleApiKey
-      }).toString();
-      const googleUrl = `https://maps.googleapis.com/maps/api/place/autocomplete/json?${apiParams}`;
+      });
+      // Only include types filter when explicitly provided —
+      // omitting it lets Google return all types (lodging, addresses, etc.)
+      if (types) {
+        apiParams.set("types", types);
+      }
+      const googleUrl = `https://maps.googleapis.com/maps/api/place/autocomplete/json?${apiParams.toString()}`;
       const googleResponse = await fetch(googleUrl);
       const googleData = await googleResponse.json();
       if (!googleResponse.ok) {


### PR DESCRIPTION
The Google Places Autocomplete proxy was hardcoding types=establishment
when no type filter was specified, which excluded addresses and could
limit lodging results. Now the types parameter is only sent to Google
when explicitly provided, allowing unfiltered searches to return all
place types (hotels, addresses, geocodes, etc.).

https://claude.ai/code/session_01RCM2RY44ssW9cYGrNhejHD