### PR TITLE
Fix mobile gap between nav and trip card on My Trips page

### DIFF
--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -292,7 +292,7 @@ const MyTrips = () => {
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-sand-50 via-sand-50 to-earth-50">
       <Navigation />
-      <div className="container mx-auto px-4 pt-20 pb-8">
+      <div className="container mx-auto px-4 pt-14 md:pt-20 pb-8">
         {/* Dynamic Travel Headquarters */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
The container had pt-20 (80px) top padding at all breakpoints, but the
nav is only h-14 (56px) on mobile, creating a 24px gap. Use pt-14 on
mobile to match the nav height, keeping pt-20 on md+ for desktop spacing.

https://claude.ai/code/session_01MV7y2dfYLWECFcb4fPewZS