### PR TITLE
Warm editorial reskin, sticky dialog footers, and timeline refinements

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -96,7 +96,6 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
 
       setPreview(signedUrl);
       onChange(signedUrl);
-      toast.success('Image uploaded successfully');
     } catch (err) {
       console.error('Upload error:', err);
       toast.error('Failed to upload image');

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -31,6 +31,7 @@ import SecondaryPanel from "@/components/trip/SecondaryPanel";
 import { supabase } from "@/integrations/supabase/client";
 import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { useInviteLinks } from "@/hooks/useInviteLinks";
+import { useTripPermissions } from "@/hooks/use-trip-permissions";
 
 export interface SidebarHandle {
   openAccommodationDialog: () => void;
@@ -128,6 +129,7 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
     handleTravelerAdd, handleTravelerEdit
   } = sidebar;
 
+  const { canEdit } = useTripPermissions(tripId);
   const isOwner = !!trip && !!user && trip.user_id === user.id;
 
   const { createLink, creating } = useInviteLinks(tripId || "");
@@ -149,7 +151,6 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
         .eq('trip_id', tripId);
       if (error) throw error;
 
-      toast({ title: 'Success', description: 'Trip deleted successfully' });
       queryClient.invalidateQueries({ queryKey: ['my-trips'] });
       queryClient.invalidateQueries({ queryKey: ['shared-trips'] });
       handleBackToTrips();
@@ -376,6 +377,7 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
         activeKey={secondaryPanel}
         onClose={() => setSecondaryPanel(null)}
         onBack={handleBackFromSecondary}
+        canEdit={canEdit}
         accommodations={accommodations}
         transportation={transportation}
         activities={activities}
@@ -472,11 +474,9 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
                 .eq('id', selectedReservation.id)
                 .eq('trip_id', tripId);
               if (error) throw error;
-              toast({ title: 'Success', description: 'Reservation updated' });
             } else {
               const { error } = await supabase.from('reservations').insert([data]);
               if (error) throw error;
-              toast({ title: 'Success', description: 'Reservation added' });
             }
             queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
             queryClient.invalidateQueries({ queryKey: ['reservations'] });

