### PR TITLE
Improve rental car display in day timeline

### DIFF
--- a/src/components/trip/day/components/useDayTimeline.ts
+++ b/src/components/trip/day/components/useDayTimeline.ts
@@ -127,9 +127,12 @@ function getTransportDisplayInfo(
   }
 
   if (isStartDay) {
+    const isRentalCar = t.type === 'rental_car';
     return {
       displayTime: t.start_time || undefined,
-      title: `${t.departure_location || 'Departure'} →`,
+      title: isRentalCar
+        ? `Rental Car Pickup: ${t.departure_location || 'Pickup'}`
+        : `${t.departure_location || 'Departure'} →`,
       isStartDay,
       isEndDay,
       isMultiDay,
@@ -137,9 +140,12 @@ function getTransportDisplayInfo(
   }
 
   if (isEndDay) {
+    const isRentalCar = t.type === 'rental_car';
     return {
       displayTime: t.end_time || undefined,
-      title: `→ ${t.arrival_location || 'Arrival'}`,
+      title: isRentalCar
+        ? `Rental Car Return: ${t.arrival_location || 'Return'}`
+        : `→ ${t.arrival_location || 'Arrival'}`,
       isStartDay,
       isEndDay,
       isMultiDay,
@@ -367,13 +373,22 @@ export function useDayTimeline({
   }, [filteredHotelStays, normalizedDay]);
 
   // Filter transportations for this day
+  // Rental cars only show on pickup (start) and return (end) dates, not mid-rental days
   const filteredTransportations = useMemo(() => {
     const list = transportations || [];
     return list.filter((t) => {
       const start = t.start_date;
       const end = t.end_date ? t.end_date : start;
       const dayDate = new Date(normalizedDay);
-      return dayDate >= new Date(start) && dayDate <= new Date(end);
+      const inRange = dayDate >= new Date(start) && dayDate <= new Date(end);
+      if (!inRange) return false;
+
+      // For rental cars, only show on start and end dates
+      if (t.type === 'rental_car') {
+        return normalizedDay === start || normalizedDay === end;
+      }
+
+      return true;
     });
   }, [transportations, normalizedDay]);
 


### PR DESCRIPTION
## Summary
Updated the day timeline component to properly handle rental car transportation display, showing rental-specific labels and only displaying rental cars on their pickup and return dates.

## Key Changes
- **Rental car labels**: Changed display titles for rental cars to show "Rental Car Pickup" on start dates and "Rental Car Return" on end dates, replacing the generic arrow notation
- **Filtered visibility**: Modified the transportation filter logic to only show rental cars on their start and end dates, preventing them from appearing on intermediate days during a multi-day rental period
- **Improved UX**: Added clearer location labels ("Pickup"/"Return") for rental cars instead of generic "Departure"/"Arrival" text

## Implementation Details
- Added type checking (`t.type === 'rental_car'`) in the `getTransportDisplayInfo` function to conditionally format titles based on transportation type
- Enhanced the `filteredTransportations` memo to include rental car-specific filtering logic that compares the current day against the rental's start and end dates
- Added clarifying comment explaining that rental cars only appear on pickup and return dates

https://claude.ai/code/session_01EJ2uwwfn3eJhsBpLQn3jQ3