### PR TITLE
fix: reset stepper state when Review & Edit dialog reopens

### DIFF
--- a/src/components/trip/ai-assistant/ItemStepperDialog.tsx
+++ b/src/components/trip/ai-assistant/ItemStepperDialog.tsx
@@ -130,6 +130,15 @@ const ItemStepperDialog: React.FC<ItemStepperDialogProps> = ({
     destination: string | null;
   }>({ arrival_date: null, departure_date: null, destination: null });
 
+  // Reset internal state whenever the dialog opens so stale index / editDialogOpen
+  // from a previous session don't cause the dialog to render nothing.
+  useEffect(() => {
+    if (open) {
+      setCurrentIndex(0);
+      setEditDialogOpen(false);
+    }
+  }, [open]);
+
   useEffect(() => {
     const fetchTrip = async () => {
       const { data } = await supabase


### PR DESCRIPTION
The ItemStepperDialog component stays mounted across sessions, but
currentIndex and editDialogOpen were never reset when the dialog
reopened with new items. After reviewing multiple items (e.g. 3),
currentIndex would be left at 2. Reopening with a single-item
extraction caused items[2] to be undefined, hitting the early
return null guard and rendering nothing — making the Review & Edit
button appear broken for single-event OCR results.

https://claude.ai/code/session_01AoHGno9tvoxq29NGLMFwm3