### PR TITLE
GitHub-style travel activity chart + UI cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/google.maps": "^3.58.1",
         "@types/react-datepicker": "^6.2.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "axios": "",
         "body-parser": "^2.2.2",
         "bun": "^1.3.9",
         "class-variance-authority": "^0.7.1",
@@ -71,8 +72,10 @@
         "lucide-react": "^0.562.0",
         "nanoid": "^5.1.6",
         "next-themes": "^0.4.6",
+        "path-to-regexp": "",
         "pdfjs-dist": "^5.4.624",
         "pdfmake": "^0.2.23",
+        "posthog-js": "^1.364.2",
         "prismjs": "^1.30.0",
         "puppeteer": "^24.37.2",
         "react": "^19.2.4",
@@ -86,6 +89,7 @@
         "react-syntax-highlighter": "^16.1.0",
         "recharts": "^2.15.4",
         "remark-gfm": "^4.0.1",
+        "rollup": "",
         "sonner": "^1.7.4",
         "stripe": "^20.3.1",
         "tailwind-merge": "^3.4.0",
@@ -1724,6 +1728,252 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oven/bun-darwin-aarch64": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.9.tgz",
@@ -1866,6 +2116,82 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.24.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.6.tgz",
+      "integrity": "sha512-9WkcRKqmXSWIJcca6m3VwA9YbFd4HiG2hKEtDq6FcwEHlvfDhQQUZ5/sJZ47Fw8OtyNMHQ6rW4+COttk4Bg5NQ==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.364.7",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.364.7.tgz",
+      "integrity": "sha512-Rg6q4wSu8krrn8f3Nv44kGXjor4qh5iG0typt2sB7/SYQFRSbXYE2C46+qDMcBYGxmRMsWBitBcZ9x94DQCnfA==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.12.1",
@@ -3490,7 +3816,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -3503,7 +3828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -3516,7 +3840,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3529,7 +3852,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3542,7 +3864,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3555,7 +3876,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3568,7 +3888,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3581,7 +3900,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3594,7 +3912,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3607,7 +3924,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3620,7 +3936,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3633,7 +3948,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3646,7 +3960,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3659,7 +3972,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3672,7 +3984,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3685,7 +3996,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3698,7 +4008,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3711,7 +4020,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3724,7 +4032,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3737,7 +4044,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -3750,7 +4056,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -3763,7 +4068,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3776,7 +4080,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3789,7 +4092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3802,7 +4104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5933,6 +6234,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -7047,6 +7359,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8112,15 +8430,22 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -9834,6 +10159,37 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.364.7",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.364.7.tgz",
+      "integrity": "sha512-mjYUjim0PSNUjxbGR8MGl7hnbbJMCU+Dy4gRexMRGMRlZT9tskGzsgS4Q6Cvx+63lpkQg5kJrC4bHCuILnQ4/A==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.24.6",
+        "@posthog/types": "1.364.7",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9917,6 +10273,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -10047,6 +10427,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -10599,7 +10985,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12548,6 +12933,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "path-to-regexp": "",
     "pdfjs-dist": "^5.4.624",
     "pdfmake": "^0.2.23",
-    "picomatch": "",
     "posthog-js": "^1.364.2",
     "prismjs": "^1.30.0",
     "puppeteer": "^24.37.2",

