### PR TITLE
Fix chat message scrolling behavior and container sizing

### DIFF
--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -40,13 +40,28 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
   const userScrolledUpRef = useRef<boolean>(false);
   const lastMessageCountRef = useRef<number>(0);
 
+  // Reliable scroll-to-bottom using scrollTop on the container
+  const scrollToBottom = useCallback((smooth = true) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (smooth) {
+      container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+    } else {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, []);
+
   // Scroll to bottom on initial load
   useEffect(() => {
-    if (messages.length > 0 && !hasInitialScrolled.current && scrollRef.current) {
-      scrollRef.current.scrollIntoView({ behavior: 'instant' });
-      hasInitialScrolled.current = true;
+    if (messages.length > 0 && !hasInitialScrolled.current && containerRef.current) {
+      // Use rAF to ensure DOM has laid out before scrolling
+      requestAnimationFrame(() => {
+        scrollToBottom(false);
+        hasInitialScrolled.current = true;
+      });
     }
-  }, [messages]);
+  }, [messages, scrollToBottom]);
 
   // Reset initial scroll flag when messages are cleared
   useEffect(() => {
@@ -71,26 +86,24 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
     if (!hasInitialScrolled.current) return;
     if (messages.length > lastMessageCountRef.current) {
       userScrolledUpRef.current = false;
-      if (scrollRef.current) {
-        scrollRef.current.scrollIntoView({ behavior: 'smooth' });
-      }
+      requestAnimationFrame(() => scrollToBottom(true));
     }
     lastMessageCountRef.current = messages.length;
-  }, [messages.length]);
+  }, [messages.length, scrollToBottom]);
 
   // Auto-scroll during streaming, but only if user hasn't scrolled up
   useEffect(() => {
     if (!hasInitialScrolled.current || !isStreaming) return;
     if (userScrolledUpRef.current) return;
 
-    if (scrollRef.current && containerRef.current) {
-      const container = containerRef.current;
-      const isNearBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight < 150;
+    const container = containerRef.current;
+    if (!container) return;
 
-      if (isNearBottom) {
-        scrollRef.current.scrollIntoView({ behavior: 'smooth' });
-      }
+    const isNearBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight < 150;
+
+    if (isNearBottom) {
+      container.scrollTop = container.scrollHeight;
     }
   }, [streamingContent, isStreaming]);
 

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -218,7 +218,11 @@ const TripDetails = () => {
                 </ErrorBoundary>
               )}
 
-              {activeTab === 'chat' && <AIAssistantPanel tripId={tripId || ''} />}
+              {activeTab === 'chat' && (
+                <div className="h-[calc(100dvh-12rem)] md:h-[calc(100dvh-10rem)]">
+                  <AIAssistantPanel tripId={tripId || ''} />
+                </div>
+              )}
               {activeTab === 'budget' && <BudgetView tripId={tripId} canEdit={canEdit} />}
               {activeTab === 'booking' && <BookingView tripId={tripId} canEdit={canEdit} />}
             </div>


### PR DESCRIPTION
## Summary
Refactored the chat message list scrolling mechanism to use direct `scrollTop` manipulation instead of `scrollIntoView()`, and added proper container height constraints to the AI Assistant panel.

## Key Changes
- **Improved scroll-to-bottom reliability**: Replaced `scrollRef.current.scrollIntoView()` calls with a new `scrollToBottom()` callback that directly manipulates `container.scrollTop`, providing more predictable behavior across different browsers and scenarios
- **Added requestAnimationFrame for scroll timing**: Wrapped initial scroll and new message scrolls with `requestAnimationFrame()` to ensure the DOM has laid out before attempting to scroll
- **Simplified streaming scroll logic**: Removed unnecessary ref checks and streamlined the near-bottom detection logic for auto-scrolling during streaming
- **Fixed AI Assistant panel sizing**: Added explicit height constraints (`h-[calc(100dvh-12rem)]` on mobile, `h-[calc(100dvh-10rem)]` on desktop) to the chat panel wrapper to prevent layout overflow issues

## Implementation Details
- The new `scrollToBottom()` callback supports both smooth and instant scrolling modes
- Scroll-to-bottom is now triggered via `requestAnimationFrame()` to ensure proper DOM layout before scrolling
- The streaming auto-scroll logic now directly checks container scroll position without relying on element references
- Container height uses `100dvh` (dynamic viewport height) to account for mobile browser UI changes

https://claude.ai/code/session_01MP1dwr1zS7zou79r3q4qBh