### PR TITLE
Fix Google Places images not loading for anonymous users

### DIFF
--- a/src/utils/googleMapsLoader.ts
+++ b/src/utils/googleMapsLoader.ts
@@ -192,7 +192,11 @@ export async function getPlaceDetails(placeId: string): Promise<PlaceResult | nu
     return (json.result ?? null) as PlaceResult | null;
   } catch (error) {
     console.error("getPlaceDetails error:", error);
-    toast.error("Failed to get location details");
+    // Only show toast for authenticated users (anonymous viewing should fail silently)
+    const session = (await supabase.auth.getSession()).data.session;
+    if (session) {
+      toast.error("Failed to get location details");
+    }
     return null;
   }
 }

--- a/supabase/functions/google-places-proxy/index.ts
+++ b/supabase/functions/google-places-proxy/index.ts
@@ -128,18 +128,26 @@ serve(async (req)=>{
       return await handlePhotoProxy(url, googleApiKey, req);
     }
 
-    // Authenticated routes require a valid user token
+    // 2) Place Details (POST) — allow anonymous access for public trip viewing
+    //    Uses IP-based rate limiting when unauthenticated
+    if (req.method === "POST") {
+      const authHeader = req.headers.get("authorization");
+      if (authHeader) {
+        const user = await authenticateUser(req);
+        if (!checkRateLimit(`user:${user.id}`)) return rateLimitResponse();
+      } else {
+        const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+        if (!checkRateLimit(`details:${ip}`)) return rateLimitResponse();
+      }
+      return await handlePlaceDetails(req, googleApiKey);
+    }
+
+    // 3) Autocomplete (GET) — requires authentication (used only when editing)
     const user = await authenticateUser(req);
     if (!checkRateLimit(`user:${user.id}`)) return rateLimitResponse();
 
-    // 2) Autocomplete (GET)
     if (req.method === "GET") {
       return await handleAutocomplete(url, googleApiKey);
-    }
-
-    // 3) Place Details (POST)
-    if (req.method === "POST") {
-      return await handlePlaceDetails(req, googleApiKey);
     }
 
     return jsonResponse({ error: "Method not allowed" }, 405);


### PR DESCRIPTION
## Summary

- **Root cause**: The Google Places proxy edge function required authentication for Place Details (POST) requests, so anonymous users viewing public trips couldn't load accommodation/reservation photos — they'd see errors instead of images.
- **Fix**: Place Details endpoint now allows unauthenticated requests with IP-based rate limiting (100 req/hour, same as photo proxy). Autocomplete remains auth-only since it's only used when editing.
- **Bonus**: Suppressed the "Failed to get location details" error toast for anonymous users so it fails silently instead of showing confusing errors.

## Files changed

- `supabase/functions/google-places-proxy/index.ts` — Moved POST handler before auth gate, with optional auth + IP-based rate limiting fallback
- `src/utils/googleMapsLoader.ts` — Suppress error toast for unauthenticated users

## Test plan

- [ ] View a public trip as an anonymous (logged-out) user — accommodation and reservation photos should load
- [ ] View a public trip as a logged-in user — photos still load as before
- [ ] Verify autocomplete search still requires authentication (only available in edit mode)
- [ ] Verify rate limiting works for anonymous place details requests

https://claude.ai/code/session_012BAu25K2aVqQw8dpSxcJri