--- a/src/components/trip/ActivityForm.tsx
+++ b/src/components/trip/ActivityForm.tsx
@@ -506,7 +506,7 @@ const ActivityForm: React.FC<ActivityFormProps> = ({
       </div>
 
       {/* Buttons */}
-      <div className="flex justify-between items-center pt-6 mt-2 border-t border-sand-200">
+      <div className="sticky bottom-0 z-10 bg-background flex justify-between items-center pt-4 -mt-px border-t border-sand-200">
         <div>
           {onDelete && (
             <button

--- a/src/components/trip/BudgetView.tsx
+++ b/src/components/trip/BudgetView.tsx
@@ -276,7 +276,6 @@ const BudgetView: React.FC<BudgetViewProps> = ({ tripId, canEdit = true }) => {
       await queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
 
       setIsEditingBudget(false);
-      toast.success('Budget updated successfully');
     } catch (error) {
       console.error('Error updating budget:', error);
       toast.error('Failed to update budget. Please try again.');

--- a/src/components/trip/HeroSection.tsx
+++ b/src/components/trip/HeroSection.tsx
@@ -154,7 +154,6 @@ const HeroSection: React.FC<HeroSectionProps> = ({
 
       await queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       setIsDialogOpen(false);
-      toast.success('Trip details updated successfully');
     } catch (error) {
       console.error('Error updating trip details:', error);
       toast.error('Failed to update trip details');

--- a/src/components/trip/SecondaryPanel.tsx
+++ b/src/components/trip/SecondaryPanel.tsx
@@ -29,6 +29,7 @@ interface SecondaryPanelProps {
   activeKey: string | null;
   onClose: () => void;  // ✕ or backdrop
   onBack: () => void;   // ←
+  canEdit?: boolean;
 
   accommodations: any[];
   transportation: any[];
@@ -54,6 +55,7 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
     activeKey,
     onClose,
     onBack,
+    canEdit = true,
     accommodations,
     transportation,
     activities,
@@ -87,6 +89,7 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
           accommodations={accommodations}
           onAdd={onAccommodationAdd}
           onEdit={onAccommodationEdit}
+          canEdit={canEdit}
           isMobile={isMobile}
           onClose={onClose}
         />
@@ -99,6 +102,7 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
           transportation={transportation}
           onAdd={onTransportationAdd}
           onEdit={onTransportationEdit}
+          canEdit={canEdit}
           isMobile={isMobile}
           onClose={onClose}
         />
@@ -111,6 +115,7 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
           activities={activities}
           onAdd={onActivityAdd}
           onEdit={onActivityEdit}
+          canEdit={canEdit}
           isMobile={isMobile}
           onClose={onClose}
         />
@@ -123,6 +128,7 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
           reservations={reservations}
           onAdd={onReservationAdd}
           onEdit={onReservationEdit}
+          canEdit={canEdit}
           isMobile={isMobile}
           onClose={onClose}
         />
@@ -134,6 +140,7 @@ export default function SecondaryPanel(props: SecondaryPanelProps) {
           {...headerProps}
           trip={trip}
           onEdit={onEditDates}
+          canEdit={canEdit}
           isMobile={isMobile}
           onClose={onClose}
         />

--- a/src/components/trip/TimelineView.tsx
+++ b/src/components/trip/TimelineView.tsx
@@ -112,7 +112,6 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
           console.log('Skipping trip dates update - missing dates in data:', data);
         }
       }
-      toast.success('Timeline updated successfully');
     } catch (error) {
       console.error('Error refreshing timeline:', error);
       toast.error('Failed to refresh timeline');
@@ -158,7 +157,6 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
 
       if (error) throw error;
 
-      toast.success('Day deleted successfully');
       refreshDays();
     } catch (error) {
       console.error('Error deleting day:', error);

--- a/src/components/trip/_shared/PhotoStrip.tsx
+++ b/src/components/trip/_shared/PhotoStrip.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  loadGoogleMapsAPI,
+  getPlaceDetails,
+  getPhotoUrl,
+  type PlacePhotoMeta,
+} from "@/utils/googleMapsLoader";
+import {
+  getCachedPlacePhotos,
+  setCachedPlacePhotos,
+} from "@/utils/placePhotoCache";
+
+/* --------------------------- photo helpers --------------------------- */
+export const resolvePhotoUrl = (p: PlacePhotoMeta, maxWidth = 360): string | null => {
+  const viaProxy = getPhotoUrl?.(p, maxWidth);
+  if (viaProxy) return viaProxy;
+  if (p?.url) return p.url;
+
+  const nextKey =
+    typeof process !== "undefined"
+      ? (process.env?.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string | undefined)
+      : undefined;
+  // @ts-ignore SSR-safe check (Vite)
+  const viteKey: string | undefined =
+    (typeof import.meta !== "undefined" && (import.meta as any)?.env?.VITE_GOOGLE_MAPS_API_KEY) || undefined;
+  const key = nextKey || viteKey;
+
+  if (key && p?.photo_reference) {
+    const params = new URLSearchParams({
+      maxwidth: String(maxWidth),
+      photo_reference: p.photo_reference,
+      key,
+    });
+    return `https://maps.googleapis.com/maps/api/place/photo?${params.toString()}`;
+  }
+  return null;
+};
+
+export function warmImageCache(photos: PlacePhotoMeta[]) {
+  const sample = photos.slice(0, 3);
+  const widths = [320, 480, 640];
+  for (const ph of sample) {
+    for (const w of widths) {
+      const url = resolvePhotoUrl(ph, w);
+      if (!url) continue;
+      const img = new Image();
+      img.decoding = "async";
+      img.loading = "eager";
+      img.src = url;
+    }
+  }
+}
+
+/* -------------------------- lazy photo strip ------------------------- */
+interface PhotoStripProps {
+  placeId?: string | null;
+  title: string;
+}
+
+export default function PhotoStrip({ placeId, title }: PhotoStripProps) {
+  const [photos, setPhotos] = useState<PlacePhotoMeta[]>([]);
+  const [triggered, setTriggered] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    loadGoogleMapsAPI().catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!placeId || triggered) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const load = () => {
+      setTriggered(true);
+
+      const cached = getCachedPlacePhotos(placeId);
+      if (cached?.length) {
+        setPhotos(cached);
+        warmImageCache(cached);
+        return;
+      }
+
+      getPlaceDetails(placeId)
+        .then((res) => {
+          const ph = res?.photos ?? [];
+          setPhotos(ph);
+          setCachedPlacePhotos(placeId, ph);
+          warmImageCache(ph);
+        })
+        .catch(() => setPhotos([]));
+    };
+
+    if ("IntersectionObserver" in window) {
+      const obs = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((e) => {
+            if (e.isIntersecting) {
+              load();
+              obs.disconnect();
+            }
+          });
+        },
+        { rootMargin: "120px" }
+      );
+      obs.observe(el);
+      return () => obs.disconnect();
+    } else {
+      load();
+    }
+  }, [placeId, triggered]);
+
+  if (!placeId) return null;
+
+  return (
+    <div ref={ref}>
+      {photos.length > 0 && (
+        <div className="mt-2 -mx-1 overflow-x-auto">
+          <div className="flex gap-2 px-1 py-1 snap-x snap-mandatory [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            {photos.slice(0, 10).map((p, i) => {
+              const url320  = resolvePhotoUrl(p, 320);
+              const url480  = resolvePhotoUrl(p, 480);
+              const url640  = resolvePhotoUrl(p, 640);
+              const url896  = resolvePhotoUrl(p, 896);
+              const src = url480 || url640 || url896 || url320;
+              if (!src) return null;
+
+              const srcSet = [
+                url320 && `${url320} 320w`,
+                url480 && `${url480} 480w`,
+                url640 && `${url640} 640w`,
+                url896 && `${url896} 896w`,
+              ]
+                .filter(Boolean)
+                .join(", ");
+
+              const sizes = "(min-width: 768px) 384px, (min-width: 640px) 320px, 240px";
+              const attribution = p.html_attributions?.[0];
+
+              return (
+                <div key={`${p.photo_reference || p.url || i}`} className="relative flex-none snap-start">
+                  <img
+                    src={src}
+                    srcSet={srcSet}
+                    sizes={sizes}
+                    alt={`${title} photo ${i + 1}`}
+                    className="
+                      h-28 w-44
+                      sm:h-32 sm:w-56
+                      md:h-32 md:w-64
+                      rounded-md object-cover border border-sand-200
+                    "
+                    loading="lazy"
+                    decoding="async"
+                    referrerPolicy="no-referrer"
+                  />
+                  {attribution && (
+                    <div
+                      className="absolute bottom-1 right-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] text-white"
+                      dangerouslySetInnerHTML={{ __html: attribution }}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/trip/accommodation/AccommodationDialog.tsx
+++ b/src/components/trip/accommodation/AccommodationDialog.tsx
@@ -81,7 +81,6 @@ const AccommodationDialog: React.FC<AccommodationDialogProps> = ({
           .update({ ...basePayload })
           .eq("stay_id", initialData.stay_id);
         if (error) throw error;
-        toast.success("Accommodation updated successfully");
       } else {
         const { error } = await supabase.from("accommodations").insert([
           {
@@ -94,7 +93,6 @@ const AccommodationDialog: React.FC<AccommodationDialogProps> = ({
           },
         ]);
         if (error) throw error;
-        toast.success("Accommodation added successfully");
       }
       
       // Invalidate queries to refresh the UI
@@ -122,7 +120,6 @@ const AccommodationDialog: React.FC<AccommodationDialogProps> = ({
         queryClient.invalidateQueries({ queryKey: ['accommodations'] });
         queryClient.invalidateQueries({ queryKey: ['trip'] });
         
-        toast.success("Accommodation deleted successfully");
         onSuccess();
         onOpenChange(false);
       }

--- a/src/components/trip/accommodation/AccommodationForm.tsx
+++ b/src/components/trip/accommodation/AccommodationForm.tsx
@@ -317,7 +317,7 @@ export default function AccommodationForm({
   /* ------------------------------- JSX --------------------------------- */
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-3 w-full overflow-hidden">
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-3 w-full">
         {/* Hotel Name */}
         <FormField
           control={form.control}
@@ -602,7 +602,7 @@ export default function AccommodationForm({
         />
 
         {/* Actions */}
-        <div className="flex justify-between items-center pt-6 mt-2 border-t border-sand-200">
+        <div className="sticky bottom-0 z-10 bg-background flex justify-between items-center pt-4 -mt-px border-t border-sand-200">
           <div>
             {initialData && onDelete && (
               <Button

--- a/src/components/trip/accommodation/AccommodationPanel.tsx
+++ b/src/components/trip/accommodation/AccommodationPanel.tsx
@@ -1,5 +1,5 @@
 // src/components/trip/accommodation/AccommodationPanel.tsx
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import {
@@ -8,174 +8,9 @@ import {
   formatTime,
 } from "@/utils/sidebarUtils";
 import Header from "../_shared/Header";
+import PhotoStrip from "../_shared/PhotoStrip";
 import { parse, format } from "date-fns";
-
-import {
-  loadGoogleMapsAPI,
-  getPlaceDetails,
-  getPhotoUrl,
-  type PlacePhotoMeta,
-} from "@/utils/googleMapsLoader";
-import {
-  getCachedPlacePhotos,
-  setCachedPlacePhotos,
-  clearExpiredPlacePhotoCache,
-} from "@/utils/placePhotoCache";
-
-/* --------------------------- photo helpers --------------------------- */
-const resolvePhotoUrl = (p: PlacePhotoMeta, maxWidth = 360): string | null => {
-  const viaProxy = getPhotoUrl?.(p, maxWidth);
-  if (viaProxy) return viaProxy;
-  if (p?.url) return p.url;
-
-  const nextKey =
-    typeof process !== "undefined"
-      ? (process.env?.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string | undefined)
-      : undefined;
-  // @ts-ignore SSR-safe check for Vite env
-  const viteKey: string | undefined =
-    (typeof import.meta !== "undefined" && (import.meta as any)?.env?.VITE_GOOGLE_MAPS_API_KEY) || undefined;
-  const key = nextKey || viteKey;
-
-  if (key && p?.photo_reference) {
-    const params = new URLSearchParams({
-      maxwidth: String(maxWidth),
-      photo_reference: p.photo_reference,
-      key,
-    });
-    return `https://maps.googleapis.com/maps/api/place/photo?${params.toString()}`;
-  }
-  return null;
-};
-
-/* Optional: warm image HTTP cache for first few images/sizes */
-function warmImageCache(photos: PlacePhotoMeta[]) {
-  const sample = photos.slice(0, 3);
-  const widths = [320, 480, 640];
-  for (const ph of sample) {
-    for (const w of widths) {
-      const url = resolvePhotoUrl(ph, w);
-      if (!url) continue;
-      const img = new Image();
-      img.decoding = "async";
-      img.loading = "eager";
-      img.src = url;
-    }
-  }
-}
-
-/* -------------------------- lazy photo strip ------------------------- */
-function PhotoStrip({ placeId, title }: { placeId?: string | null; title: string }) {
-  const [photos, setPhotos] = useState<PlacePhotoMeta[]>([]);
-  const [triggered, setTriggered] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    loadGoogleMapsAPI().catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    if (!placeId || triggered) return;
-    const el = ref.current;
-    if (!el) return;
-
-    const load = () => {
-      setTriggered(true);
-
-      // 1) Try cache first
-      const cached = getCachedPlacePhotos(placeId);
-      if (cached?.length) {
-        setPhotos(cached);
-        // Warm HTTP cache in the background for instant re-renders
-        warmImageCache(cached);
-        return;
-      }
-
-      // 2) Fetch details (once) and store
-      getPlaceDetails(placeId)
-        .then((res) => {
-          const ph = res?.photos ?? [];
-          setPhotos(ph);
-          setCachedPlacePhotos(placeId, ph);
-          warmImageCache(ph);
-        })
-        .catch(() => setPhotos([]));
-    };
-
-    if ("IntersectionObserver" in window) {
-      const obs = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((e) => {
-            if (e.isIntersecting) {
-              load();
-              obs.disconnect();
-            }
-          });
-        },
-        { rootMargin: "120px" }
-      );
-      obs.observe(el);
-      return () => obs.disconnect();
-    } else {
-      load();
-    }
-  }, [placeId, triggered]);
-
-  return (
-    <div ref={ref}>
-      {placeId && photos.length > 0 && (
-        <div className="mt-2 -mx-1 overflow-x-auto">
-          <div className="flex gap-2 px-1 py-1 snap-x snap-mandatory [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {photos.slice(0, 10).map((p, i) => {
-              const url320  = resolvePhotoUrl(p, 320);
-              const url480  = resolvePhotoUrl(p, 480);
-              const url640  = resolvePhotoUrl(p, 640);
-              const url896  = resolvePhotoUrl(p, 896);
-              const src = url480 || url640 || url896 || url320;
-              if (!src) return null;
-
-              const srcSet = [
-                url320 && `${url320} 320w`,
-                url480 && `${url480} 480w`,
-                url640 && `${url640} 640w`,
-                url896 && `${url896} 896w`,
-              ].filter(Boolean).join(", ");
-
-              const sizes = "(min-width: 768px) 384px, (min-width: 640px) 320px, 240px";
-              const attribution = p.html_attributions?.[0];
-
-              return (
-                <div key={`${p.photo_reference || p.url || i}`} className="relative flex-none snap-start">
-                  <img
-                    src={src}
-                    srcSet={srcSet}
-                    sizes={sizes}
-                    alt={`${title || "Hotel"} photo ${i + 1}`}
-                    className="
-                      h-28 w-44
-                      sm:h-32 sm:w-56
-                      md:h-32 md:w-64
-                      rounded-md object-cover border border-sand-200
-                    "
-                    loading="lazy"
-                    decoding="async"
-                    referrerPolicy="no-referrer"
-                  />
-                  {attribution && (
-                    <div
-                      className="absolute bottom-1 right-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] text-white"
-                      dangerouslySetInnerHTML={{ __html: attribution }}
-                    />
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
+import { clearExpiredPlacePhotoCache } from "@/utils/placePhotoCache";
 
 /* ------------------------------- types -------------------------------- */
 interface Props {
@@ -192,6 +27,7 @@ interface Props {
   }>;
   onAdd: () => void;
   onEdit: (a: any) => void;
+  canEdit?: boolean;
   isMobile: boolean;
   onClose: () => void;
   onBack: () => void;
@@ -201,6 +37,7 @@ export default function AccommodationPanel({
   accommodations,
   onAdd,
   onEdit,
+  canEdit = true,
   isMobile,
   onClose,
   onBack,
@@ -225,13 +62,15 @@ export default function AccommodationPanel({
     <div className="p-4">
       <Header title="Accommodations" {...{ isMobile, onBack, onClose }} />
 
-      <Button
-        size="sm"
-        onClick={onAdd}
-        className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
-      >
-        <Plus size={14} className="mr-1" /> Add Accommodation
-      </Button>
+      {canEdit && (
+        <Button
+          size="sm"
+          onClick={onAdd}
+          className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
+        >
+          <Plus size={14} className="mr-1" /> Add Accommodation
+        </Button>
+      )}
 
       {dates.map((d) => (
         <div key={d} className="space-y-2">
@@ -265,8 +104,8 @@ export default function AccommodationPanel({
                   key={a.stay_id}
                   className="ml-2 w-full rounded-lg bg-sand-50 p-3 text-left transition-colors hover:bg-sand-100"
                 >
-                  {/* Clickable header block */}
-                  <button onClick={() => onEdit(a)} className="w-full text-left">
+                  {/* Clickable header block (edit-only) */}
+                  <div onClick={canEdit ? () => onEdit(a) : undefined} role={canEdit ? "button" : undefined} className={`w-full text-left ${canEdit ? 'cursor-pointer' : ''}`}>
                     <h4 className="mb-1 text-sm font-medium">{a.hotel}</h4>
                     <p className="text-xs text-sand-600">
                       {timeDisplay}
@@ -277,7 +116,7 @@ export default function AccommodationPanel({
                         </>
                       )}
                     </p>
-                  </button>
+                  </div>
 
                   {/* Non-clickable scroller below the header */}
                   <PhotoStrip placeId={a.hotel_place_id} title={a.hotel} />

--- a/src/components/trip/accommodation/hooks/useAccommodationHandlers.ts
+++ b/src/components/trip/accommodation/hooks/useAccommodationHandlers.ts
@@ -21,7 +21,6 @@ export const useAccommodationHandlers = ({ tripId, onAccommodationChange }: UseA
       return await deleteAccommodation(stayId);
     },
     onSuccess: () => {
-      toast.success('Accommodation deleted successfully');
       // Invalidate the accommodations query for this trip
       queryClient.invalidateQueries(['accommodations', tripId]);
       // Only call onAccommodationChange if it's a function

--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -219,7 +219,6 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
 
   const handleStepperComplete = useCallback(() => {
     setItemsToProcess([]);
-    toast.success('All items have been processed');
   }, []);
 
   const handleClearChat = useCallback(async () => {

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -246,7 +246,6 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
   // Handle stepper complete
   const handleStepperComplete = useCallback(() => {
     setItemsToProcess([]);
-    toast.success('All items have been processed');
   }, []);
 
   // Handle clear chat - also clear extraction messages

--- a/src/components/trip/ai-assistant/ItemStepperDialog.tsx
+++ b/src/components/trip/ai-assistant/ItemStepperDialog.tsx
@@ -93,6 +93,7 @@ const mapToActivity = (f: Record<string, any>, tripId: string) => ({
   end_time: toDbTime(f.end_time) ?? '',
   cost: typeof f.cost === 'number' ? String(f.cost) : '',
   currency: f.currency ?? 'USD',
+  location_address: f.location ?? null,
   travelers: [],
   trip_id: tripId,
 });

--- a/src/components/trip/budget/hooks/useBudgetEvents.tsx
+++ b/src/components/trip/budget/hooks/useBudgetEvents.tsx
@@ -57,7 +57,6 @@ export const useBudgetEvents = (tripId: string | undefined) => {
       if (error) throw error;
       
       queryClient.invalidateQueries({ queryKey: ['expenses', tripId] });
-      toast.success('Expense deleted successfully');
     } catch (error) {
       console.error('Error deleting expense:', error);
       toast.error('Failed to delete expense');
@@ -74,7 +73,6 @@ export const useBudgetEvents = (tripId: string | undefined) => {
       if (error) throw error;
       
       queryClient.invalidateQueries({ queryKey: ['expenses', tripId] });
-      toast.success('Expense updated successfully');
     } catch (error) {
       console.error('Error updating expense:', error);
       toast.error('Failed to update expense');

--- a/src/components/trip/budget/hooks/useBudgetMutations.ts
+++ b/src/components/trip/budget/hooks/useBudgetMutations.ts
@@ -66,7 +66,6 @@ export const useBudgetMutations = (tripId: string) => {
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
     },
     onSuccess: () => {
-      toast.success('Expense added successfully');
     }
   });
 
@@ -81,7 +80,6 @@ export const useBudgetMutations = (tripId: string) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['expenses', tripId] });
-      toast.success('Expense updated successfully');
     },
     onError: (error) => {
       console.error('Error updating expense:', error);
@@ -100,7 +98,6 @@ export const useBudgetMutations = (tripId: string) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['expenses', tripId] });
-      toast.success('Expense deleted successfully');
     },
     onError: (error) => {
       console.error('Error deleting expense:', error);

--- a/src/components/trip/create/ImageSection.tsx
+++ b/src/components/trip/create/ImageSection.tsx
@@ -82,7 +82,6 @@ const ImageSection: React.FC<ImageSectionProps> = ({
     onImageChange(hit.url, { photographer: hit.photographer, username: hit.username });
     // Trigger Unsplash download endpoint (API guideline requirement)
     supabase.functions.invoke('fetch-unsplash-metadata', { body: { photoId: hit.id } });
-    toast.success('Cover image selected');
   };
 
   // Handle image removal - only update local state, don't save empty URL

--- a/src/components/trip/day/DayCardHandlers.ts
+++ b/src/components/trip/day/DayCardHandlers.ts
@@ -11,7 +11,6 @@ export const useDayCardHandlers = (id: string, onDelete: (id: string) => void) =
         .eq('day_id', id);
 
       if (error) throw error;
-      toast.success('Day title updated successfully');
       return true;
     } catch (error) {
       console.error('Error updating day title:', error);
@@ -46,7 +45,6 @@ export const useDayCardHandlers = (id: string, onDelete: (id: string) => void) =
 
       if (dayError) throw dayError;
 
-      toast.success('Day deleted successfully');
       onDelete(id);
     } catch (error) {
       console.error('Error deleting day:', error);

--- a/src/components/trip/day/activities/ActivitiesPanel.tsx
+++ b/src/components/trip/day/activities/ActivitiesPanel.tsx
@@ -1,13 +1,17 @@
 // src/components/trip/day/activities/ActivitiesPanel.tsx
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { formatDateSafe, compareDatesSafe, formatTime } from "@/utils/sidebarUtils";
 import Header from "../../_shared/Header";
+import PhotoStrip from "../../_shared/PhotoStrip";
+import { clearExpiredPlacePhotoCache } from "@/utils/placePhotoCache";
 
 interface Props {
   activities: any[];
   onAdd: () => void;
   onEdit: (a: any) => void;
+  canEdit?: boolean;
   isMobile: boolean;
   onClose: () => void;
   onBack: () => void;
@@ -16,10 +20,15 @@ export default function ActivitiesPanel({
   activities,
   onAdd,
   onEdit,
+  canEdit = true,
   isMobile,
   onClose,
   onBack,
 }: Props) {
+  useEffect(() => {
+    clearExpiredPlacePhotoCache();
+  }, []);
+
   const grouped = activities.reduce((acc: Record<string, any[]>, a) => {
     const d = a.trip_days?.date || "No Date";
     (acc[d] ||= []).push(a);
@@ -31,13 +40,15 @@ export default function ActivitiesPanel({
     <div className="p-4">
       <Header title="Activities" {...{ isMobile, onBack, onClose }} />
 
-      <Button
-        size="sm"
-        onClick={onAdd}
-        className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
-      >
-        <Plus size={14} className="mr-1" /> Add Activity
-      </Button>
+      {canEdit && (
+        <Button
+          size="sm"
+          onClick={onAdd}
+          className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
+        >
+          <Plus size={14} className="mr-1" /> Add Activity
+        </Button>
+      )}
 
       {dates.map((d) => (
         <div key={d} className="space-y-2">
@@ -47,21 +58,30 @@ export default function ActivitiesPanel({
           {grouped[d]
             .sort((a, b) => (a.start_time || "").localeCompare(b.start_time || ""))
             .map((a) => (
-              <button
+              <div
                 key={a.id}
-                onClick={() => onEdit(a)}
                 className="ml-2 w-full rounded-lg bg-sand-50 p-3 text-left transition-colors hover:bg-sand-100"
               >
-                <h4 className="mb-1 text-sm font-medium">{a.title}</h4>
-                <p className="text-xs text-sand-600">
-                  {formatTime(a.start_time)} – {formatTime(a.end_time)}
-                </p>
-                {a.cost && (
+                {/* Clickable header area */}
+                <div
+                  onClick={canEdit ? () => onEdit(a) : undefined}
+                  role={canEdit ? "button" : undefined}
+                  className={`w-full text-left ${canEdit ? 'cursor-pointer' : ''}`}
+                >
+                  <h4 className="mb-1 text-sm font-medium">{a.title}</h4>
                   <p className="text-xs text-sand-600">
-                    {(a.currency || "USD")} {a.cost.toLocaleString()}
+                    {formatTime(a.start_time)} – {formatTime(a.end_time)}
                   </p>
-                )}
-              </button>
+                  {a.cost && (
+                    <p className="text-xs text-sand-600">
+                      {(a.currency || "USD")} {a.cost.toLocaleString()}
+                    </p>
+                  )}
+                </div>
+
+                {/* Non-clickable photo strip */}
+                <PhotoStrip placeId={a.location_place_id} title={a.title} />
+              </div>
             ))}
         </div>
       ))}

--- a/src/components/trip/day/activities/ActivityDialog.tsx
+++ b/src/components/trip/day/activities/ActivityDialog.tsx
@@ -179,8 +179,6 @@ const ActivityDialog: React.FC<ActivityDialogProps> = (props) => {
     const dataToSave = activityData || finalActivity;
 
     try {
-      const { toast } = await import("sonner");
-
       if (!dataToSave.title?.trim()) {
         throw new Error("Activity title is required");
       }
@@ -241,13 +239,11 @@ const ActivityDialog: React.FC<ActivityDialogProps> = (props) => {
             .update(dbData)
             .eq("id", activityId!);
           if (error) throw error;
-          toast.success("Activity updated");
         } else {
           const { error } = await supabase
             .from("day_activities")
             .insert([{ ...dbData, trip_id: tripId, order_index: 0 }]);
           if (error) throw error;
-          toast.success("Activity added");
         }
 
         // Invalidate queries to refresh the UI (use trip-scoped keys for consistency)
@@ -270,7 +266,7 @@ const ActivityDialog: React.FC<ActivityDialogProps> = (props) => {
   return (
     <Dialog open={finalOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="w-[95vw] max-w-[95vw] sm:max-w-[600px] max-h-[90dvh] overflow-y-auto scrollbar-none p-4 sm:p-6"
+        className="w-[95vw] max-w-[95vw] sm:max-w-[600px] max-h-[90dvh] p-4 sm:p-6"
         onPointerDownOutside={(e) => e.preventDefault()}
       >
         <DialogHeader className="flex-shrink-0">

--- a/src/components/trip/day/components/DayActivityManager.tsx
+++ b/src/components/trip/day/components/DayActivityManager.tsx
@@ -57,7 +57,6 @@ const DayActivityManager = ({ id, tripId, activities }: DayActivityManagerProps)
         toast.error('Failed to save activity');
         throw error;
       }
-      toast.success('Activity added successfully');
       queryClient.invalidateQueries({ queryKey: ['trip'] });
       queryClient.invalidateQueries({ queryKey: ['activities', id] });
     } catch (error) {
@@ -115,7 +114,6 @@ const DayActivityManager = ({ id, tripId, activities }: DayActivityManagerProps)
         .single();
 
       if (error) throw error;
-      toast.success('Activity updated successfully');
       queryClient.invalidateQueries({ queryKey: ['trip'] });
       queryClient.invalidateQueries({ queryKey: ['activities', id] });
     } catch (error) {
@@ -132,7 +130,6 @@ const DayActivityManager = ({ id, tripId, activities }: DayActivityManagerProps)
         .delete()
         .eq('id', activityId);
       if (error) throw error;
-      toast.success('Activity deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['trip'] });
       queryClient.invalidateQueries({ queryKey: ['activities', id] });
     } catch (error) {

--- a/src/components/trip/day/components/GroupedEventCard.tsx
+++ b/src/components/trip/day/components/GroupedEventCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
-import { TimelineItem, TimelineType, formatTime12Stacked, formatTime12, getEventIconComponent } from './timeline-utils';
+import { TimelineItem, TimelineType, formatTimeRange, getEventIconComponent } from './timeline-utils';
 import TimelineRow from './TimelineRow';
 import TravelerAvatars from '../../timeline/TravelerAvatars';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -128,40 +128,36 @@ const GroupedEventCard: React.FC<Props> = ({
                             }
                           }}
                         >
-                          <div className="flex items-start gap-3">
-                            {/* Time */}
-                            <div className="flex-shrink-0 text-xs font-medium text-earth-700 w-14">
-                              {item.time ? formatTime12Stacked(item.time).time : '\u2014'}
-                              {item.time && (
-                                <span className="text-[10px] ml-0.5">{formatTime12Stacked(item.time).meridiem}</span>
-                              )}
-                              {item.type === 'transportation' && item.endTime && (
-                                <div className="text-[10px] text-earth-400 mt-0.5">
-                                  &rarr; {formatTime12(item.endTime)}
-                                </div>
-                              )}
-                            </div>
-
-                            {/* Content */}
-                            <div className="flex-1 min-w-0">
-                              <div className="text-sm font-semibold text-earth-900 line-clamp-1">
-                                {item.title}
+                          <div>
+                            {/* Time range on one row */}
+                            {item.time && (
+                              <div className="text-xs font-semibold text-earth-600 tracking-tight mb-1">
+                                {formatTimeRange(item.time, item.endTime, item.type === 'transportation')}
                               </div>
-                              {item.description && (
-                                <div className="text-xs text-earth-500 mt-0.5 line-clamp-1">
-                                  {item.description}
-                                </div>
-                              )}
-                            </div>
+                            )}
 
-                            {/* Traveler Avatars */}
-                            <div className="flex-shrink-0">
-                              <TravelerAvatars
-                                tripId={tripId}
-                                eventType={item.type === 'hotel' ? 'accommodation' : item.type}
-                                eventId={item.type === 'hotel' ? item.data?.stay_id : item.id}
-                                maxShow={3}
-                              />
+                            {/* Title + Avatars */}
+                            <div className="flex items-start gap-3">
+                              <div className="flex-1 min-w-0">
+                                <div className="text-sm font-semibold text-earth-900 line-clamp-1">
+                                  {item.title}
+                                </div>
+                                {item.description && (
+                                  <div className="text-xs text-earth-500 mt-0.5 line-clamp-1">
+                                    {item.description}
+                                  </div>
+                                )}
+                              </div>
+
+                              {/* Traveler Avatars */}
+                              <div className="flex-shrink-0">
+                                <TravelerAvatars
+                                  tripId={tripId}
+                                  eventType={item.type === 'hotel' ? 'accommodation' : item.type}
+                                  eventId={item.type === 'hotel' ? item.data?.stay_id : item.id}
+                                  maxShow={3}
+                                />
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/src/components/trip/day/components/HotelPhotoThumb.tsx
+++ b/src/components/trip/day/components/HotelPhotoThumb.tsx
@@ -11,7 +11,7 @@ interface HotelPhotoThumbProps {
   size?: 'sm' | 'md';
 }
 
-const sizeMap = { sm: 'h-10 w-14', md: 'h-12 w-16' };
+const sizeMap = { sm: 'h-10 w-14', md: 'h-16 w-22' };
 
 export default function HotelPhotoThumb({
   placeId,
@@ -73,7 +73,8 @@ export default function HotelPhotoThumb({
 
   if (!placeId) return null;
 
-  const src = photo ? (getPhotoUrl?.(photo, 160) || (photo as any)?.url) : null;
+  const maxWidth = size === 'md' ? 240 : 160;
+  const src = photo ? (getPhotoUrl?.(photo, maxWidth) || (photo as any)?.url) : null;
 
   return (
     <div

--- a/src/components/trip/day/components/TimelineRow.tsx
+++ b/src/components/trip/day/components/TimelineRow.tsx
@@ -206,9 +206,15 @@ const TimelineRow: React.FC<Props> = ({
                 <EventMetadata item={item} />
               </div>
 
-              {/* Hotel photo thumbnail */}
+              {/* Place photo thumbnail */}
               {item.type === 'hotel' && item.data?.hotel_place_id && (
-                <HotelPhotoThumb placeId={item.data.hotel_place_id} title={item.data.hotel} size="sm" />
+                <HotelPhotoThumb placeId={item.data.hotel_place_id} title={item.data.hotel} size="md" />
+              )}
+              {item.type === 'activity' && item.data?.location_place_id && (
+                <HotelPhotoThumb placeId={item.data.location_place_id} title={item.title} size="md" />
+              )}
+              {item.type === 'dining' && item.data?.place_id && (
+                <HotelPhotoThumb placeId={item.data.place_id} title={item.title} size="md" />
               )}
             </div>
 

--- a/src/components/trip/dining/DiningList.tsx
+++ b/src/components/trip/dining/DiningList.tsx
@@ -96,7 +96,6 @@ const DiningList = forwardRef<HTMLDivElement, DiningListProps>(
               .throwOnError();
 
             console.log('UPDATE status', status, 'data', data);
-            toast.success('Reservation updated');
           } else {
             /* ----- INSERT ----- */
             const { data, status } = await supabase
@@ -110,8 +109,6 @@ const DiningList = forwardRef<HTMLDivElement, DiningListProps>(
               toast.error(
                 'Row saved, but SELECT policy is hiding it. Check RLS.'
               );
-            } else {
-              toast.success('Reservation added');
             }
           }
 
@@ -150,8 +147,6 @@ const DiningList = forwardRef<HTMLDivElement, DiningListProps>(
           .eq('id', deletingId)
           .eq('trip_id', tripId)
           .throwOnError();
-
-        toast.success('Reservation deleted');
 
         await qc.invalidateQueries({
           queryKey: reservationsKey(tripId, dayId),

--- a/src/components/trip/dining/ReservationsPanel.tsx
+++ b/src/components/trip/dining/ReservationsPanel.tsx
@@ -1,176 +1,11 @@
 // src/components/trip/dining/ReservationsPanel.tsx
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { formatDateSafe, compareDatesSafe, formatTime } from "@/utils/sidebarUtils";
 import Header from "../_shared/Header";
-
-import {
-  loadGoogleMapsAPI,
-  getPlaceDetails,
-  getPhotoUrl,
-  type PlacePhotoMeta,
-} from "@/utils/googleMapsLoader";
-import {
-  getCachedPlacePhotos,
-  setCachedPlacePhotos,
-  clearExpiredPlacePhotoCache,
-} from "@/utils/placePhotoCache";
-
-/* --------------------------- photo helpers --------------------------- */
-const resolvePhotoUrl = (p: PlacePhotoMeta, maxWidth = 360): string | null => {
-  const viaProxy = getPhotoUrl?.(p, maxWidth);
-  if (viaProxy) return viaProxy;
-  if (p?.url) return p.url;
-
-  const nextKey =
-    typeof process !== "undefined"
-      ? (process.env?.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string | undefined)
-      : undefined;
-  // @ts-ignore SSR-safe check (Vite)
-  const viteKey: string | undefined =
-    (typeof import.meta !== "undefined" && (import.meta as any)?.env?.VITE_GOOGLE_MAPS_API_KEY) || undefined;
-  const key = nextKey || viteKey;
-
-  if (key && p?.photo_reference) {
-    const params = new URLSearchParams({
-      maxwidth: String(maxWidth),
-      photo_reference: p.photo_reference,
-      key,
-    });
-    return `https://maps.googleapis.com/maps/api/place/photo?${params.toString()}`;
-  }
-  return null;
-};
-
-function warmImageCache(photos: PlacePhotoMeta[]) {
-  const sample = photos.slice(0, 3);
-  const widths = [320, 480, 640];
-  for (const ph of sample) {
-    for (const w of widths) {
-      const url = resolvePhotoUrl(ph, w);
-      if (!url) continue;
-      const img = new Image();
-      img.decoding = "async";
-      img.loading = "eager";
-      img.src = url;
-    }
-  }
-}
-
-/* -------------------------- lazy photo strip ------------------------- */
-function PhotoStrip({ placeId, title }: { placeId?: string | null; title: string }) {
-  const [photos, setPhotos] = useState<PlacePhotoMeta[]>([]);
-  const [triggered, setTriggered] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    loadGoogleMapsAPI().catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    if (!placeId || triggered) return;
-    const el = ref.current;
-    if (!el) return;
-
-    const load = () => {
-      setTriggered(true);
-
-      const cached = getCachedPlacePhotos(placeId);
-      if (cached?.length) {
-        setPhotos(cached);
-        warmImageCache(cached);
-        return;
-      }
-
-      getPlaceDetails(placeId)
-        .then((res) => {
-          const ph = res?.photos ?? [];
-          setPhotos(ph);
-          setCachedPlacePhotos(placeId, ph);
-          warmImageCache(ph);
-        })
-        .catch(() => setPhotos([]));
-    };
-
-    if ("IntersectionObserver" in window) {
-      const obs = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((e) => {
-            if (e.isIntersecting) {
-              load();
-              obs.disconnect();
-            }
-          });
-        },
-        { rootMargin: "120px" }
-      );
-      obs.observe(el);
-      return () => obs.disconnect();
-    } else {
-      load();
-    }
-  }, [placeId, triggered]);
-
-  if (!placeId) return null;
-
-  return (
-    <div ref={ref}>
-      {photos.length > 0 && (
-        <div className="mt-2 -mx-1 overflow-x-auto">
-          <div className="flex gap-2 px-1 py-1 snap-x snap-mandatory [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {photos.slice(0, 10).map((p, i) => {
-              const url320  = resolvePhotoUrl(p, 320);
-              const url480  = resolvePhotoUrl(p, 480);
-              const url640  = resolvePhotoUrl(p, 640);
-              const url896  = resolvePhotoUrl(p, 896);
-              const src = url480 || url640 || url896 || url320;
-              if (!src) return null;
-
-              const srcSet = [
-                url320 && `${url320} 320w`,
-                url480 && `${url480} 480w`,
-                url640 && `${url640} 640w`,
-                url896 && `${url896} 896w`,
-              ]
-                .filter(Boolean)
-                .join(", ");
-
-              const sizes = "(min-width: 768px) 384px, (min-width: 640px) 320px, 240px";
-              const attribution = p.html_attributions?.[0];
-
-              return (
-                <div key={`${p.photo_reference || p.url || i}`} className="relative flex-none snap-start">
-                  <img
-                    src={src}
-                    srcSet={srcSet}
-                    sizes={sizes}
-                    alt={`${title || "Restaurant"} photo ${i + 1}`}
-                    className="
-                      h-28 w-44
-                      sm:h-32 sm:w-56
-                      md:h-32 md:w-64
-                      rounded-md object-cover border border-sand-200
-                    "
-                    loading="lazy"
-                    decoding="async"
-                    referrerPolicy="no-referrer"
-                  />
-                  {attribution && (
-                    <div
-                      className="absolute bottom-1 right-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] text-white"
-                      dangerouslySetInnerHTML={{ __html: attribution }}
-                    />
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
+import PhotoStrip from "../_shared/PhotoStrip";
+import { clearExpiredPlacePhotoCache } from "@/utils/placePhotoCache";
 
 /* --------------------------------- types --------------------------------- */
 interface Props {
@@ -186,6 +21,7 @@ interface Props {
   }>;
   onAdd: () => void;
   onEdit: (r: any) => void;
+  canEdit?: boolean;
   isMobile: boolean;
   onClose: () => void;
   onBack: () => void;
@@ -196,6 +32,7 @@ export default function ReservationsPanel({
   reservations,
   onAdd,
   onEdit,
+  canEdit = true,
   isMobile,
   onClose,
   onBack,
@@ -216,13 +53,15 @@ export default function ReservationsPanel({
     <div className="p-4">
       <Header title="Reservations" {...{ isMobile, onBack, onClose }} />
 
-      <Button
-        size="sm"
-        onClick={onAdd}
-        className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
-      >
-        <Plus size={14} className="mr-1" /> Add Reservation
-      </Button>
+      {canEdit && (
+        <Button
+          size="sm"
+          onClick={onAdd}
+          className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
+        >
+          <Plus size={14} className="mr-1" /> Add Reservation
+        </Button>
+      )}
 
       {dates.map((d) => (
         <div key={d} className="space-y-2">
@@ -236,8 +75,8 @@ export default function ReservationsPanel({
                 key={r.id}
                 className="ml-2 w-full rounded-lg bg-sand-50 p-3 text-left transition-colors hover:bg-sand-100"
               >
-                {/* Clickable header area */}
-                <button onClick={() => onEdit(r)} className="w-full text-left">
+                {/* Clickable header area (edit-only) */}
+                <div onClick={canEdit ? () => onEdit(r) : undefined} role={canEdit ? "button" : undefined} className={`w-full text-left ${canEdit ? 'cursor-pointer' : ''}`}>
                   <h4 className="mb-1 text-sm font-medium">{r.restaurant_name}</h4>
                   <p className="text-xs text-sand-600">{formatTime(r.reservation_time)}</p>
                   {r.number_of_people && (
@@ -248,7 +87,7 @@ export default function ReservationsPanel({
                       {(r.currency || "USD")} {r.cost.toLocaleString()}
                     </p>
                   )}
-                </button>
+                </div>
 
                 {/* Non-clickable, scrollable photo strip */}
                 <PhotoStrip placeId={r.place_id} title={r.restaurant_name} />

--- a/src/components/trip/dining/RestaurantReservationDialog.tsx
+++ b/src/components/trip/dining/RestaurantReservationDialog.tsx
@@ -69,7 +69,6 @@ const RestaurantReservationDialog: React.FC<RestaurantReservationDialogProps> = 
           .eq('trip_id', tripId);
         
         if (error) throw error;
-        toast.success('Reservation updated');
       } else {
         // Create new reservation
         const { error } = await supabase
@@ -77,7 +76,6 @@ const RestaurantReservationDialog: React.FC<RestaurantReservationDialogProps> = 
           .insert([{ ...data, trip_id: tripId }]);
         
         if (error) throw error;
-        toast.success('Reservation added');
       }
 
       queryClient.invalidateQueries({ queryKey: ['reservations'] });
@@ -109,8 +107,7 @@ const RestaurantReservationDialog: React.FC<RestaurantReservationDialogProps> = 
         .eq('trip_id', tripId);
       
       if (error) throw error;
-      toast.success('Reservation deleted');
-      
+
       queryClient.invalidateQueries({ queryKey: ['reservations'] });
       queryClient.invalidateQueries({ queryKey: ['trip'] });
       onOpenChange(false);
@@ -123,14 +120,14 @@ const RestaurantReservationDialog: React.FC<RestaurantReservationDialogProps> = 
 
   return (
     <Dialog open={finalOpen} onOpenChange={onOpenChange}>
-      <DialogContent onPointerDownOutside={(e) => e.preventDefault()} className="overflow-visible">
+      <DialogContent onPointerDownOutside={(e) => e.preventDefault()}>
         <DialogHeader className="flex-shrink-0 z-40">
           <DialogTitle>{title || (finalInitialData?.id ? 'Edit Reservation' : 'Add Reservation')}</DialogTitle>
           <DialogDescription className="sr-only">
             {finalInitialData?.id ? 'Update your restaurant booking details' : 'Add a new dining reservation'}
           </DialogDescription>
         </DialogHeader>
-        <div className="flex-1 overflow-y-auto scrollbar-none px-1 overflow-visible">
+        <div className="flex-1 overflow-y-auto scrollbar-none px-1">
           <RestaurantReservationForm
             onSubmit={handleSubmit}
             isSubmitting={legacyIsSubmitting ?? isSubmitting}

--- a/src/components/trip/dining/RestaurantReservationForm.tsx
+++ b/src/components/trip/dining/RestaurantReservationForm.tsx
@@ -561,7 +561,7 @@ const RestaurantReservationForm: React.FC<RestaurantReservationFormProps> = ({
         />
 
         {/* Buttons */}
-        <div className="flex justify-between items-center pt-6 mt-2 border-t border-sand-200">
+        <div className="sticky bottom-0 z-10 bg-background flex justify-between items-center pt-4 -mt-px border-t border-sand-200">
           <div>
             {defaultValues?.id && onDelete && (
               <Button

--- a/src/components/trip/timeline/TimelineContent.tsx
+++ b/src/components/trip/timeline/TimelineContent.tsx
@@ -279,8 +279,6 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                     await setDayActivityTravelers(sortedDays[0].trip_id, editingActivity.id, activityEdit.travelers);
                   }
                   
-                  toast.success('Activity updated successfully');
-                  
                   // Invalidate queries
                   if (sortedDays.length > 0) {
                     queryClient.invalidateQueries({ queryKey: ['trip', sortedDays[0].trip_id] });
@@ -327,7 +325,6 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                     await setDayActivityTravelers(sortedDays[0].trip_id, data.id, newActivity.travelers);
                   }
                   
-                  toast.success('Activity added successfully');
                   setActivityOpen(false);
                   setNewActivity({
                     title: '',
@@ -362,7 +359,6 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                   .eq('id', id);
                 
                 if (error) throw error;
-                toast.success('Activity deleted successfully');
                 setEditingActivity(null);
                 
                 // Invalidate queries
@@ -413,8 +409,7 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                     });
                   
                   if (error) throw error;
-                  toast.success('Reservation added successfully');
-                  
+
                   // Invalidate both trip and reservation queries for real-time updates
                   queryClient.invalidateQueries({ queryKey: ['trip', sortedDays[0].trip_id] });
                   queryClient.invalidateQueries({ queryKey: ['reservations', sortedDays[0].trip_id, selectedDayId] });
@@ -431,8 +426,7 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                     .eq('id', editingReservation.id);
                   
                   if (error) throw error;
-                  toast.success('Reservation updated successfully');
-                  
+
                   // Invalidate both trip and reservation queries for real-time updates
                   queryClient.invalidateQueries({ queryKey: ['trip', sortedDays[0].trip_id] });
                   if (editingReservation.day_id) {
@@ -456,7 +450,6 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                 
                 if (error) throw error;
                 
-                toast.success('Reservation deleted successfully');
                 setReservationOpen(false);
                 setEditingReservation(null);
                 

--- a/src/components/trip/timeline/TripDates.tsx
+++ b/src/components/trip/timeline/TripDates.tsx
@@ -124,7 +124,6 @@ const TripDates: React.FC<TripDatesProps> = ({
       await createTripDays(tripId, allDates);
     }
 
-    toast.success('Trip dates updated');
     onDatesChange({ arrival_date: arr, departure_date: dep });
     setIsOpen(false);
     setIsSubmitting(false);

--- a/src/components/trip/timeline/TripDatesPanel.tsx
+++ b/src/components/trip/timeline/TripDatesPanel.tsx
@@ -3,17 +3,18 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { Edit } from "lucide-react";
 import Header from "@/components/trip/_shared/Header";
-import { parse, differenceInCalendarDays, format } from "date-fns";
+import { differenceInCalendarDays, format } from "date-fns";
 
 interface TripDatesPanelProps {
   trip: { arrival_date: string; departure_date: string } | null;
   onEdit: () => void;
+  canEdit?: boolean;
   isMobile: boolean;
   onClose: () => void;
   onBack: () => void;
 }
 
-/** Parse an ISO “YYYY-MM-DD” string to a local‐midnight Date */
+/** Parse an ISO "YYYY-MM-DD" string to a local-midnight Date */
 function parseLocalDate(iso: string): Date {
   const [y, m, d] = iso.split("-").map(Number);
   return new Date(y, m - 1, d);
@@ -22,6 +23,7 @@ function parseLocalDate(iso: string): Date {
 export default function TripDatesPanel({
   trip,
   onEdit,
+  canEdit = true,
   isMobile,
   onClose,
   onBack,
@@ -36,14 +38,16 @@ export default function TripDatesPanel({
     <div className="p-4">
       <Header title="Trip Dates" isMobile={isMobile} onBack={onBack} onClose={onClose} />
 
-      <Button
-        size="sm"
-        onClick={onEdit}
-        className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
-      >
-        <Edit size={14} className="mr-1" />
-        Edit Dates
-      </Button>
+      {canEdit && (
+        <Button
+          size="sm"
+          onClick={onEdit}
+          className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
+        >
+          <Edit size={14} className="mr-1" />
+          Edit Dates
+        </Button>
+      )}
 
       <div className="space-y-3">
         <div className="rounded-lg bg-sand-50 p-3">
@@ -61,7 +65,7 @@ export default function TripDatesPanel({
         <div className="rounded-lg bg-sand-50 p-3">
           <p className="text-sm font-medium text-earth-600">Duration</p>
           <p className="text-sm text-sand-700">
-            {nights > 0 ? `${nights} night${nights === 1 ? "" : "s"}` : "—"}
+            {nights > 0 ? `${nights} night${nights === 1 ? "" : "s"}` : "\u2014"}
           </p>
         </div>
       </div>

--- a/src/components/trip/transportation/LocationSearchInput.tsx
+++ b/src/components/trip/transportation/LocationSearchInput.tsx
@@ -27,6 +27,7 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const isSelectingRef = useRef(false);
 
   // Update dropdown position when showing suggestions
   useEffect(() => {
@@ -137,14 +138,14 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
     }
   };
 
-  const handleBlur = (e: React.FocusEvent) => {
-    // Longer timeout for mobile devices where touch events take longer to process
+  const handleBlur = () => {
+    if (isSelectingRef.current) return;
     setTimeout(() => {
-      if (!dropdownRef.current?.contains(document.activeElement)) {
+      if (!isSelectingRef.current && !dropdownRef.current?.contains(document.activeElement)) {
         setShowSuggestions(false);
         setSelectedIndex(-1);
       }
-    }, 300);
+    }, 200);
   };
 
   useEffect(() => {
@@ -156,14 +157,18 @@ const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
   const dropdownContent = showSuggestions && suggestions.length > 0 && (
     <div
       ref={dropdownRef}
-      className="bg-white border border-sand-200 rounded-md shadow-warm-xl max-h-60 overflow-y-auto"
+      className="bg-white border border-sand-200 rounded-md shadow-warm-xl max-h-60 overflow-y-auto pointer-events-auto"
       style={{
         position: 'fixed',
         top: dropdownPosition.top + 4,
         left: dropdownPosition.left,
         width: dropdownPosition.width,
-        zIndex: 9999
+        zIndex: 99999
       }}
+      onMouseDown={() => { isSelectingRef.current = true; }}
+      onMouseUp={() => { setTimeout(() => { isSelectingRef.current = false; }, 100); }}
+      onTouchStart={() => { isSelectingRef.current = true; }}
+      onTouchEnd={() => { setTimeout(() => { isSelectingRef.current = false; }, 100); }}
     >
       {suggestions.map((suggestion, index) => (
         <button

--- a/src/components/trip/transportation/TransportationDialog.tsx
+++ b/src/components/trip/transportation/TransportationDialog.tsx
@@ -84,7 +84,6 @@ const TransportationDialog: React.FC<TransportationDialogProps> = ({
           .single();
         if (error || !updatedRecord) throw error;
         savedRecord = updatedRecord;
-        toast.success('Transportation updated successfully');
       } else {
         // Insert new
         const { data: inserted, error } = await supabase
@@ -94,7 +93,6 @@ const TransportationDialog: React.FC<TransportationDialogProps> = ({
           .single();
         if (error || !inserted) throw error;
         savedRecord = inserted;
-        toast.success('Transportation added successfully');
       }
 
       // Invalidate queries to refresh the UI
@@ -128,7 +126,6 @@ const TransportationDialog: React.FC<TransportationDialogProps> = ({
       queryClient.invalidateQueries({ queryKey: ['transportation', tripId] });
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       
-      toast.success('Transportation deleted successfully');
       onOpenChange(false);
     } catch (err) {
       console.error('Error deleting transportation:', err);

--- a/src/components/trip/transportation/TransportationForm.tsx
+++ b/src/components/trip/transportation/TransportationForm.tsx
@@ -172,7 +172,7 @@ export default function TransportationForm({
           tripId={tripId}
         />
 
-        <div className="flex items-center justify-between pt-6 mt-2 border-t border-sand-200">
+        <div className="sticky bottom-0 z-10 bg-background flex items-center justify-between pt-4 -mt-px border-t border-sand-200">
           <div>
             {initialData && onDelete && (
               <Button

--- a/src/components/trip/transportation/TransportationPanel.tsx
+++ b/src/components/trip/transportation/TransportationPanel.tsx
@@ -25,6 +25,7 @@ interface Props {
   }>;
   onAdd: () => void;
   onEdit: (t: any) => void;
+  canEdit?: boolean;
   isMobile: boolean;
   onClose: () => void;
   onBack: () => void;
@@ -34,6 +35,7 @@ export default function TransportationPanel({
   transportation,
   onAdd,
   onEdit,
+  canEdit = true,
   isMobile,
   onClose,
   onBack,
@@ -53,13 +55,15 @@ export default function TransportationPanel({
     <div className="p-4">
       <Header title="Transportation" {...{ isMobile, onBack, onClose }} />
 
-      <Button
-        size="sm"
-        onClick={onAdd}
-        className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
-      >
-        <Plus size={14} className="mr-1" /> Add Transportation
-      </Button>
+      {canEdit && (
+        <Button
+          size="sm"
+          onClick={onAdd}
+          className="mb-4 w-full bg-earth-500 text-white hover:bg-earth-600"
+        >
+          <Plus size={14} className="mr-1" /> Add Transportation
+        </Button>
+      )}
 
       {dates.map((d) => (
         <div key={d} className="space-y-2">
@@ -90,10 +94,11 @@ export default function TransportationPanel({
               }
 
               return (
-                <button
+                <div
                   key={t.id}
-                  onClick={() => onEdit(t)}
-                  className="ml-2 w-full rounded-lg bg-sand-50 p-3 text-left transition-colors hover:bg-sand-100"
+                  onClick={canEdit ? () => onEdit(t) : undefined}
+                  role={canEdit ? "button" : undefined}
+                  className={`ml-2 w-full rounded-lg bg-sand-50 p-3 text-left transition-colors ${canEdit ? 'hover:bg-sand-100 cursor-pointer' : ''}`}
                 >
                   <h4 className="mb-1 text-sm font-medium flex items-center gap-2">
                     <span className="text-base">{getTransportationIcon(t.type)}</span>
@@ -105,7 +110,7 @@ export default function TransportationPanel({
                       {(t.currency || "USD")} {t.cost.toLocaleString()}
                     </p>
                   )}
-                </button>
+                </div>
               );
             })}
         </div>

--- a/src/components/trip/travelers/EditInviteLinkDialog.tsx
+++ b/src/components/trip/travelers/EditInviteLinkDialog.tsx
@@ -53,7 +53,6 @@ export default function EditInviteLinkDialog({
 
     try {
       onSave(link.id, updates);
-      toast.success('Invite link updated');
       onOpenChange(false);
     } catch {
       toast.error('Failed to update invite link');

--- a/src/components/trip/travelers/TravelerDialog.tsx
+++ b/src/components/trip/travelers/TravelerDialog.tsx
@@ -142,7 +142,6 @@ export default function TravelerDialog({
       return result;
     },
     onSuccess: () => {
-      toast.success(isEditing ? "Traveler updated" : "Traveler added");
       queryClient.invalidateQueries({ queryKey: ["travelers", tripId] });
       onOpenChange(false);
       form.reset();
@@ -303,7 +302,6 @@ export default function TravelerDialog({
       if (error) throw error;
     },
     onSuccess: () => {
-      toast.success("Traveler removed");
       queryClient.invalidateQueries({ queryKey: ["travelers", tripId] });
       setCreatedShareId(null);
       onOpenChange(false);

--- a/src/hooks/use-timeline-events.tsx
+++ b/src/hooks/use-timeline-events.tsx
@@ -76,7 +76,6 @@ export function useTimelineEvents(tripId: string) {
       return data;
     },
     onSuccess: () => {
-      toast.success('Stay updated successfully');
       queryClient.invalidateQueries({ queryKey: ['accommodations', tripId] });
     },
     onError: (error) => {
@@ -91,7 +90,6 @@ export function useTimelineEvents(tripId: string) {
       throw new Error('Accommodation functionality has been removed');
     },
     onSuccess: () => {
-      toast.success('Event deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['accommodations', tripId] });
     },
     onError: (error) => {

--- a/src/hooks/use-trip-days.tsx
+++ b/src/hooks/use-trip-days.tsx
@@ -60,7 +60,6 @@ export const useTripDays = (tripId: string | undefined) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['trip-days', tripId] });
-      toast.success('Day added successfully');
     },
     onError: () => {
       toast.error('Failed to add day');
@@ -91,7 +90,6 @@ export const useTripDays = (tripId: string | undefined) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['trip-days', tripId] });
-      toast.success('Day updated successfully');
     },
     onError: () => {
       toast.error('Failed to update day');
@@ -132,7 +130,6 @@ export const useTripDays = (tripId: string | undefined) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['trip-days', tripId] });
-      toast.success('Activity added successfully');
     },
     onError: () => {
       toast.error('Failed to add activity');
@@ -168,7 +165,6 @@ export const useTripDays = (tripId: string | undefined) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['trip-days', tripId] });
-      toast.success('Activities reordered successfully');
     },
     onError: () => {
       toast.error('Failed to reorder activities');

--- a/src/hooks/useSidebarState.ts
+++ b/src/hooks/useSidebarState.ts
@@ -405,7 +405,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       if (error) throw error;
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       queryClient.invalidateQueries({ queryKey: ['accommodations'] });
-      toast({ title: 'Success', description: 'Accommodation deleted' });
     } catch (err) {
       console.error('Error deleting accommodation:', err);
       toast({ variant: 'destructive', title: 'Error', description: 'Failed to delete accommodation' });
@@ -431,7 +430,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       if (error) throw error;
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       queryClient.invalidateQueries({ queryKey: ['transportation', tripId] });
-      toast({ title: 'Success', description: 'Transportation deleted' });
     } catch (err) {
       console.error('Error deleting transportation:', err);
       toast({ variant: 'destructive', title: 'Error', description: 'Failed to delete transportation' });
@@ -457,7 +455,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       if (error) throw error;
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       queryClient.invalidateQueries({ queryKey: ['reservations'] });
-      toast({ title: 'Success', description: 'Reservation deleted' });
     } catch (err) {
       console.error('Error deleting reservation:', err);
       toast({ variant: 'destructive', title: 'Error', description: 'Failed to delete reservation' });
@@ -493,7 +490,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       if (error) throw error;
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       queryClient.invalidateQueries({ queryKey: ['activities', tripId] });
-      toast({ title: 'Success', description: 'Activity deleted' });
     } catch (err) {
       console.error('Error deleting activity:', err);
       toast({ variant: 'destructive', title: 'Error', description: 'Failed to delete activity' });
@@ -543,7 +539,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       queryClient.invalidateQueries({ queryKey: ['activities', tripId] });
-      toast({ title: 'Success', description: 'Activity added' });
       setActivityOpen(false);
     } catch (err) {
       console.error('Error adding activity:', err);
@@ -592,7 +587,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       
       queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
       queryClient.invalidateQueries({ queryKey: ['activities', tripId] });
-      toast({ title: 'Success', description: 'Activity updated' });
       setSelectedActivity(null);
     } catch (err) {
       console.error('Error editing activity:', err);
@@ -701,7 +695,6 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
       await createTripDays(tripId || '', allDates);
     }
     
-    toast({ title: 'Success', description: 'Trip dates updated' });
     setTripDatesOpen(false);
     setIsSubmittingDates(false);
   };

--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -141,7 +141,6 @@ const MyTrips = () => {
 
       if (error) throw error;
 
-      toast.success('Trip deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['my-trips'] });
       queryClient.invalidateQueries({ queryKey: ['shared-trips'] });
     } catch (error) {
@@ -292,7 +291,7 @@ const MyTrips = () => {
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-sand-50 via-sand-50 to-earth-50">
       <Navigation />
-      <div className="container mx-auto px-4 pt-20 pb-8">
+      <div className="container mx-auto px-4 pt-14 sm:pt-20 pb-8">
         {/* Dynamic Travel Headquarters */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -307,7 +307,6 @@ const Profile = () => {
       setAvatarUrl(cacheBustedUrl);
       // Refresh the auth context so nav/sidebar update immediately
       await refreshProfile();
-      toast.success('Avatar updated successfully');
     } catch (error) {
       console.error('Error uploading avatar:', error);
       toast.error('Failed to upload avatar');
@@ -349,7 +348,6 @@ const Profile = () => {
 
       // Refresh the auth context so nav/sidebar update immediately
       await refreshProfile();
-      toast.success('Profile updated successfully');
     } catch (error) {
       console.error('Error updating profile:', error);
       toast.error('Failed to update profile');
@@ -409,7 +407,6 @@ const Profile = () => {
         // Skipping DB write here; still allow saving as an "alias" for future. Consider persisting to a contacts_overrides table if you have one.
       }
 
-      toast.success("Contact updated");
       setEditOpen(false);
       await fetchContacts();
     } catch (e: any) {

--- a/src/services/bulkImportService.ts
+++ b/src/services/bulkImportService.ts
@@ -150,6 +150,7 @@ async function importActivity(
         end_time: toDbTime(fields.end_time as string),
         cost: typeof fields.cost === 'number' ? fields.cost : null,
         currency: (fields.currency as string) || 'USD',
+        location_address: (fields.location as string) || null,
         order_index: nextIndex,
         created_at: new Date().toISOString()
       });


### PR DESCRIPTION
## Summary
- **Warm editorial reskin** — DM Serif Display headings, cream/bronze palette, sunset accent CTAs, brown-tinted shadows
- **Sticky dialog footers on mobile** — Save/cancel/delete buttons pinned to bottom of viewport in all 4 dialog types (accommodation, transportation, activity, reservation) so users don't have to scroll to reach actions
- **Timeline simplification** — removed vision board, unified outline icons, single warm neutral palette
- **PDF export reskin** — DM Serif/DM Sans fonts, updated color palette
- **Google Places location search** for activities
- **AI assistant improvements** — chat responsiveness, mobile scrolling fixes, document extraction support
- **Misc fixes** — double-scroll in ActivityDialog, broken overflow in ReservationDialog, sidebar/panel refinements

## Test plan
- [ ] Open each dialog (accommodation, transportation, activity, reservation) on mobile viewport (~375px)
- [ ] Verify save/cancel/delete buttons stay pinned at bottom while form content scrolls
- [ ] Verify date pickers and dropdowns in reservation dialog still render correctly (not clipped)
- [ ] Check timeline view renders with outline icons and warm palette
- [ ] Verify PDF export uses DM Serif/DM Sans fonts and updated colors
- [ ] Test Google Places autocomplete in activity form

🤖 Generated with [Claude Code](https://claude.com/claude-code)