### PR TITLE
Tighten AI chatbot mobile UX: consolidate layout and reduce whitespace

### DIFF
--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -287,48 +287,32 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
       <FullScreenModal open={open} onOpenChange={handleOpenChange} closeOnOverlayClick={!isStreaming}>
         {/* Header with safe area padding for PWA/notch */}
         <div
-          className="border-b border-sand-200 pb-3 px-4 flex-shrink-0"
-          style={{ paddingTop: 'max(env(safe-area-inset-top, 0px), 12px)' }}
+          className="border-b border-sand-200 pb-2 px-4 flex-shrink-0"
+          style={{ paddingTop: 'max(env(safe-area-inset-top, 0px), 10px)' }}
         >
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-earth-500 flex items-center justify-center">
-                <Sparkles className="w-4 h-4 text-white" />
+            <div className="flex items-center gap-2.5">
+              <div className="w-7 h-7 rounded-full bg-earth-500 flex items-center justify-center">
+                <Sparkles className="w-3.5 h-3.5 text-white" />
               </div>
-              <div>
-                <h2 className="text-left text-earth-700 font-semibold text-lg leading-none tracking-tight">Trip Assistant</h2>
-                <p className="text-xs text-sand-500">AI-powered travel help</p>
-              </div>
+              <h2 className="text-left text-earth-700 font-semibold text-base leading-none tracking-tight">Trip Assistant</h2>
             </div>
 
-            <div className="flex items-center gap-1">
-              {/* Minimize button */}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => handleOpenChange(false)}
-                className="h-8 w-8 p-0 text-sand-400 hover:text-earth-600"
-                disabled={isStreaming}
-                title="Minimize"
-              >
-                <ChevronDown className="w-5 h-5" />
-              </Button>
-            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleOpenChange(false)}
+              className="h-8 w-8 p-0 text-sand-400 hover:text-earth-600"
+              disabled={isStreaming}
+              title="Minimize"
+            >
+              <ChevronDown className="w-5 h-5" />
+            </Button>
           </div>
         </div>
 
           <AIAssistantErrorBoundary key={errorBoundaryKey} onReset={handleErrorBoundaryReset}>
             <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-              {/* Prompt chips - show when no messages */}
-              {allMessages.length === 0 && !isLoading && (
-                <div className="flex-shrink-0">
-                  <PromptChips
-                    onSelect={handlePromptSelect}
-                    disabled={isDisabled}
-                  />
-                </div>
-              )}
-
               <ChatMessageList
                 messages={allMessages}
                 isLoading={isLoading || isExtracting}
@@ -341,6 +325,12 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
                 onImportAll={handleImportAll}
                 onReviewEdit={handleReviewEdit}
                 isImporting={isImporting}
