### PR TITLE
fix: remove CSS scroll-snap that caused auto-scroll on trip open

### DIFF
--- a/src/components/trip/timeline/TimelineContent.tsx
+++ b/src/components/trip/timeline/TimelineContent.tsx
@@ -326,7 +326,7 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
   return (
     <>
       {/* Day Cards */}
-      <div className="space-y-2 sm:space-y-3 md:space-y-4 snap-y snap-proximity pb-20 md:pb-4 -mx-1 md:-mx-6 px-1 md:px-6 py-4 md:py-6 rounded-lg">
+      <div className="space-y-2 sm:space-y-3 md:space-y-4 pb-20 md:pb-4 -mx-1 md:-mx-6 px-1 md:px-6 py-4 md:py-6 rounded-lg">
         {sortedDays.map((day, index) => {
           const dayIndex = dayIndexMap.get(day.day_id) || index + 1;
           const dayDate = day.date.split('T')[0];
@@ -334,7 +334,7 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
           const isTodayDay = isToday(dayDate);
 
           return (
-            <div key={day.day_id} className="snap-start">
+            <div key={day.day_id}>
               <CompactDayCard
                 id={day.day_id}
                 tripId={day.trip_id}


### PR DESCRIPTION
## Summary
- Removed `snap-y snap-proximity` from the timeline container and `snap-start` from each day card wrapper
- These CSS scroll-snap properties caused the browser to snap the viewport midway down the timeline when opening a trip, because collapsed past days + expanded future days shifted the snap target away from the top

## Test plan
- [ ] Open a trip with multiple days (some past, some future) — page should load at the top
- [ ] Scroll through the timeline — day cards should still render and space correctly
- [ ] Verify on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)