### PR TITLE
Fix CSP violations blocking fonts, images, and external APIs before login

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'wanderluxe-v3';
+const CACHE_NAME = 'wanderluxe-v4';
 const OFFLINE_URL = '/index.html';
 const URLS_TO_CACHE = [
   '/',
@@ -39,6 +39,13 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') {
+    return;
+  }
+
+  // Skip cross-origin requests — let the browser handle them directly
+  // This avoids CSP connect-src violations for external resources (fonts, images, analytics)
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) {
     return;
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,7 +42,7 @@ app.use(helmet({
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "blob:", "https://images.unsplash.com", "https://plus.unsplash.com", "https://*.supabase.co", "https://maps.googleapis.com", "https://lh3.googleusercontent.com", "https://places.googleapis.com", "https://www.googletagmanager.com", "https://www.google-analytics.com"],
-      connectSrc: ["'self'", "https://*.supabase.co", "wss://*.supabase.co", "https://api.stripe.com", "https://maps.googleapis.com", "https://places.googleapis.com", "https://www.google-analytics.com", "https://region1.google-analytics.com", "https://www.googletagmanager.com"],
+      connectSrc: ["'self'", "https://*.supabase.co", "wss://*.supabase.co", "https://api.stripe.com", "https://maps.googleapis.com", "https://places.googleapis.com", "https://www.google-analytics.com", "https://region1.google-analytics.com", "https://www.googletagmanager.com", "https://fonts.googleapis.com", "https://fonts.gstatic.com", "https://images.unsplash.com", "https://plus.unsplash.com", "https://lh3.googleusercontent.com", "https://ipapi.co"],
       frameSrc: ["'self'", "https://js.stripe.com"],
       frameAncestors: ["'self'", "https://*.replit.dev", "https://*.repl.co"],
     },


### PR DESCRIPTION
Two issues were causing the ~10s grey-out on page load:

1. Helmet CSP `connect-src` was missing domains for Google Fonts,
   Unsplash images, Google profile pics, and ipapi.co geolocation.
   Added all missing domains.

2. Service worker was intercepting ALL fetch requests (including
   cross-origin) via `event.respondWith(fetch(...))`, which subjects
   them to the SW's CSP context. Now skips cross-origin requests
   entirely, letting the browser handle them directly.

Bumped SW cache version to v4 to ensure browsers pick up the fix.

https://claude.ai/code/session_01P9mjHyN9hbNs263svo5zpe