+                emptyStateSlot={
+                  <PromptChips
+                    onSelect={handlePromptSelect}
+                    disabled={isDisabled}
+                  />
+                }
               />
 
               {/* Error display */}

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -280,14 +280,6 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
         {/* Collapsible content */}
         {!isCollapsed && (
           <>
-            {/* Prompt chips - show when no messages */}
-            {allMessages.length === 0 && !isLoading && (
-              <PromptChips
-                onSelect={handlePromptSelect}
-                disabled={isDisabled}
-              />
-            )}
-
             {/* Messages area */}
             <ChatMessageList
               messages={allMessages}
@@ -301,6 +293,12 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
               onImportAll={handleImportAll}
               onReviewEdit={handleReviewEdit}
               isImporting={isImporting}
+              emptyStateSlot={
+                <PromptChips
+                  onSelect={handlePromptSelect}
+                  disabled={isDisabled}
+                />
+              }
             />
 
             {/* Error display */}

--- a/src/components/trip/ai-assistant/ChatInput.tsx
+++ b/src/components/trip/ai-assistant/ChatInput.tsx
@@ -82,7 +82,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const canSend = (message.trim().length > 0 || attachment) && !disabled && !isSending;
 
   return (
-    <div className="border-t border-sand-200 bg-background p-3">
+    <div className="border-t border-sand-200 bg-background px-3 py-2">
       {/* Attachment preview */}
       {attachment && (
         <div className="mb-2 relative inline-block">

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -15,6 +15,7 @@ interface ChatMessageListProps {
   onImportAll?: (items: ExtractedItem[]) => Promise<void>;
   onReviewEdit?: (items: ExtractedItem[]) => void;
   isImporting?: boolean;
+  emptyStateSlot?: React.ReactNode;
 }
 
 const ChatMessageList: React.FC<ChatMessageListProps> = ({
@@ -28,7 +29,8 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
   tripId,
   onImportAll,
   onReviewEdit,
-  isImporting = false
+  isImporting = false,
+  emptyStateSlot
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -137,19 +139,16 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
 
   if (messages.length === 0 && !isStreaming) {
     return (
-      <div className="flex-1 flex items-center justify-center p-6">
-        <div className="flex flex-col items-center gap-4 text-center max-w-sm">
-          <div className="w-12 h-12 rounded-full bg-sand-100 flex items-center justify-center">
-            <Sparkles className="w-6 h-6 text-earth-500" />
+      <div className="flex-1 flex flex-col items-center justify-center px-5 py-4 gap-5">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="w-10 h-10 rounded-full bg-sand-100 flex items-center justify-center">
+            <Sparkles className="w-5 h-5 text-earth-500" />
           </div>
-          <div>
-            <h3 className="font-medium text-earth-700 mb-1">Trip Assistant</h3>
-            <p className="text-sm text-sand-500">
-              Ask me anything about your trip! I can help with recommendations,
-              scheduling, packing tips, and more.
-            </p>
-          </div>
+          <p className="text-sm text-sand-500 max-w-[260px]">
+            Ask me anything about your trip — recommendations, scheduling, packing tips, and more.
+          </p>
         </div>
+        {emptyStateSlot}
       </div>
     );
   }

--- a/src/components/trip/ai-assistant/PromptChips.tsx
+++ b/src/components/trip/ai-assistant/PromptChips.tsx
@@ -60,26 +60,23 @@ const getIcon = (iconName: string) => {
 
 const PromptChips: React.FC<PromptChipsProps> = ({ onSelect, disabled = false }) => {
   return (
-    <div className="px-4 py-3 border-b border-sand-100">
-      <p className="text-xs text-sand-500 mb-2">Quick prompts:</p>
-      <div className="flex flex-wrap gap-2">
-        {DEFAULT_PROMPTS.map((chip) => {
-          const Icon = getIcon(chip.icon || 'calendar');
-          return (
-            <Button
-              key={chip.id}
-              variant="outline"
-              size="sm"
-              onClick={() => onSelect(chip.prompt)}
-              disabled={disabled}
-              className="h-7 px-2.5 text-xs bg-white border-sand-200 text-earth-600 hover:bg-sand-50 hover:border-earth-300 hover:text-earth-700 rounded-full transition-colors"
-            >
-              <Icon className="w-3 h-3 mr-1.5" />
-              {chip.label}
-            </Button>
-          );
-        })}
-      </div>
+    <div className="flex flex-wrap justify-center gap-2 w-full">
+      {DEFAULT_PROMPTS.map((chip) => {
+        const Icon = getIcon(chip.icon || 'calendar');
+        return (
+          <Button
+            key={chip.id}
+            variant="outline"
+            size="sm"
+            onClick={() => onSelect(chip.prompt)}
+            disabled={disabled}
+            className="h-8 px-3 text-xs bg-white border-sand-200 text-earth-600 hover:bg-sand-50 hover:border-earth-300 hover:text-earth-700 rounded-full transition-colors"
+          >
+            <Icon className="w-3.5 h-3.5 mr-1.5" />
+            {chip.label}
+          </Button>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/trip/ai-assistant/UsageMeter.tsx
+++ b/src/components/trip/ai-assistant/UsageMeter.tsx
@@ -43,24 +43,12 @@ const UsageMeter: React.FC<UsageMeterProps> = ({ usage, onUpgradeClick }) => {
     );
   }
 
-  // Anonymous trial meter
+  // Anonymous trial meter - compact single row with inline progress
   if (isAnon) {
     return (
-      <div className="px-3 py-2 bg-sand-50 border-t border-sand-100">
-        <div className="flex items-center justify-between mb-1.5">
-          <div className="flex items-center gap-1.5">
-            <Zap className={cn('w-3.5 h-3.5', isLow ? 'text-amber-500' : 'text-sand-400')} />
-            <span className={cn(
-              'text-xs font-medium',
-              isExhausted ? 'text-red-600' : isLow ? 'text-amber-600' : 'text-earth-600'
-            )}>
-              {usage.used}/{usage.limit} trial messages
-            </span>
-          </div>
-        </div>
-
-        {/* Progress bar */}
-        <div className="h-1.5 bg-sand-200 rounded-full overflow-hidden">
+      <div className="px-3 py-1.5 bg-sand-50 border-t border-sand-100 flex items-center gap-2">
+        <Zap className={cn('w-3 h-3 flex-shrink-0', isLow ? 'text-amber-500' : 'text-sand-400')} />
+        <div className="h-1 bg-sand-200 rounded-full overflow-hidden flex-1 max-w-[100px]">
           <div
             className={cn(
               'h-full rounded-full transition-all duration-300',
@@ -69,18 +57,22 @@ const UsageMeter: React.FC<UsageMeterProps> = ({ usage, onUpgradeClick }) => {
             style={{ width: `${percentage}%` }}
           />
         </div>
-
-        {/* Sign up CTA */}
+        <span className={cn(
+          'text-[11px]',
+          isExhausted ? 'text-red-600' : isLow ? 'text-amber-600' : 'text-sand-500'
+        )}>
+          {usage.used}/{usage.limit} trial
+        </span>
         {onUpgradeClick && (
           <button
             onClick={onUpgradeClick}
             className={cn(
-              'mt-2 flex items-center gap-1 text-xs font-medium underline underline-offset-2',
+              'ml-auto text-[11px] font-medium flex items-center gap-1',
               isExhausted ? 'text-red-600 hover:text-red-700' : 'text-earth-500 hover:text-earth-600'
             )}
           >
             <UserPlus className="w-3 h-3" />
-            {isExhausted ? 'Sign up free to keep chatting' : 'Sign up free for more messages'}
+            <span className="underline underline-offset-2">Sign up free</span>
           </button>
         )}
       </div>
@@ -88,24 +80,9 @@ const UsageMeter: React.FC<UsageMeterProps> = ({ usage, onUpgradeClick }) => {
   }
 
   return (
-    <div className="px-3 py-2 bg-sand-50 border-t border-sand-100">
-      <div className="flex items-center justify-between mb-1.5">
-        <div className="flex items-center gap-1.5">
-          <Zap className={cn('w-3.5 h-3.5', isLow ? 'text-amber-500' : 'text-sand-400')} />
-          <span className={cn(
-            'text-xs font-medium',
-            isExhausted ? 'text-red-600' : isLow ? 'text-amber-600' : 'text-earth-600'
-          )}>
-            {usage.used}/{usage.limit} messages today
-          </span>
-        </div>
-        {formatResetTime() && (
-          <span className="text-xs text-sand-400">{formatResetTime()}</span>
-        )}
-      </div>
-
-      {/* Progress bar */}
-      <div className="h-1.5 bg-sand-200 rounded-full overflow-hidden">
+    <div className="px-3 py-1.5 bg-sand-50 border-t border-sand-100 flex items-center gap-2">
+      <Zap className={cn('w-3 h-3 flex-shrink-0', isLow ? 'text-amber-500' : 'text-sand-400')} />
+      <div className="h-1 bg-sand-200 rounded-full overflow-hidden flex-1 max-w-[100px]">
         <div
           className={cn(
             'h-full rounded-full transition-all duration-300',
@@ -114,17 +91,24 @@ const UsageMeter: React.FC<UsageMeterProps> = ({ usage, onUpgradeClick }) => {
           style={{ width: `${percentage}%` }}
         />
       </div>
-
-      {/* Upgrade CTA for low/exhausted users */}
+      <span className={cn(
+        'text-[11px]',
+        isExhausted ? 'text-red-600' : isLow ? 'text-amber-600' : 'text-sand-500'
+      )}>
+        {usage.used}/{usage.limit} today
+      </span>
+      {formatResetTime() && (
+        <span className="text-[11px] text-sand-400">{formatResetTime()}</span>
+      )}
       {isLow && onUpgradeClick && (
         <button
           onClick={onUpgradeClick}
           className={cn(
-            'mt-2 text-xs font-medium underline underline-offset-2',
+            'ml-auto text-[11px] font-medium underline underline-offset-2',
             isExhausted ? 'text-red-600 hover:text-red-700' : 'text-amber-600 hover:text-amber-700'
           )}
         >
-          {isExhausted ? 'Upgrade to continue chatting' : 'Upgrade for unlimited messages'}
+          {isExhausted ? 'Upgrade' : 'Go unlimited'}
         </button>
       )}
     </div>


### PR DESCRIPTION
- Merge empty state and prompt chips into one cohesive centered section
  instead of chips at top + separate empty state in middle
- Remove redundant "Trip Assistant" title from empty state (already in header)
- Compact header: smaller icon, remove subtitle, reduce padding
- Flatten usage meter to single inline row (progress bar + text + CTA)
- Reduce chat input padding for tighter bottom bar

https://claude.ai/code/session_01G3RbYV7oN2y1S7eNxp5VeB