### PR TITLE
Fix accommodations search returning irrelevant results

### DIFF
--- a/src/components/trip/ActivityForm.tsx
+++ b/src/components/trip/ActivityForm.tsx
@@ -265,7 +265,6 @@ const ActivityForm: React.FC<ActivityFormProps> = ({
           <GooglePlacesAutocomplete
             value={locationSearch}
             placeholder="Search for a location..."
-            locationContext={destination}
             onChange={(name, details?: PlaceResult) => {
               setLocationSearch(name);
               if (details) {

--- a/src/components/trip/accommodation/AccommodationForm.tsx
+++ b/src/components/trip/accommodation/AccommodationForm.tsx
@@ -246,7 +246,7 @@ export default function AccommodationForm({
 
     (async () => {
       try {
-        const results = await searchPlaces(hotelName, '', destination);
+        const results = await searchPlaces(hotelName);
         if (cancelled || results.length === 0) return;
 
         const topMatch = results[0];
@@ -329,7 +329,6 @@ export default function AccommodationForm({
               </FormLabel>
               <HotelSearchInput
                 value={field.value}
-                locationContext={destination}
                 onChange={(val, d: any) => {
                   field.onChange(val);
                   // Basic details from picker (if present)

--- a/src/components/trip/accommodation/GooglePlacesAutocomplete.tsx
+++ b/src/components/trip/accommodation/GooglePlacesAutocomplete.tsx
@@ -10,16 +10,14 @@ interface GooglePlacesAutocompleteProps {
   className?: string;
   placeholder?: string;
   autoFocus?: boolean;
-  locationContext?: string; // e.g., "Paris, France" to bias search results
 }
 
 const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
   value,
   onChange,
   className,
-  placeholder = "Search for hotels, addresses...",
-  autoFocus,
-  locationContext
+  placeholder = "Search for a hotel name or address...",
+  autoFocus
 }) => {
   const [suggestions, setSuggestions] = useState<AutocompleteResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -63,7 +61,7 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
 
     setIsLoading(true);
     try {
-      const results = await searchPlaces(query, '', locationContext);
+      const results = await searchPlaces(query);
       setSuggestions(results);
       setShowSuggestions(results.length > 0);
       setSelectedIndex(-1);
@@ -74,7 +72,7 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [locationContext]);
+  }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;

--- a/src/components/trip/accommodation/HotelSearchInput.tsx
+++ b/src/components/trip/accommodation/HotelSearchInput.tsx
@@ -11,13 +11,11 @@ declare global {
 interface HotelSearchInputProps {
   value: string;
   onChange: (hotelName: string, placeDetails?: google.maps.places.PlaceResult) => void;
-  locationContext?: string; // e.g., "Paris, France" to bias search results
 }
 
 const HotelSearchInput: React.FC<HotelSearchInputProps> = ({
   value,
-  onChange,
-  locationContext
+  onChange
 }) => {
 
   return (
@@ -25,8 +23,7 @@ const HotelSearchInput: React.FC<HotelSearchInputProps> = ({
       <GooglePlacesAutocomplete
         value={value}
         onChange={onChange}
-        placeholder="Start typing to search for hotels..."
-        locationContext={locationContext}
+        placeholder="Search for a hotel name or address..."
       />
     </div>
   );

--- a/src/components/trip/dining/RestaurantReservationForm.tsx
+++ b/src/components/trip/dining/RestaurantReservationForm.tsx
@@ -299,7 +299,6 @@ const RestaurantReservationForm: React.FC<RestaurantReservationFormProps> = ({
               <RestaurantSearchInput
                 autoFocus
                 value={field.value}
-                locationContext={destination}
                 onChange={(name, details) => {
                   field.onChange(name);
                   if (details) {

--- a/src/components/trip/dining/RestaurantSearchInput.tsx
+++ b/src/components/trip/dining/RestaurantSearchInput.tsx
@@ -8,14 +8,12 @@ interface RestaurantSearchInputProps {
   value: string;
   onChange: (value: string, details?: PlaceResult) => void;
   autoFocus?: boolean;
-  locationContext?: string; // e.g., "Paris, France" to bias search results
 }
 
 const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
   value,
   onChange,
-  autoFocus,
-  locationContext
+  autoFocus
 }) => {
   const [suggestions, setSuggestions] = useState<AutocompleteResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -60,7 +58,7 @@ const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
     setIsLoading(true);
     try {
       // Use 'establishment' to include restaurants, bars, cafes, etc.
-      const results = await searchPlaces(query, 'establishment', locationContext);
+      const results = await searchPlaces(query, 'establishment');
       setSuggestions(results);
       setShowSuggestions(results.length > 0);
       setSelectedIndex(-1);
@@ -71,7 +69,7 @@ const RestaurantSearchInput: React.FC<RestaurantSearchInputProps> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [locationContext]);
+  }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;

--- a/src/utils/googleMapsLoader.ts
+++ b/src/utils/googleMapsLoader.ts
@@ -100,8 +100,7 @@ export function getPhotoUrl(photo: PlacePhotoMeta, maxWidth: number = 640): stri
 
 export async function searchPlaces(
   input: string,
-  types: string = "",
-  locationContext?: string // e.g., "Paris, France" - appended to bias results
+  types: string = ""
 ): Promise<AutocompleteResult[]> {
   if (!input?.trim()) return [];
 
@@ -112,13 +111,8 @@ export async function searchPlaces(
     const session = (await supabase.auth.getSession()).data.session;
     const token = session?.access_token;
 
-    // Append location context to help bias results toward the trip destination
-    const biasedInput = locationContext
-      ? `${input} ${locationContext}`
-      : input;
-
     const params = new URLSearchParams({
-      input: biasedInput,
+      input: input.trim(),
       ...(types ? { types } : {}),
       language: "en",
       // sessiontoken helps Google group keystrokes; your function accepts arbitrary query params


### PR DESCRIPTION
## Summary
- **Root cause**: `searchPlaces()` was concatenating the trip destination onto the user's query (e.g., "123 Oak Street" → "123 Oak Street Paris, France"), confusing Google's autocomplete and returning irrelevant results
- Removed the `locationContext` string concatenation so raw queries go directly to Google Places Autocomplete, allowing both hotel names and specific addresses to return accurate results
- Updated placeholder text to clarify that both hotel names and addresses are supported

## Test plan
- [ ] Search for a hotel by name (e.g., "Marriott") — should return relevant hotel results
- [ ] Search for a specific address (e.g., "123 Main Street, Portland") — should return the correct address
- [ ] Search for a hotel in a different city than the trip destination — should return correct results
- [ ] Verify dining/restaurant search still works correctly
- [ ] Verify activity location search still works correctly

https://claude.ai/code/session_012u8rgarnd4qdmCFUivv4sg