--- a/src/components/trip/stats/MonthlyActivityChart.tsx
+++ b/src/components/trip/stats/MonthlyActivityChart.tsx
@@ -1,31 +1,144 @@
-import React from 'react';
-import { AreaChart, Area, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
+import React, { useMemo, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { format, getDay } from 'date-fns';
+import { Calendar } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-interface MonthlyActivityData {
-  month: string;
-  days: number;
-}
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
+import type { DailyActivity, DailyTripInfo } from '@/hooks/useTravelStats';
+import { DEFAULT_TRIP_IMAGE } from '@/constants/unsplash';
 
 interface MonthlyActivityChartProps {
-  data: MonthlyActivityData[];
+  data: DailyActivity[];
   className?: string;
-  height?: number;
-  showAxis?: boolean;
-  gradientId?: string;
+}
+
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+
+function TripMiniCard({ trip, onClick }: { trip: DailyTripInfo; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-start gap-2.5 w-full text-left rounded-lg hover:bg-sand-50 p-1.5 -m-1.5 transition-colors"
+    >
+      <img
+        src={trip.coverImageUrl || DEFAULT_TRIP_IMAGE}
+        alt={trip.destination}
+        className="w-10 h-10 rounded-md object-cover flex-shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-earth-800 truncate">{trip.destination}</p>
+        <div className="flex items-center gap-1 text-[11px] text-earth-500 mt-0.5">
+          <Calendar className="h-3 w-3 flex-shrink-0" />
+          <span>
+            {format(new Date(trip.arrivalDate + 'T00:00:00'), 'MMM d')} – {format(new Date(trip.departureDate + 'T00:00:00'), 'MMM d')}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
 }
 
 export function MonthlyActivityChart({
   data,
   className,
-  height = 80,
-  showAxis = true,
-  gradientId = 'travelGradient'
 }: MonthlyActivityChartProps) {
-  const hasData = data.some(d => d.days > 0);
+  const navigate = useNavigate();
 
-  if (!hasData) {
+  const { weeks, monthLabels, yearLabels, todayColIndex } = useMemo(() => {
+    if (!data || data.length === 0) {
+      return { weeks: [], monthLabels: [], yearLabels: [] };
+    }
+
+    const weeksArr: (DailyActivity | null)[][] = [];
+    let currentWeek: (DailyActivity | null)[] = [];
+
+    // Pad the first week so column 0 starts on Sunday
+    const firstDayOfWeek = getDay(data[0].date);
+    for (let i = 0; i < firstDayOfWeek; i++) {
+      currentWeek.push(null);
+    }
+
+    for (const day of data) {
+      currentWeek.push(day);
+      if (currentWeek.length === 7) {
+        weeksArr.push(currentWeek);
+        currentWeek = [];
+      }
+    }
+    if (currentWeek.length > 0) {
+      while (currentWeek.length < 7) currentWeek.push(null);
+      weeksArr.push(currentWeek);
+    }
+
+    // Month labels at the first week each month appears
+    const labels: { label: string; colIndex: number; endColIndex: number }[] = [];
+    let lastMonth = -1;
+    weeksArr.forEach((week, colIdx) => {
+      const firstDay = week.find(d => d !== null);
+      if (firstDay) {
+        const month = firstDay.date.getMonth();
+        if (month !== lastMonth) {
+          if (labels.length > 0) {
+            labels[labels.length - 1].endColIndex = colIdx - 1;
+          }
+          labels.push({ label: format(firstDay.date, 'MMM'), colIndex: colIdx, endColIndex: weeksArr.length - 1 });
+          lastMonth = month;
+        }
+      }
+    });
+
+    // Year labels — one per calendar year, positioned at the first week of that year
+    const yearLabelsArr: { year: string; colIndex: number; endColIndex: number }[] = [];
+    let lastYear = -1;
+    weeksArr.forEach((week, colIdx) => {
+      const firstDay = week.find(d => d !== null);
+      if (firstDay) {
+        const year = firstDay.date.getFullYear();
+        if (year !== lastYear) {
+          if (yearLabelsArr.length > 0) {
+            yearLabelsArr[yearLabelsArr.length - 1].endColIndex = colIdx - 1;
+          }
+          yearLabelsArr.push({ year: String(year), colIndex: colIdx, endColIndex: weeksArr.length - 1 });
+          lastYear = year;
+        }
+      }
+    });
+
+    // Find the column index for today
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    let todayCol = -1;
+    for (let colIdx = 0; colIdx < weeksArr.length; colIdx++) {
+      for (const day of weeksArr[colIdx]) {
+        if (day && day.date.getTime() === today.getTime()) {
+          todayCol = colIdx;
+          break;
+        }
+      }
+      if (todayCol >= 0) break;
+    }
+
+    return { weeks: weeksArr, monthLabels: labels, yearLabels: yearLabelsArr, todayColIndex: todayCol };
+  }, [data]);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const CELL_SIZE = 11;
+  const CELL_GAP = 2;
+  const LABEL_WIDTH = 28;
+  const totalCellSize = CELL_SIZE + CELL_GAP;
+
+  // Scroll to center today's column on mount
+  useEffect(() => {
+    if (scrollRef.current && todayColIndex >= 0) {
+      const todayX = LABEL_WIDTH + todayColIndex * totalCellSize;
+      const containerWidth = scrollRef.current.clientWidth;
+      scrollRef.current.scrollLeft = todayX - containerWidth / 2;
+    }
+  }, [todayColIndex, totalCellSize]);
+
+  if (!data || data.length === 0) {
     return (
       <motion.div
         initial={{ opacity: 0, y: 10 }}
@@ -37,10 +150,7 @@ export function MonthlyActivityChart({
         )}
       >
         <div className="text-xs font-medium text-earth-600 mb-2">Travel Activity</div>
-        <div
-          className="flex items-center justify-center text-earth-400 text-sm"
-          style={{ height }}
-        >
+        <div className="flex items-center justify-center text-earth-400 text-sm h-20">
           No travel data yet
         </div>
       </motion.div>
@@ -57,45 +167,144 @@ export function MonthlyActivityChart({
         className
       )}
     >
-      <div className="text-xs font-medium text-earth-600 mb-2">12-Month Travel Activity</div>
-      <ResponsiveContainer width="100%" height={height}>
-        <AreaChart data={data} margin={{ top: 5, right: 5, left: 5, bottom: showAxis ? 0 : 5 }}>
-          <defs>
-            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.4} />
-              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-            </linearGradient>
-          </defs>
-          {showAxis && (
-            <XAxis
-              dataKey="month"
-              axisLine={false}
-              tickLine={false}
-              tick={{ fontSize: 10, fill: '#6b7280' }}
-              interval="preserveStartEnd"
-            />
+      <div className="text-xs font-medium text-earth-600 mb-3">Travel Activity</div>
+      <div ref={scrollRef} className="overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {/* Year row — sticky labels */}
+        <div className="flex" style={{ width: LABEL_WIDTH + weeks.length * totalCellSize }}>
+          {/* Left padding to align with grid */}
+          <div style={{ minWidth: LABEL_WIDTH, width: LABEL_WIDTH }} className="flex-shrink-0" />
+          {yearLabels.map(({ year, colIndex, endColIndex }, idx) => {
+            const width = (endColIndex - colIndex + 1) * totalCellSize;
+            return (
+              <div
+                key={`year-${year}`}
+                className="flex-shrink-0 relative"
+                style={{ width }}
+              >
+                <div className="absolute bg-earth-200/60" style={{ left: 0, right: 0, bottom: 0, height: 1 }} />
+                <div className="sticky left-0 w-fit z-10 pb-1">
+                  <span className="text-[11px] font-semibold text-earth-500 leading-none bg-sand-50 pr-1.5">{year}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Month row — sticky labels */}
+        <div className="flex mb-1" style={{ width: LABEL_WIDTH + weeks.length * totalCellSize }}>
+          <div style={{ minWidth: LABEL_WIDTH, width: LABEL_WIDTH }} className="flex-shrink-0" />
+          {monthLabels.map(({ label, colIndex, endColIndex }) => {
+            const width = (endColIndex - colIndex + 1) * totalCellSize;
+            return (
+              <div
+                key={`month-${colIndex}`}
+                className="flex-shrink-0"
+                style={{ width }}
+              >
+                <div className="sticky left-0 w-fit z-10">
+                  <span className="text-[11px] text-earth-500 leading-none bg-sand-50 pr-1">{label}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          className="relative"
+          style={{
+            width: LABEL_WIDTH + weeks.length * totalCellSize,
+            height: 7 * totalCellSize,
+          }}
+        >
+          {/* Day labels */}
+          {DAY_LABELS.map((label, rowIdx) =>
+            label ? (
+              <span
+                key={`day-${rowIdx}`}
+                className="absolute text-[11px] text-earth-500 leading-none"
+                style={{
+                  left: 0,
+                  top: rowIdx * totalCellSize + CELL_SIZE - 3,
+                }}
+              >
+                {label}
+              </span>
+            ) : null
           )}
-          <Tooltip
-            contentStyle={{
-              backgroundColor: 'rgba(255, 255, 255, 0.95)',
-              border: '1px solid #e5e7eb',
-              borderRadius: '8px',
-              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-              padding: '8px 12px'
-            }}
-            labelStyle={{ fontWeight: 600, color: '#374151' }}
-            formatter={(value: number) => [`${value} day${value !== 1 ? 's' : ''}`, 'Travel']}
-          />
-          <Area
-            type="monotone"
-            dataKey="days"
-            stroke="#3b82f6"
-            strokeWidth={2}
-            fill={`url(#${gradientId})`}
-            animationDuration={1000}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+
+          {/* Grid cells */}
+          {weeks.map((week, colIdx) =>
+            week.map((day, rowIdx) => {
+              if (!day) return null;
+
+              const left = LABEL_WIDTH + colIdx * totalCellSize;
+              const top = rowIdx * totalCellSize;
+
+              const cell = (
+                <div
+                  className={cn(
+                    "absolute rounded-[2px] transition-colors",
+                    day.traveling
+                      ? 'bg-sunset-500 hover:bg-sunset-600'
+                      : 'bg-sand-200 hover:bg-sand-300'
+                  )}
+                  style={{
+                    left,
+                    top,
+                    width: CELL_SIZE,
+                    height: CELL_SIZE,
+                  }}
+                />
+              );
+
+              if (!day.traveling) {
+                return (
+                  <div key={`${colIdx}-${rowIdx}`} title={format(day.date, 'MMM d, yyyy')}>
+                    {cell}
+                  </div>
+                );
+              }
+
+              return (
+                <HoverCard key={`${colIdx}-${rowIdx}`} openDelay={150} closeDelay={100}>
+                  <HoverCardTrigger asChild>
+                    {cell}
+                  </HoverCardTrigger>
+                  <HoverCardContent
+                    side="top"
+                    align="center"
+                    className="w-56 p-3"
+                    sideOffset={6}
+                    collisionPadding={8}
+                    avoidCollisions
+                  >
+                    <p className="text-[11px] font-medium text-earth-500 mb-2">
+                      {format(day.date, 'EEEE, MMM d, yyyy')}
+                    </p>
+                    <div className="space-y-2">
+                      {day.trips.map((trip) => (
+                        <TripMiniCard
+                          key={trip.tripId}
+                          trip={trip}
+                          onClick={() => navigate(`/trip/${trip.tripId}`)}
+                        />
+                      ))}
+                    </div>
+                  </HoverCardContent>
+                </HoverCard>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center justify-end gap-1.5 mt-2 text-[11px] text-earth-500">
+        <span className="inline-block w-[11px] h-[11px] rounded-sm bg-sand-200" />
+        <span>No plans</span>
+        <span className="inline-block w-[11px] h-[11px] rounded-sm bg-sunset-500 ml-1.5" />
+        <span>Trip day</span>
+      </div>
     </motion.div>
   );
 }

--- a/src/components/trip/stats/TravelStatsCard.tsx
+++ b/src/components/trip/stats/TravelStatsCard.tsx
@@ -15,6 +15,7 @@ interface TravelStatsCardProps {
   chartData?: { completed: number; total: number };
   className?: string;
   compact?: boolean;
+  noBackground?: boolean;
   onClick?: () => void;
 }
 
@@ -61,6 +62,7 @@ export function TravelStatsCard({
   chartData,
   className,
   compact,
+  noBackground,
   onClick
 }: TravelStatsCardProps) {
   const colors = gradientClasses[gradient];
@@ -141,7 +143,7 @@ export function TravelStatsCard({
       className={cn(
         "rounded-xl border backdrop-blur-sm",
         compact ? "p-3" : "p-4",
-        colors.bg,
+        noBackground ? "border-sand-200/50 bg-transparent" : colors.bg,
         onClick && "cursor-pointer hover:scale-[1.02] transition-transform",
         className
       )}
@@ -150,9 +152,11 @@ export function TravelStatsCard({
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
-            <div className={cn("p-1.5 rounded-lg", colors.iconBg)}>
-              <Icon className={cn("h-4 w-4", colors.icon)} />
-            </div>
+            {!noBackground && (
+              <div className={cn("p-1.5 rounded-lg", colors.iconBg)}>
+                <Icon className={cn("h-4 w-4", colors.icon)} />
+              </div>
+            )}
             <span className="text-xs font-medium text-earth-600 truncate">{title}</span>
           </div>
           <div className={cn("font-black tracking-tight", compact ? "text-2xl" : "text-3xl md:text-4xl", colors.text)}>

--- a/src/hooks/useTravelStats.ts
+++ b/src/hooks/useTravelStats.ts
@@ -1,10 +1,24 @@
 import { useMemo } from 'react';
-import { differenceInDays, parseISO, format, subMonths, isWithinInterval, startOfMonth, endOfMonth } from 'date-fns';
+import { differenceInDays, parseISO, format, subMonths, subDays, addMonths, startOfMonth, endOfMonth, min as dateMin, max as dateMax } from 'date-fns';
 import { Trip } from '@/types/trip';
 
 interface MonthlyActivity {
   month: string;
   days: number;
+}
+
+export interface DailyTripInfo {
+  tripId: string;
+  destination: string;
+  arrivalDate: string;
+  departureDate: string;
+  coverImageUrl: string | null;
+}
+
+export interface DailyActivity {
+  date: Date;
+  traveling: boolean;
+  trips: DailyTripInfo[];
 }
 
 interface TravelStats {
@@ -13,6 +27,7 @@ interface TravelStats {
   activeTrips: number;
   upcomingTrips: number;
   monthlyActivity: MonthlyActivity[];
+  dailyActivity: DailyActivity[];
   completionRate: { completed: number; total: number };
   countriesVisited: number;
   longestTrip: { destination: string; days: number } | null;
@@ -63,6 +78,65 @@ function calculateDaysInMonth(trips: Trip[], monthDate: Date): number {
   return totalDays;
 }
 
+function buildDailyActivity(allTrips: Trip[]): DailyActivity[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const twelveMonthsAgo = subMonths(today, 12);
+  const twelveMonthsAhead = addMonths(today, 12);
+
+  // Find oldest trip start and latest trip end
+  let oldestTripDate = twelveMonthsAgo;
+  let latestTripDate = twelveMonthsAhead;
+
+  for (const trip of allTrips) {
+    if (trip.arrival_date) {
+      const d = parseISO(trip.arrival_date);
+      if (d < oldestTripDate) oldestTripDate = d;
+    }
+    if (trip.departure_date) {
+      const d = parseISO(trip.departure_date);
+      if (d > latestTripDate) latestTripDate = d;
+    }
+  }
+
+  // Min date: older of (oldest trip) or (12 months ago)
+  const minDate = dateMin([oldestTripDate, twelveMonthsAgo]);
+  // Max date: greater of (latest trip end) or (12 months ahead)
+  const maxDate = dateMax([latestTripDate, twelveMonthsAhead]);
+
+  minDate.setHours(0, 0, 0, 0);
+  maxDate.setHours(0, 0, 0, 0);
+
+  const totalDays = differenceInDays(maxDate, minDate);
+  const result: DailyActivity[] = [];
+
+  for (let i = 0; i <= totalDays; i++) {
+    const date = subDays(maxDate, totalDays - i);
+    date.setHours(0, 0, 0, 0);
+    const matchingTrips: DailyTripInfo[] = [];
+
+    for (const trip of allTrips) {
+      if (!trip.arrival_date || !trip.departure_date) continue;
+      const start = parseISO(trip.arrival_date);
+      const end = parseISO(trip.departure_date);
+      if (date >= start && date <= end) {
+        matchingTrips.push({
+          tripId: trip.trip_id,
+          destination: trip.destination,
+          arrivalDate: trip.arrival_date,
+          departureDate: trip.departure_date,
+          coverImageUrl: trip.cover_image_url,
+        });
+      }
+    }
+
+    result.push({ date, traveling: matchingTrips.length > 0, trips: matchingTrips });
+  }
+
+  return result;
+}
+
 export function useTravelStats(trips: Trip[]): TravelStats {
   return useMemo(() => {
     if (!trips || trips.length === 0) {
@@ -75,6 +149,7 @@ export function useTravelStats(trips: Trip[]): TravelStats {
           month: format(subMonths(new Date(), 11 - i), 'MMM'),
           days: 0
         })),
+        dailyActivity: buildDailyActivity([]),
         completionRate: { completed: 0, total: 0 },
         countriesVisited: 0,
         longestTrip: null
@@ -127,12 +202,16 @@ export function useTravelStats(trips: Trip[]): TravelStats {
       }
     });
 
+    // Build daily activity spanning all trips (past, current, and upcoming)
+    const dailyActivity = buildDailyActivity(trips);
+
     return {
       totalDaysTraveled,
       completedTrips: pastTrips.length,
       activeTrips: currentTrips.length,
       upcomingTrips: upcomingTrips.length,
       monthlyActivity,
+      dailyActivity,
       completionRate: {
         completed: pastTrips.length,
         total: pastTrips.length + currentTrips.length + upcomingTrips.length

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -17,6 +17,7 @@ import { useAuth } from "@/contexts/AuthContext";
 // Import hero and stats components from MyTrips
 import { NextTripBoardingPass, DefaultHeroCard } from '@/components/trip/hero';
 import { TravelStatsCard, MonthlyActivityChart } from '@/components/trip/stats';
+import { useTravelStats } from '@/hooks/useTravelStats';
 import { DEFAULT_TRIP_IMAGE } from '@/constants/unsplash';
 
 const Explore = () => {
@@ -136,42 +137,8 @@ const Explore = () => {
     return 'default';
   }, [currentTrips, nextTrip, daysUntilNextTrip]);
 
-  // Calculate simple stats for public trips
-  const travelStats = useMemo(() => {
-    const allTrips = publicTrips || [];
-    const completed = pastTrips.length;
-    const total = allTrips.length;
-
-    // Calculate total days traveled from past trips
-    let totalDays = 0;
-    pastTrips.forEach(trip => {
-      if (trip.arrival_date && trip.departure_date) {
-        const arrival = new Date(trip.arrival_date);
-        const departure = new Date(trip.departure_date);
-        totalDays += Math.max(0, differenceInDays(departure, arrival) + 1);
-      }
-    });
-
-    // Get unique destinations
-    const destinations = new Set(allTrips.map(t => t.destination?.split(',')[0]?.trim()).filter(Boolean));
-
-    // Monthly activity (simplified)
-    const monthlyActivity = Array.from({ length: 12 }, (_, i) => ({
-      month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][i],
-      trips: allTrips.filter(t => {
-        const date = new Date(t.arrival_date || '');
-        return date.getMonth() === i;
-      }).length
-    }));
-
-    return {
-      totalDaysTraveled: totalDays,
-      completedTrips: completed,
-      completionRate: { completed, total },
-      countriesVisited: destinations.size,
-      monthlyActivity
-    };
-  }, [publicTrips, pastTrips]);
+  // Calculate stats for public trips
+  const travelStats = useTravelStats(publicTrips || []);
 
   // Get last completed trip for background
   const lastCompletedTrip = useMemo(() => {
@@ -203,7 +170,7 @@ const Explore = () => {
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-sand-50 via-sand-50 to-earth-50">
       <Navigation />
-      <div className="container mx-auto px-4 pt-20 pb-8">
+      <div className="container mx-auto px-4 pt-12 md:pt-20 pb-8">
         {/* Dynamic Hero Section - Same as MyTrips */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -229,20 +196,21 @@ const Explore = () => {
             )}
 
             {/* Mobile: Swipeable Stats Row */}
-            <div className="-mx-4 px-4 overflow-x-auto mt-4">
-              <div className="flex gap-4 py-2 snap-x snap-mandatory
+            <div className="-mx-4 px-4 overflow-x-auto mt-3">
+              <div className="flex gap-3 py-1 snap-x snap-mandatory
                             [-ms-overflow-style:none] [scrollbar-width:none]
                             [&::-webkit-scrollbar]:hidden">
-                <div className="min-w-[200px] snap-start shrink-0">
+                <div className="min-w-[160px] snap-start shrink-0">
                   <TravelStatsCard
                     title="Days Traveling"
                     value={travelStats.totalDaysTraveled}
                     subtitle="Total days explored"
                     icon={Globe}
                     gradient="blue"
+                    compact
                   />
                 </div>
-                <div className="min-w-[200px] snap-start shrink-0">
+                <div className="min-w-[160px] snap-start shrink-0">
                   <TravelStatsCard
                     title="Trip Progress"
                     value={`${travelStats.completedTrips}/${travelStats.completionRate.total}`}
@@ -251,18 +219,25 @@ const Explore = () => {
                     gradient="green"
                     chart="donut"
                     chartData={travelStats.completionRate}
+                    compact
                   />
                 </div>
-                <div className="min-w-[200px] snap-start shrink-0">
+                <div className="min-w-[160px] snap-start shrink-0">
                   <TravelStatsCard
                     title="Destinations"
                     value={travelStats.countriesVisited}
                     subtitle="Places visited"
                     icon={MapPin}
                     gradient="purple"
+                    compact
                   />
                 </div>
               </div>
+            </div>
+
+            {/* Mobile: Full-width Activity Chart */}
+            <div className="mt-3">
+              <MonthlyActivityChart data={travelStats.dailyActivity} />
             </div>
           </div>
 
@@ -285,25 +260,29 @@ const Explore = () => {
               )}
             </div>
 
-            {/* STATS AREA - Spans 1 column */}
-            <div className="md:col-span-1 space-y-4">
-              <TravelStatsCard
-                title="Life on the Road"
-                value={travelStats.totalDaysTraveled}
-                subtitle="Days spent exploring"
-                icon={Globe}
-                gradient="blue"
-              />
-              <MonthlyActivityChart data={travelStats.monthlyActivity} />
-              <TravelStatsCard
-                title="Trip Progress"
-                value={`${travelStats.completedTrips}/${travelStats.completionRate.total}`}
-                subtitle="Trips completed"
-                icon={CheckCircle}
-                gradient="green"
-                chart="donut"
-                chartData={travelStats.completionRate}
-              />
+            {/* STATS AREA - Spans 1 column, stretches to match hero */}
+            <div className="md:col-span-1 flex flex-col gap-4">
+              <div className="grid grid-cols-2 gap-3">
+                <TravelStatsCard
+                  title="Life on the Road"
+                  value={travelStats.totalDaysTraveled}
+                  subtitle="Days spent exploring"
+                  icon={Globe}
+                  gradient="blue"
+                  noBackground
+                />
+                <TravelStatsCard
+                  title="Trip Progress"
+                  value={`${travelStats.completedTrips}/${travelStats.completionRate.total}`}
+                  subtitle="Trips completed"
+                  icon={CheckCircle}
+                  gradient="green"
+                  chart="donut"
+                  chartData={travelStats.completionRate}
+                  noBackground
+                />
+              </div>
+              <MonthlyActivityChart data={travelStats.dailyActivity} className="flex-1" />
             </div>
           </div>
         </motion.div>

--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -369,6 +369,11 @@ const MyTrips = () => {
                 </div>
               </div>
             </div>
+
+            {/* Mobile: Full-width Activity Chart */}
+            <div className="mt-3">
+              <MonthlyActivityChart data={travelStats.dailyActivity} />
+            </div>
           </div>
 
           {/* Desktop: Grid Layout */}
@@ -402,25 +407,29 @@ const MyTrips = () => {
               )}
             </div>
 
-            {/* STATS AREA - Spans 1 column */}
-            <div className="md:col-span-1 space-y-4">
-              <TravelStatsCard
-                title="Life on the Road"
-                value={travelStats.totalDaysTraveled}
-                subtitle="Days spent exploring"
-                icon={Globe}
-                gradient="blue"
-              />
-              <MonthlyActivityChart data={travelStats.monthlyActivity} />
-              <TravelStatsCard
-                title="Trip Progress"
-                value={`${travelStats.completedTrips}/${travelStats.completionRate.total}`}
-                subtitle="Trips completed"
-                icon={CheckCircle}
-                gradient="green"
-                chart="donut"
-                chartData={travelStats.completionRate}
-              />
+            {/* STATS AREA - Spans 1 column, stretches to match hero */}
+            <div className="md:col-span-1 flex flex-col gap-4">
+              <div className="grid grid-cols-2 gap-3">
+                <TravelStatsCard
+                  title="Life on the Road"
+                  value={travelStats.totalDaysTraveled}
+                  subtitle="Days spent exploring"
+                  icon={Globe}
+                  gradient="blue"
+                  noBackground
+                />
+                <TravelStatsCard
+                  title="Trip Progress"
+                  value={`${travelStats.completedTrips}/${travelStats.completionRate.total}`}
+                  subtitle="Trips completed"
+                  icon={CheckCircle}
+                  gradient="green"
+                  chart="donut"
+                  chartData={travelStats.completionRate}
+                  noBackground
+                />
+              </div>
+              <MonthlyActivityChart data={travelStats.dailyActivity} className="flex-1" />
             </div>
           </div>
         </motion.div>
@@ -432,28 +441,15 @@ const MyTrips = () => {
           transition={{ delay: 0.5, duration: 0.5 }}
           className="mb-8"
         >
-          <div className="flex flex-col sm:flex-row gap-4 items-center justify-between">
-            <div className="relative flex-1 max-w-md">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-              <Input
-                type="search"
-                placeholder="Search destinations, dates..."
-                className="pl-10 pr-4 py-3 bg-white border-earth-200 focus:border-earth-400 focus:ring-earth-400 rounded-xl shadow-sm"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            </div>
-            
-            <div className="flex gap-2">
-              <Button 
-                onClick={() => navigate('/create-trip')} 
-                className="bg-earth-600 hover:bg-earth-700 text-white px-6 py-3 rounded-xl shadow-sm flex items-center gap-2"
-              >
-                <Plus className="h-4 w-4" />
-                <span className="hidden sm:inline">Plan New Trip</span>
-                <span className="sm:hidden">New Trip</span>
-              </Button>
-            </div>
+          <div className="relative max-w-md">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+            <Input
+              type="search"
+              placeholder="Search destinations, dates..."
+              className="pl-10 pr-4 py-3 bg-white border-earth-200 focus:border-earth-400 focus:ring-earth-400 rounded-xl shadow-sm"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
           </div>
         </motion.div>
         
@@ -611,28 +607,15 @@ const MyTrips = () => {
                   ))}
                 </div>
               ) : (
-                <Card className="p-12 text-center bg-gradient-to-br from-sand-50 to-earth-50 border-sand-200">
-                  <div className="max-w-md mx-auto">
-                    <div className="bg-sand-200 rounded-full p-4 w-20 h-20 mx-auto mb-6">
-                      <MapPin className="h-12 w-12 text-earth-600 mx-auto" />
-                    </div>
-                    <h3 className="text-xl font-semibold text-earth-800 mb-3">
-                      {tripFilter === 'shared' ? 'No Shared Adventures Yet' : 'Your Next Adventure Awaits'}
-                    </h3>
-                    <p className="text-earth-600 mb-6">
-                      {tripFilter === 'shared'
-                        ? 'When someone shares a trip with you, it will appear here.'
-                        : "Ready to explore somewhere new? Let's plan your perfect getaway."}
-                    </p>
-                    {tripFilter !== 'shared' && (
-                      <Button
-                        onClick={() => navigate('/create-trip')}
-                        className="bg-primary hover:bg-primary/90 text-primary-foreground px-8 py-3 rounded-xl font-medium"
-                      >
-                        Plan Your Trip
-                      </Button>
-                    )}
-                  </div>
+                <Card className="p-6 text-center bg-gradient-to-br from-sand-50 to-earth-50 border-sand-200">
+                  <h3 className="text-lg font-semibold text-earth-800 mb-1">
+                    {tripFilter === 'shared' ? 'No Shared Adventures Yet' : 'Your Next Adventure Awaits'}
+                  </h3>
+                  <p className="text-sm text-earth-600">
+                    {tripFilter === 'shared'
+                      ? 'When someone shares a trip with you, it will appear here.'
+                      : "Ready to explore somewhere new? Let's plan your perfect getaway."}
+                  </p>
                 </Card>
               )}
             </motion.div>


### PR DESCRIPTION
## Summary
- Replace the Recharts area chart with a GitHub-style contribution grid showing daily travel activity across a dynamic date range
- Hover cards on travel days show mini trip cards with cover image, destination, and dates (clickable to navigate)
- Sticky year/month labels, auto-scroll to today, responsive on mobile
- Unify Explore page layout to be identical to My Trips (stats area, activity chart, spacing)
- Fix `picomatch` override conflict that blocked `npm install`
- Remove duplicate "Plan New Trip" CTA and compact the empty state

## Test plan
- [ ] Verify activity chart renders on My Trips with correct travel days highlighted
- [ ] Hover over a travel day cell and confirm mini trip card popover appears
- [ ] Click a mini trip card and confirm navigation to trip details
- [ ] Scroll horizontally and verify year/month labels stick properly
- [ ] Confirm chart auto-scrolls to center today's date on load
- [ ] Check Explore page matches My Trips layout exactly
- [ ] Test on mobile: activity chart renders full-width below stat cards
- [ ] Verify shared trips appear on the activity chart
- [ ] Confirm `npm install` succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)