### PR TITLE
Add popover color support and fix dropdown menu background

### DIFF
--- a/src/components/trip/day/CompactDayCard.tsx
+++ b/src/components/trip/day/CompactDayCard.tsx
@@ -408,7 +408,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                                   Add to this day
                                 </Button>
                               </DropdownMenuTrigger>
-                              <DropdownMenuContent align="start" className="w-48">
+                              <DropdownMenuContent align="start" className="w-48 bg-white">
                                 <DropdownMenuItem onClick={addActivityForThisDay} className="gap-2">
                                   <Star className="h-4 w-4 text-earth-600" />
                                   Activity

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -71,6 +71,10 @@ export default {
           900: '#0F172A',
           950: '#020617',
         },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
       },
       animation: {
         "fade-up": "fadeUp 0.5s ease-out forwards",


### PR DESCRIPTION
## Summary
This PR adds popover color theme support to the Tailwind configuration and fixes the background color of a dropdown menu in the CompactDayCard component.

## Key Changes
- **Tailwind Config**: Added `popover` color theme with `DEFAULT` and `foreground` variants using CSS custom properties (`--popover` and `--popover-foreground`)
- **CompactDayCard**: Fixed the "Add to this day" dropdown menu by explicitly setting `bg-white` class to ensure proper background visibility

## Implementation Details
The popover colors follow the existing pattern in the Tailwind config of using HSL CSS variables, allowing for consistent theming across popover components. The dropdown menu background fix ensures the menu content is properly visible against the page background.

https://claude.ai/code/session_01EaidNLxbUY432MjvknkW9g