### PR TITLE
fix: prevent timeline page from overflowing viewport width

### DIFF
--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -145,9 +145,9 @@ const TripDetails = () => {
   const sidebar = <Sidebar ref={sidebarRef} tripId={tripId} activeTab={activeTab} onTabChange={handleTabChange} />;
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen w-full overflow-x-hidden">
       {sidebar}
-      <main ref={mainRef} className="flex-1 pl-0 md:pl-[280px] transition-all duration-300">
+      <main ref={mainRef} className="flex-1 min-w-0 pl-0 md:pl-[280px] transition-all duration-300">
         <div className="min-h-screen flex flex-col">
 
           {/* Hero — renders fixed background + spacer */}


### PR DESCRIPTION
## Summary
- Adds `w-full overflow-x-hidden` on the TripDetails root flex container to prevent horizontal overflow
- Adds `min-w-0` on the `<main>` flex child so it can shrink below its content's intrinsic width, preventing wide children (hero image, AI panel, timeline cards) from pushing the layout beyond the viewport

## Test plan
- [ ] Open a trip's timeline view in Chrome on desktop
- [ ] Resize the browser window — content should stay within the visible width
- [ ] Verify sidebar, hero image, and timeline content all render correctly without horizontal scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)