### PR TITLE
Remove unnecessary preventDefault calls in TripCard click handlers

### DIFF
--- a/src/components/trip/TripCard.tsx
+++ b/src/components/trip/TripCard.tsx
@@ -306,7 +306,6 @@ const TripCard = ({
                           variant="outline"
                           className="h-8 px-3"
                           onClick={(e) => {
-                            e.preventDefault();
                             e.stopPropagation();
                           }}
                         >
@@ -374,7 +373,6 @@ const TripCard = ({
                         size="icon"
                         className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-full h-8 w-8"
                         onClick={(e) => {
-                          e.preventDefault();
                           e.stopPropagation();
                         }}
                         aria-label="Leave shared trip"


### PR DESCRIPTION
## Summary
Removed redundant `e.preventDefault()` calls from two click event handlers in the TripCard component. Since these handlers only call `e.stopPropagation()`, the `preventDefault()` is unnecessary and has been cleaned up.

## Changes
- Removed `e.preventDefault()` from the outline button click handler (line 309)
- Removed `e.preventDefault()` from the leave trip icon button click handler (line 376)

## Details
Both click handlers were already calling `e.stopPropagation()` to prevent event bubbling. The `preventDefault()` calls were redundant since:
1. These are button elements that don't have default browser behaviors that need to be prevented
2. `stopPropagation()` alone is sufficient to prevent the click from triggering parent element handlers

This is a minor cleanup that reduces unnecessary code without changing functionality.

https://claude.ai/code/session_01LESpL25gCDBx1L26VbcqbP