### PR TITLE
Fix cookie banner padding on devices with safe area insets

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -23,7 +23,7 @@ export default function CookieConsentBanner() {
   };
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 md:p-6">
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 pb-[max(1rem,env(safe-area-inset-bottom,0px))] md:p-6">
       <Card className="mx-auto max-w-2xl bg-white/95 backdrop-blur-sm border-sand-200 shadow-warm-lg">
         <div className="p-4 md:p-5">
           {/* Main banner content */}


### PR DESCRIPTION
## Summary
Updated the CookieConsentBanner component to respect device safe area insets on mobile devices with notches or home indicators, ensuring the banner doesn't overlap with system UI elements.

## Key Changes
- Modified the bottom padding (`pb`) to use `max(1rem, env(safe-area-inset-bottom, 0px))` instead of the standard `p-4` padding
- This ensures the banner respects the device's safe area inset on notched devices while maintaining a minimum 1rem padding on devices without safe area requirements

## Implementation Details
The change uses CSS `env()` function to read the device's safe area inset value, with a fallback to 0px for devices that don't support it. The `max()` function ensures a minimum padding of 1rem is always applied, preventing the banner from being too close to the bottom edge on standard devices.

https://claude.ai/code/session_01MZ2yRSDDP6mQiMiG2wQHBN