### PR TITLE
Fix overflow behavior on TripDetails page layout

### DIFF
--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -145,7 +145,7 @@ const TripDetails = () => {
   const sidebar = <Sidebar ref={sidebarRef} tripId={tripId} activeTab={activeTab} onTabChange={handleTabChange} />;
 
   return (
-    <div className="flex min-h-screen w-full overflow-x-hidden">
+    <div className="flex min-h-screen w-full overflow-x-clip">
       {sidebar}
       <main ref={mainRef} className="flex-1 min-w-0 pl-0 md:pl-[280px] transition-all duration-300">
         <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
## Summary
Changed the overflow behavior on the TripDetails page container from `overflow-x-hidden` to `overflow-x-clip` to improve how horizontal overflow is handled.

## Changes
- Updated the main container's overflow-x class from `overflow-x-hidden` to `overflow-x-clip` in TripDetails component
  - `overflow-x-hidden`: hides overflow content but still allows scrolling
  - `overflow-x-clip`: clips overflow content at the padding edge without allowing scroll

## Details
This change affects how content that exceeds the horizontal bounds of the TripDetails container is handled. The `overflow-x-clip` approach provides more predictable clipping behavior at the element's padding edge, which may prevent unwanted scrollbar appearance or improve visual consistency with the sidebar and main content layout.

https://claude.ai/code/session_011jnuXDfd15QeQU96aLFg46