### PR TITLE
Fix invite link flow, simplify Travelers panel, unify chat input styling

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -28,7 +28,6 @@ import TravelerDialog from "../trip/travelers/TravelerDialog";
 import InviteLinkDialog from "../trip/travelers/InviteLinkDialog";
 import { useSidebarState } from "@/hooks/useSidebarState";
 import SecondaryPanel from "@/components/trip/SecondaryPanel";
-import ShareTripDialog from "@/components/trip/ShareTripDialog";
 import { supabase } from "@/integrations/supabase/client";
 import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { useInviteLinks } from "@/hooks/useInviteLinks";
@@ -74,7 +73,6 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
   const queryClient = useQueryClient();
   const sidebar = useSidebarState(tripId);
   const { canInstall, handleInstall } = usePWAInstall();
-  const [isShareDialogOpen, setIsShareDialogOpen] = React.useState(false);
   const { isAdmin } = useIsAdmin();
 
   // Listen for custom event from Navigation hamburger menu
@@ -180,15 +178,6 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
             Back to Trips
           </Button>
           <Separator className="my-4" />
-          
-          <Button
-            size="sm"
-            className="w-full mb-4 bg-earth-500 text-white hover:bg-earth-600 shadow-sm"
-            onClick={() => setInviteLinkOpen(true)}
-          >
-            <Link2 className="mr-2 h-4 w-4" />
-            Generate Invite Link
-          </Button>
 
           {tripNavItems.map(item => (
             <div key={item.title}>
@@ -211,7 +200,7 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
               {item.title === "Booking" && tripId && (
                 <Button
                   size="sm"
-                  onClick={() => setIsShareDialogOpen(true)}
+                  onClick={() => setInviteLinkOpen(true)}
                   className="mt-2 mb-4 w-full bg-earth-500 text-white hover:bg-earth-600 shadow-sm"
                 >
                   <Link2 className="mr-2 h-4 w-4" />
@@ -555,11 +544,12 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
       />
 
       {tripId && (
-        <ShareTripDialog
-          tripId={tripId}
+        <InviteLinkDialog
+          open={inviteLinkOpen}
+          onOpenChange={setInviteLinkOpen}
+          onGenerate={createLink}
+          creating={creating}
           tripDestination={trip?.destination || "Trip"}
-          open={isShareDialogOpen}
-          onOpenChange={setIsShareDialogOpen}
         />
       )}
     </>

--- a/src/components/trip/ai-assistant/ChatInput.tsx
+++ b/src/components/trip/ai-assistant/ChatInput.tsx
@@ -142,8 +142,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             enterKeyHint="send"
             className={cn(
               'w-full resize-none rounded-xl border border-sand-200 bg-sand-50',
-              // Use text-base (16px) to prevent iOS Safari auto-zoom on focus
-              'px-4 py-2.5 text-base text-earth-700 placeholder:text-sand-400',
+              'px-4 py-2.5 text-sm text-earth-700 placeholder:text-sand-400',
               'focus:outline-none focus:ring-2 focus:ring-earth-500/20 focus:border-earth-500',
               'transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
               'max-h-[120px] overflow-y-auto'

--- a/src/components/trip/travelers/InviteLinkSection.tsx
+++ b/src/components/trip/travelers/InviteLinkSection.tsx
@@ -59,7 +59,8 @@ export default function InviteLinkSection({ tripId }: InviteLinkSectionProps) {
 
       <Button
         size="sm"
-        className="w-full mb-3 bg-earth-500 text-white hover:bg-earth-600"
+        variant="outline"
+        className="w-full mb-3 bg-white text-sand-700 border-sand-300 hover:bg-sand-50 hover:border-sand-400"
         onClick={() => setDialogOpen(true)}
       >
         <Link2 className="mr-1 h-3.5 w-3.5" />

--- a/src/components/trip/travelers/TravelersPanel.tsx
+++ b/src/components/trip/travelers/TravelersPanel.tsx
@@ -1,13 +1,12 @@
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { UserPlus, Link2 } from "lucide-react";
+import { UserPlus } from "lucide-react";
 import { useTravelers } from "@/hooks/useTravelers";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTripPermissions } from "@/hooks/use-trip-permissions";
 import { Separator } from "@/components/ui/separator";
 import Header from "../_shared/Header";
 import TravelerRow from "./TravelerRow";
-import ShareTripDialog from "../ShareTripDialog";
+import InviteLinkSection from "./InviteLinkSection";
 
 interface TravelersPanelProps {
   tripId: string;
@@ -28,7 +27,6 @@ export default function TravelersPanel({
   onClose,
   onBack,
 }: TravelersPanelProps) {
-  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const { travelers, loading, error } = useTravelers(tripId);
   const { isOwner } = useTripPermissions(tripId);
 
@@ -65,22 +63,6 @@ export default function TravelersPanel({
       >
         <UserPlus size={14} className="mr-1" /> Add Traveler
       </Button>
-
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => setIsShareDialogOpen(true)}
-        className="mb-4 w-full border-sand-300 text-sand-700 hover:bg-sand-50 hover:border-sand-400"
-      >
-        <Link2 size={14} className="mr-1" /> Generate Invite Link
-      </Button>
-
-      <ShareTripDialog
-        tripId={tripId}
-        tripDestination={tripDestination}
-        open={isShareDialogOpen}
-        onOpenChange={setIsShareDialogOpen}
-      />
 
       {travelers.length === 0 ? (
         <div className="text-center py-12 border border-dashed rounded-lg">


### PR DESCRIPTION
- Sidebar: Wire Generate Invite Link to InviteLinkDialog (not ShareTripDialog)
- Sidebar: Remove duplicate ShareTripDialog from Booking section
- TravelersPanel: Remove duplicative Generate Invite Link button; InviteLinkSection is the single source
- TravelersPanel: Add missing InviteLinkSection import
- InviteLinkSection: Update Generate Invite Link button to white bg with dark text
- ChatInput: Use text-sm to match chat message output size