### PR TITLE
fix: trip date extension not generating new days on mobile

### DIFF
--- a/src/components/trip/timeline/TripDateEditDialog.tsx
+++ b/src/components/trip/timeline/TripDateEditDialog.tsx
@@ -12,7 +12,7 @@ interface TripDateEditDialogProps {
   departureDate: string;
   onArrivalChange: (date: string) => void;
   onDepartureChange: (date: string) => void;
-  onSave: (arrivalDate?: string, departureDate?: string) => void;
+  onSave: (arrivalDate?: string, departureDate?: string) => void | Promise<void>;
 }
 
 // parse "YYYY-MM-DD" as local date (no TZ offset)
@@ -43,14 +43,21 @@ export default function TripDateEditDialog({
     }
   }, [isOpen, arrivalDate, departureDate]);
 
-  const handleSave = () => {
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
     if (range?.from && range?.to) {
       const newArrival = format(range.from, 'yyyy-MM-dd');
       const newDeparture = format(range.to, 'yyyy-MM-dd');
       console.log('TripDateEditDialog saving dates:', { newArrival, newDeparture });
       onArrivalChange(newArrival);
       onDepartureChange(newDeparture);
-      onSave(newArrival, newDeparture);
+      setIsSaving(true);
+      try {
+        await onSave(newArrival, newDeparture);
+      } finally {
+        setIsSaving(false);
+      }
       onOpenChange(false);
     }
   };
@@ -104,9 +111,9 @@ export default function TripDateEditDialog({
             <Button
               onClick={handleSave}
               className="flex-1 bg-earth-600 hover:bg-earth-700 text-white"
-              disabled={!range?.from || !range?.to}
+              disabled={!range?.from || !range?.to || isSaving}
             >
-              Save Changes
+              {isSaving ? 'Saving…' : 'Save Changes'}
             </Button>
           </div>
         </div>

--- a/src/hooks/useSidebarState.ts
+++ b/src/hooks/useSidebarState.ts
@@ -672,6 +672,7 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
     } catch (err) {
       console.error('Failed to add new trip days:', err);
       toast({ variant: 'destructive', title: 'Error', description: 'Failed to add new trip days' });
+      throw err;
     }
   };
 
@@ -679,22 +680,26 @@ export function useSidebarState(tripId: string | undefined): SidebarState {
   const saveDateChanges = async (arr: string, dep: string) => {
     console.log('saveDateChanges called with:', { arr, dep, tripId });
     console.log('Current trip data:', trip);
-    
+
+    // Capture old dates before any async work to avoid closure staleness
+    const oldArrival = trip?.arrival_date;
+    const oldDeparture = trip?.departure_date;
+
     const { error } = await supabase
       .from('trips')
       .update({ arrival_date: arr, departure_date: dep })
       .eq('trip_id', tripId);
     if (error) throw error;
-    
-    if (trip?.arrival_date && trip?.departure_date) {
+
+    if (oldArrival && oldDeparture) {
       console.log('Taking addNewTripDays path - existing trip has dates');
-      await addNewTripDays(trip.arrival_date, trip.departure_date, arr, dep);
+      await addNewTripDays(oldArrival, oldDeparture, arr, dep);
     } else {
       console.log('Taking createTripDays path - no existing dates');
       const allDates = generateDatesArray(arr, dep);
       await createTripDays(tripId || '', allDates);
     }
-    
+
     setTripDatesOpen(false);
     setIsSubmittingDates(false);
   };

--- a/src/services/accommodation/dateUtils.ts
+++ b/src/services/accommodation/dateUtils.ts
@@ -2,7 +2,16 @@
 import { format, parse, addDays, isBefore, isEqual, differenceInDays } from 'date-fns';
 
 /**
- * Generates an array of dates between start and end (inclusive)
+ * Parse a "YYYY-MM-DD" string as a local-midnight Date (no UTC offset issues).
+ */
+function parseLocalDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * Generates an array of date strings between start and end (inclusive).
+ * Uses local-date parsing and date-fns arithmetic to avoid timezone/DST bugs.
  */
 export const generateDateArray = (startDate: string, endDate: string): string[] => {
   if (!startDate || !endDate) {
@@ -10,27 +19,22 @@ export const generateDateArray = (startDate: string, endDate: string): string[] 
     return [];
   }
 
-  const datesArray: string[] = [];
-  const start = new Date(startDate);
-  const end = new Date(endDate);
+  const start = parseLocalDate(startDate);
+  const end = parseLocalDate(endDate);
 
   if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-    console.error('Invalid dates provided to generateDateArray', { startDate, endDate, start, end });
+    console.error('Invalid dates provided to generateDateArray', { startDate, endDate });
     return [];
   }
 
-  // Generate array of dates between start and end (inclusive of start)
-  const current = new Date(start);
-  while (current <= end) { //Corrected the comparison to include the end date.
-    const dateString = current.toISOString().split('T')[0];
-    datesArray.push(dateString);
-    current.setDate(current.getDate() + 1);
+  const datesArray: string[] = [];
+  let current = start;
+  while (current <= end) {
+    datesArray.push(format(current, 'yyyy-MM-dd'));
+    current = addDays(current, 1);
   }
 
-  console.log(`Generated ${datesArray.length} dates:`, datesArray);
   return datesArray;
 };
 
-// We don't need to create an alias since we're already exporting the function with the correct name
-// If other parts of the app expect a function named 'generateDatesArray', uncomment the line below:
 export const generateDatesArray = generateDateArray;


### PR DESCRIPTION
Three issues prevented new trip days from being created when extending
trip dates, particularly on mobile:

1. generateDatesArray used `new Date("YYYY-MM-DD")` (UTC midnight) with
   local-time getDate()/setDate() and UTC toISOString() output, causing
   off-by-one date strings in certain timezone/DST configurations. Now
   uses local-date parsing with date-fns addDays() for safe arithmetic.

2. TripDateEditDialog fired onSave (async) without awaiting it, then
   immediately closed the dialog. On mobile browsers this could cause
   the async save to be deprioritized. Now awaits the save, shows a
   "Saving..." state, and only closes after completion.

3. addNewTripDays swallowed errors from createTripDays, preventing the
   parent handler from knowing day creation failed. Now re-throws so
   handleSaveDates can surface the error properly.

Also captures old trip dates into local variables before the async
Supabase update to guard against any closure staleness.

https://claude.ai/code/session_01REg9E1xMDCfcTx64MDXWLA