### PR TITLE
Filter MyTrips to exclude public trips

### DIFF
--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -55,6 +55,7 @@ const MyTrips = () => {
           .select(`*`)
           .eq('user_id', user.id)
           .eq('hidden', showHidden)
+          .eq('is_public', false)
           .order('arrival_date', { ascending: true });
 
         if (tripsError) {


### PR DESCRIPTION
## Summary
Updated the MyTrips page to filter out public trips from the user's trip list, ensuring only private trips are displayed.

## Key Changes
- Added `.eq('is_public', false)` filter to the trips query in MyTrips component
- This ensures that only private trips (where `is_public` is false) are returned alongside the existing `user_id` and `hidden` filters

## Implementation Details
The filter is applied at the database query level in the Supabase select statement, maintaining consistency with the existing filtering logic for user-specific trips and hidden trip visibility.

https://claude.ai/code/session_01NbxkWB9D5AZieugyuz4XbB