### PR TITLE
Fix mobile chat keyboard issues on iOS PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-visual" />
     <meta name="theme-color" content="#603D2E" />
     <meta name="description" content="Travel planning made easy with WanderLuxe" />
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo, Component, ReactNode } from 'react';
 import { FullScreenModal } from '@/components/ui/fullscreen-modal';
+import { useVisualViewport } from '@/hooks/useVisualViewport';
 import { Sparkles, Trash2, ChevronDown, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useQueryClient } from '@tanstack/react-query';
@@ -81,6 +82,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
   onOpenChange
 }) => {
   const queryClient = useQueryClient();
+  const { isKeyboardOpen } = useVisualViewport();
   const [showPaywall, setShowPaywall] = useState(false);
   const [paywallUsage, setPaywallUsage] = useState<AIUsageInfo | undefined>();
   const [errorBoundaryKey, setErrorBoundaryKey] = useState(0);
@@ -402,18 +404,20 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
                 </div>
               )}
 
-              {/* Usage meter */}
-              <div className="flex-shrink-0">
-                <UsageMeter
-                  usage={usage}
-                  onUpgradeClick={() => setShowPaywall(true)}
-                />
-              </div>
+              {/* Usage meter - hidden when keyboard is open to save space */}
+              {!isKeyboardOpen && (
+                <div className="flex-shrink-0">
+                  <UsageMeter
+                    usage={usage}
+                    onUpgradeClick={() => setShowPaywall(true)}
+                  />
+                </div>
+              )}
 
-              {/* Input - with safe area padding for PWA bottom inset */}
+              {/* Input - safe area padding only when keyboard is closed (keyboard covers the home indicator) */}
               <div
                 className="flex-shrink-0 bg-white"
-                style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+                style={{ paddingBottom: isKeyboardOpen ? 0 : 'env(safe-area-inset-bottom, 0px)' }}
               >
                 <ChatInput
                   onSend={handleSend}

--- a/src/components/trip/ai-assistant/ChatInput.tsx
+++ b/src/components/trip/ai-assistant/ChatInput.tsx
@@ -30,19 +30,17 @@ const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [message]);
 
-  // Handle focus to prevent browser auto-scroll issues on mobile
+  // Handle focus - wait for iOS keyboard to settle, then ensure input is visible
   const handleFocus = useCallback(() => {
-    // On mobile, we don't want to call scrollIntoView at all because:
-    // 1. The visual viewport API already handles keyboard appearance
-    // 2. Browser scrollIntoView can cause the entire page to shift
-    // 3. The fixed positioning of the drawer keeps the input visible
-
-    // Prevent default scroll behavior by stopping propagation
-    // The drawer's fixed positioning with visual viewport height handles visibility
-    if (textareaRef.current) {
-      // Just ensure focus without scrolling
-      // The visual viewport resize will keep this in view
-    }
+    // On iOS PWA, the keyboard animation takes ~300ms. After it settles,
+    // the FullScreenModal resizes via Visual Viewport API. We then scroll
+    // the textarea into view *within the modal* (not the page) so paste
+    // and text selection work properly.
+    setTimeout(() => {
+      if (textareaRef.current) {
+        textareaRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    }, 350);
   }, []);
 
   const handleSend = useCallback(() => {

--- a/src/components/ui/fullscreen-modal.tsx
+++ b/src/components/ui/fullscreen-modal.tsx
@@ -98,6 +98,9 @@ export function FullScreenModal({
           height: viewport.height,
           overscrollBehavior: 'contain',
           overflow: 'hidden',
+          // Smooth keyboard open/close transitions on iOS
+          willChange: 'height, top',
+          transition: 'height 0.1s ease-out, top 0.1s ease-out',
         }}
       >
         {children}


### PR DESCRIPTION
## Summary

- **Switch `interactive-widget` from `resizes-content` to `resizes-visual`** — the old value caused the layout viewport to resize when the keyboard opened, conflicting with the Visual Viewport API positioning in FullScreenModal and causing content to jump/push up unexpectedly
- **Hide the UsageMeter banner when keyboard is open** — frees up ~30px of vertical space so messages and input stay visible
- **Remove bottom safe-area padding when keyboard is open** — the keyboard covers the home indicator bar, so the padding is unnecessary and was creating odd spacing
- **Add delayed `scrollIntoView` on input focus** — waits for the iOS keyboard animation to settle (~350ms) then scrolls the textarea into view within the modal, fixing the paste/selection accessibility issue
- **Add smooth height/top transitions on FullScreenModal** — reduces visual jank during keyboard open/close

## Test plan

- [ ] Open the app from iOS home screen (PWA standalone mode)
- [ ] Open the Trip Assistant chat
- [ ] Tap the input field — keyboard should open smoothly without content jumping
- [ ] Verify the "Pro - Unlimited messages" banner hides when keyboard is open
- [ ] Verify no extra gap below the input when keyboard is open
- [ ] Long-press the input to paste — context menu should be accessible
- [ ] Dismiss the keyboard — banner reappears, bottom spacing returns for home indicator
- [ ] Test on Android Chrome as well to confirm no regressions

https://claude.ai/code/session_017LPpxKzNeUAgWvBHMubhar