### PR TITLE
Remove trash can icon from AI chat assistant

### DIFF
--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo, Component, ReactNode } from 'react';
 import { FullScreenModal } from '@/components/ui/fullscreen-modal';
 import { useVisualViewport } from '@/hooks/useVisualViewport';
-import { Sparkles, Trash2, ChevronDown, AlertCircle } from 'lucide-react';
+import { Sparkles, ChevronDown, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -15,17 +15,6 @@ import UsageMeter from './UsageMeter';
 import PaywallModal from './PaywallModal';
 import ItemStepperDialog from './ItemStepperDialog';
 import type { AIUsageInfo, AIChatMessage, ChatFileAttachment, ExtractedItem } from '@/types/ai-assistant';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger
-} from '@/components/ui/alert-dialog';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -223,15 +212,6 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
     setItemsToProcess([]);
   }, []);
 
-  const handleClearChat = useCallback(async () => {
-    try {
-      await clearThread();
-    } catch (e) {
-      console.error('Failed to clear thread:', e);
-    }
-    setExtractionMessages([]);
-    clearExtraction();
-  }, [clearThread, clearExtraction]);
 
   const handleSend = useCallback(async (message: string, attachment?: ChatFileAttachment) => {
     try {
@@ -322,40 +302,6 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
             </div>
 
             <div className="flex items-center gap-1">
-              {/* Clear chat button */}
-              {allMessages.length > 0 && (
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 w-8 p-0 text-sand-400 hover:text-red-500"
-                      title="Clear chat"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Clear chat history?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        This will permanently delete all messages in this conversation.
-                        This action cannot be undone.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={handleClearChat}
-                        className="bg-red-500 hover:bg-red-600"
-                      >
-                        Clear
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              )}
-
               {/* Minimize button */}
               <Button
                 variant="ghost"

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { Sparkles, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
+import { Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -14,17 +14,6 @@ import PaywallModal from './PaywallModal';
 import ExtractionResultMessage from './ExtractionResultMessage';
 import ItemStepperDialog from './ItemStepperDialog';
 import type { AIUsageInfo, AIChatMessage, ChatFileAttachment, ExtractedItem } from '@/types/ai-assistant';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger
-} from '@/components/ui/alert-dialog';
 
 interface AIAssistantPanelProps {
   tripId: string;
@@ -252,15 +241,6 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
   }, []);
 
   // Handle clear chat - also clear extraction messages
-  const handleClearChat = useCallback(async () => {
-    try {
-      await clearThread();
-    } catch (e) {
-      console.error('Failed to clear thread:', e);
-    }
-    setExtractionMessages([]);
-    clearExtraction();
-  }, [clearThread, clearExtraction]);
 
   const isDisabled = isStreaming || isExtracting || (usage && (usage.tier === 'free' || usage.tier === 'anon') && usage.used >= usage.limit);
 
@@ -280,40 +260,6 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
           </div>
 
           <div className="flex items-center gap-1">
-            {/* Clear chat button */}
-            {allMessages.length > 0 && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0 text-sand-400 hover:text-red-500"
-                    title="Clear chat"
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Clear chat history?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will permanently delete all messages in this conversation.
-                      This action cannot be undone.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleClearChat}
-                      className="bg-red-500 hover:bg-red-600"
-                    >
-                      Clear
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            )}
-
             {/* Collapse toggle */}
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary
- Removes the Trash2 icon button and its AlertDialog confirmation from both `AIAssistantDrawer` and `AIAssistantPanel`
- Cleans up unused imports (`Trash2`, `AlertDialog` components) and the `handleClearChat` callback

## Test plan
- [ ] Open a trip and verify the AI assistant drawer (mobile) no longer shows a trash icon
- [ ] Open a trip and verify the AI assistant panel (desktop) no longer shows a trash icon
- [ ] Confirm the rest of the chat UI (send messages, minimize, collapse) still works

https://claude.ai/code/session_0145Gd1MSbXXWk9BDz7FSgce