### PR TITLE
Enhance transportation events with end times and traveler avatars

### DIFF
--- a/src/components/trip/day/components/GroupedEventCard.tsx
+++ b/src/components/trip/day/components/GroupedEventCard.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
 import { TimelineItem, TimelineType, getEventColors, formatTime12Stacked, formatTime12, getEventIconComponent } from './timeline-utils';
 import TimelineRow from './TimelineRow';
+import TravelerAvatars from '../../timeline/TravelerAvatars';
 import { motion, AnimatePresence } from 'framer-motion';
 
 type Props = {
@@ -142,6 +143,11 @@ const GroupedEventCard: React.FC<Props> = ({
                               {item.time && (
                                 <span className="text-[10px] ml-0.5">{formatTime12Stacked(item.time).meridiem}</span>
                               )}
+                              {item.type === 'transportation' && item.endTime && (
+                                <div className="text-[10px] text-earth-400 mt-0.5">
+                                  → {formatTime12(item.endTime)}
+                                </div>
+                              )}
                             </div>
 
                             {/* Content */}
@@ -154,6 +160,16 @@ const GroupedEventCard: React.FC<Props> = ({
                                   {item.description}
                                 </div>
                               )}
+                            </div>
+
+                            {/* Traveler Avatars */}
+                            <div className="flex-shrink-0">
+                              <TravelerAvatars
+                                tripId={tripId}
+                                eventType={item.type === 'hotel' ? 'accommodation' : item.type}
+                                eventId={item.type === 'hotel' ? item.data?.stay_id : item.id}
+                                maxShow={2}
+                              />
                             </div>
                           </div>
                         </div>
@@ -270,6 +286,11 @@ const GroupedEventCard: React.FC<Props> = ({
                             {item.time && (
                               <span className="text-[10px] ml-0.5">{formatTime12Stacked(item.time).meridiem}</span>
                             )}
+                            {item.type === 'transportation' && item.endTime && (
+                              <div className="text-[10px] text-earth-400 mt-0.5">
+                                → {formatTime12(item.endTime)}
+                              </div>
+                            )}
                           </div>
 
                           {/* Content */}
@@ -282,6 +303,16 @@ const GroupedEventCard: React.FC<Props> = ({
                                 {item.description}
                               </div>
                             )}
+                          </div>
+
+                          {/* Traveler Avatars */}
+                          <div className="flex-shrink-0">
+                            <TravelerAvatars
+                              tripId={tripId}
+                              eventType={item.type === 'hotel' ? 'accommodation' : item.type}
+                              eventId={item.type === 'hotel' ? item.data?.stay_id : item.id}
+                              maxShow={3}
+                            />
                           </div>
                         </div>
                       </div>

--- a/src/components/trip/day/components/TimelineRow.tsx
+++ b/src/components/trip/day/components/TimelineRow.tsx
@@ -192,7 +192,7 @@ const TimelineRow: React.FC<Props> = ({
                   </span>
                   {item.time && (
                     <span className="text-xs font-medium text-earth-500 whitespace-nowrap">
-                      {formatTime12(item.time)}
+                      {formatTime12(item.time)}{item.type === 'transportation' && item.endTime ? ` → ${formatTime12(item.endTime)}` : ''}
                     </span>
                   )}
                 </div>
@@ -204,8 +204,8 @@ const TimelineRow: React.FC<Props> = ({
                   </div>
                 )}
 
-                {/* End Time */}
-                {item.endTime && (
+                {/* End Time (non-transportation) */}
+                {item.endTime && item.type !== 'transportation' && (
                   <div className="text-xs text-earth-400 mt-1">until {formatTime12(item.endTime)}</div>
                 )}
 
@@ -310,6 +310,11 @@ const TimelineRow: React.FC<Props> = ({
               {/* Event Title - Bold, slightly reduced size */}
               <div className="text-sm font-bold text-earth-900 hover:text-earth-950 transition-colors line-clamp-2">
                 {item.title}
+                {item.type === 'transportation' && item.time && item.endTime && (
+                  <span className="ml-2 text-xs font-medium text-earth-500">
+                    {formatTime12(item.time)} → {formatTime12(item.endTime)}
+                  </span>
+                )}
               </div>
 
               {/* Subtitle/Details */}
@@ -319,8 +324,8 @@ const TimelineRow: React.FC<Props> = ({
                 </div>
               )}
 
-              {/* End Time */}
-              {item.endTime && (
+              {/* End Time (non-transportation) */}
+              {item.endTime && item.type !== 'transportation' && (
                 <div className="text-xs text-earth-400 mt-1">until {formatTime12(item.endTime)}</div>
               )}
 

--- a/src/components/trip/day/components/useDayTimeline.ts
+++ b/src/components/trip/day/components/useDayTimeline.ts
@@ -153,17 +153,17 @@ export function useDayTimeline({
       if (isMultiDay) {
         if (isStartDay) {
           displayTime = t.start_time || undefined;
-          title = `Depart: ${t.departure_location || 'Departure'}`;
+          title = `${t.departure_location || 'Departure'} →`;
         } else if (isEndDay) {
           displayTime = t.end_time || undefined;
-          title = `Arrive: ${t.arrival_location || 'Arrival'}`;
+          title = `→ ${t.arrival_location || 'Arrival'}`;
         } else {
           displayTime = undefined;
           title = `${typeLabel} (In Transit): ${t.departure_location || 'Departure'} → ${t.arrival_location || 'Arrival'}`;
         }
       } else {
         displayTime = t.start_time || undefined;
-        title = `Depart: ${t.departure_location || 'Departure'} • Arrive: ${t.arrival_location || 'Arrival'}`;
+        title = `${t.departure_location || 'Departure'} → ${t.arrival_location || 'Arrival'}`;
       }
 
       const departTimeOnThisDay = isStartDay ? t.start_time : undefined;


### PR DESCRIPTION
## Summary
This PR improves the display of transportation events in the trip timeline by showing end times and adding traveler avatars to all event cards.

## Key Changes

- **Transportation end time display**: Added end time indicators for transportation events in multiple locations:
  - In `GroupedEventCard`: Shows end time as "→ HH:MM" format below the start time
  - In `TimelineRow`: Displays time range as "HH:MM → HH:MM" inline with the start time
  - Updated `useDayTimeline`: Simplified transportation titles to use arrow notation (e.g., "Departure → Arrival") instead of "Depart:" and "Arrive:" labels

- **Traveler avatars integration**: Added `TravelerAvatars` component to both expanded and collapsed event card layouts in `GroupedEventCard`:
  - Shows up to 2 avatars in collapsed view
  - Shows up to 3 avatars in expanded view
  - Properly maps event types (hotel → accommodation) and event IDs for the avatar component

- **End time logic refinement**: Modified end time display logic to exclude transportation events from the "until HH:MM" format, since they now display the end time as part of the time range

## Implementation Details

- The changes maintain backward compatibility with existing event types
- Transportation events now have a distinct visual treatment with arrow notation for better clarity
- Traveler avatars are conditionally rendered with appropriate max display counts based on the card layout
- All changes follow existing code patterns and styling conventions

https://claude.ai/code/session_012grkAwLRu6HwyFDvsPRGE8