### PR TITLE
Prevent default auto-focus behavior in Dialog and Sheet components

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -30,11 +30,15 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, onOpenAutoFocus, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      onOpenAutoFocus={(e) => {
+        e.preventDefault();
+        onOpenAutoFocus?.(e);
+      }}
       className={cn(
         "fixed left-[50%] top-[50%] z-[250] flex flex-col w-[95vw] max-w-[95vw] sm:max-w-[600px] max-h-[90dvh] translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-warm-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -54,11 +54,15 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, onOpenAutoFocus, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
+      onOpenAutoFocus={(e) => {
+        e.preventDefault();
+        onOpenAutoFocus?.(e);
+      }}
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >


### PR DESCRIPTION
## Summary
This PR prevents the default auto-focus behavior in Dialog and Sheet components while allowing consumers to optionally provide their own `onOpenAutoFocus` handler.

## Key Changes
- **Dialog component**: Added `onOpenAutoFocus` prop handling that prevents default focus behavior and delegates to the provided callback
- **Sheet component**: Applied the same `onOpenAutoFocus` pattern for consistency across modal components
- Both components now intercept the `onOpenAutoFocus` event, call `preventDefault()`, and conditionally invoke any user-provided handler

## Implementation Details
The implementation uses a wrapper function that:
1. Prevents the default auto-focus behavior with `e.preventDefault()`
2. Optionally calls the consumer-provided `onOpenAutoFocus` handler if supplied
3. Maintains backward compatibility by making the callback optional with optional chaining (`onOpenAutoFocus?.()`)

This gives developers explicit control over focus management when opening dialogs and sheets, which is important for accessibility and UX customization.

https://claude.ai/code/session_0167Jc58pGMcqTbVpudFHSKs