### PR TITLE
Redesign trip creation wizard, fix admin escalation & image bugs

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -51,15 +51,6 @@ const BottomNavigation = ({ tripId, onQuickAddClick, onPeopleClick, onAIClick }:
           }}
         </NavLink>
 
-        {/* AI Chat */}
-        <button
-          onClick={onAIClick}
-          className="flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors text-sand-600 hover:text-earth-600"
-        >
-          <MessageCircle className="h-5 w-5" />
-          <span className="text-[10px]">AI Chat</span>
-        </button>
-
         {/* Center FAB */}
         <div className="flex items-center justify-center">
           <Button
@@ -71,6 +62,15 @@ const BottomNavigation = ({ tripId, onQuickAddClick, onPeopleClick, onAIClick }:
             <Plus className="h-6 w-6 text-white" />
           </Button>
         </div>
+
+        {/* AI Chat */}
+        <button
+          onClick={onAIClick}
+          className="flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors text-sand-600 hover:text-earth-600"
+        >
+          <MessageCircle className="h-5 w-5" />
+          <span className="text-[10px]">AI Chat</span>
+        </button>
 
         {/* Budget */}
         <NavLink

--- a/src/components/trip/HeroSection.tsx
+++ b/src/components/trip/HeroSection.tsx
@@ -346,9 +346,9 @@ const HeroSection: React.FC<HeroSectionProps> = ({
           }
         }}
       >
-        <DialogContent className="max-w-3xl max-h-[90dvh] overflow-y-auto">
+        <DialogContent className="max-w-3xl max-h-[90dvh]">
           <DialogTitle>Edit Trip Details</DialogTitle>
-          <div className="space-y-6 pt-2">
+          <div className="space-y-6 pt-2 overflow-y-auto flex-1 min-h-0 pr-1">
             {/* Trip Name */}
             <div className="space-y-3">
               <Label htmlFor="tripName" className="text-earth-700 font-semibold">
@@ -378,24 +378,24 @@ const HeroSection: React.FC<HeroSectionProps> = ({
               objectPosition={imagePosition}
               onPositionChange={handlePositionChange}
             />
+          </div>
 
-            {/* Action Buttons */}
-            <div className="flex justify-end gap-2 pt-4 border-t border-earth-100">
-              <Button
-                variant="ghost"
-                onClick={handleCloseDialog}
-                disabled={isSaving}
-              >
-                Cancel
-              </Button>
-              <Button
-                className="bg-earth-600 hover:bg-earth-700 text-white"
-                onClick={handleSaveChanges}
-                disabled={isSaving}
-              >
-                {isSaving ? 'Saving...' : 'Save Changes'}
-              </Button>
-            </div>
+          {/* Action Buttons — fixed at bottom, outside scroll area */}
+          <div className="flex justify-end gap-2 pt-4 border-t border-earth-100 shrink-0">
+            <Button
+              variant="ghost"
+              onClick={handleCloseDialog}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="bg-earth-600 hover:bg-earth-700 text-white"
+              onClick={handleSaveChanges}
+              disabled={isSaving}
+            >
+              {isSaving ? 'Saving...' : 'Save Changes'}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/components/trip/create/CreateTripForm.tsx
+++ b/src/components/trip/create/CreateTripForm.tsx
@@ -1,78 +1,95 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import ImageSection, { ImageMetadata } from "./ImageSection";
 import TimingSection from "./TimingSection";
 import DestinationInput from "./DestinationInput";
 import PrimaryDestinationInput from "./PrimaryDestinationInput";
-import FormActions from "./FormActions";
 import { supabase } from '@/integrations/supabase/client';
 import { generateDateArray } from '../../../utils/dateUtils';
 import { createTripDays } from '@/services/tripDaysService';
 import { addOwnerToTripShares } from '@/services/travelers';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, ArrowRight, MapPin, Pen, CalendarDays, Camera, Loader2 } from 'lucide-react';
 
 interface CreateTripFormProps {
-  destination: string;
-  setDestination: (value: string) => void;
-  startDate: string;
-  setStartDate: (value: string) => void;
-  endDate: string;
-  setEndDate: (value: string) => void;
-  coverImageUrl: string;
-  setCoverImageUrl: (value: string) => void;
-  isLoading: boolean;
   onSubmit: (tripId: string) => void;
   onCancel: () => void;
 }
 
-const CreateTripForm: React.FC<CreateTripFormProps> = ({
-  destination,
-  setDestination,
-  startDate,
-  setStartDate,
-  endDate,
-  setEndDate,
-  coverImageUrl,
-  setCoverImageUrl,
-  isLoading,
-  onSubmit,
-  onCancel
-}) => {
-  const [imagePosition, setImagePosition] = useState<string>("center 50%");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+const TOTAL_STEPS = 4;
+
+const stepConfig = [
+  { icon: MapPin, label: 'Destination' },
+  { icon: Pen, label: 'Name' },
+  { icon: CalendarDays, label: 'Dates' },
+  { icon: Camera, label: 'Photo' },
+];
+
+const CreateTripForm: React.FC<CreateTripFormProps> = ({ onSubmit, onCancel }) => {
+  const [step, setStep] = useState(0);
+  const [direction, setDirection] = useState(1); // 1 = forward, -1 = back
+
+  // Form state
+  const [tripName, setTripName] = useState('');
   const [primaryDestination, setPrimaryDestination] = useState('');
   const [primaryDestinationPlaceId, setPrimaryDestinationPlaceId] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [coverImageUrl, setCoverImageUrl] = useState('');
+  const [imagePosition, setImagePosition] = useState('center 50%');
   const [photographerName, setPhotographerName] = useState('');
   const [photographerUsername, setPhotographerUsername] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleImageChange = (url: string, metadata?: ImageMetadata) => {
+  const handlePrimaryDestinationChange = useCallback((destination: string, placeId: string) => {
+    setPrimaryDestination(destination);
+    setPrimaryDestinationPlaceId(placeId);
+  }, []);
+
+  const handleImageChange = useCallback((url: string, metadata?: ImageMetadata) => {
     setCoverImageUrl(url);
     setPhotographerName(metadata?.photographer || '');
     setPhotographerUsername(metadata?.username || '');
+  }, []);
+
+  const canProceed = (): boolean => {
+    switch (step) {
+      case 0: return primaryDestination.trim().length > 0;
+      case 1: return tripName.trim().length > 0;
+      case 2: return !!startDate && !!endDate && new Date(startDate) < new Date(endDate);
+      case 3: return true; // Photo is optional
+      default: return false;
+    }
   };
 
-  const handlePrimaryDestinationChange = (destination: string, placeId: string) => {
-    setPrimaryDestination(destination);
-    setPrimaryDestinationPlaceId(placeId);
+  const goNext = () => {
+    if (step < TOTAL_STEPS - 1) {
+      setDirection(1);
+      setStep(s => s + 1);
+    } else {
+      handleSubmit();
+    }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (isLoading || isSubmitting) return;
-
-    if (!destination.trim()) {
-      toast.error('Please enter a destination');
-      return;
+  const goBack = () => {
+    if (step > 0) {
+      setDirection(-1);
+      setStep(s => s - 1);
+    } else {
+      onCancel();
     }
-    if (!startDate || !endDate) {
-      toast.error('Please select travel dates');
-      return;
-    }
-    if (new Date(startDate) >= new Date(endDate)) {
-      toast.error('End date must be after start date');
-      return;
-    }
+  };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && canProceed() && !isSubmitting) {
+      e.preventDefault();
+      goNext();
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
     setIsSubmitting(true);
 
     try {
@@ -83,10 +100,10 @@ const CreateTripForm: React.FC<CreateTripFormProps> = ({
         .from('trips')
         .insert([{
           user_id: user.id,
-          destination,
+          destination: tripName,
           arrival_date: startDate,
           departure_date: endDate,
-          cover_image_url: coverImageUrl,
+          cover_image_url: coverImageUrl || null,
           cover_image_position: imagePosition || 'center 50%',
           cover_image_photographer: photographerName || null,
           cover_image_photographer_username: photographerUsername || null,
@@ -101,57 +118,204 @@ const CreateTripForm: React.FC<CreateTripFormProps> = ({
 
       if (trip) {
         await addOwnerToTripShares(trip.trip_id, user.id);
-
         const days = generateDateArray(startDate, endDate);
         await createTripDays(trip.trip_id, days);
-
         onSubmit(trip.trip_id);
       }
     } catch (error) {
       console.error('Error creating trip:', error);
-      toast.error('Failed to create trip. Please check your details and try again.');
+      toast.error('Failed to create trip. Please try again.');
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const variants = {
+    enter: (dir: number) => ({ x: dir > 0 ? 80 : -80, opacity: 0 }),
+    center: { x: 0, opacity: 1 },
+    exit: (dir: number) => ({ x: dir > 0 ? -80 : 80, opacity: 0 }),
+  };
+
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="space-y-2"
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' && (isLoading || isSubmitting)) {
-          e.preventDefault();
-        }
-      }}
-    >
-      <DestinationInput destination={destination} setDestination={setDestination} />
+    <div className="w-full" onKeyDown={handleKeyDown}>
+      {/* Progress dots */}
+      <div className="flex items-center justify-center gap-3 mb-8">
+        {stepConfig.map((s, i) => {
+          const Icon = s.icon;
+          const isActive = i === step;
+          const isCompleted = i < step;
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => {
+                if (i < step) {
+                  setDirection(i < step ? -1 : 1);
+                  setStep(i);
+                }
+              }}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-300 ${
+                isActive
+                  ? 'bg-earth-600 text-white shadow-warm-sm scale-105'
+                  : isCompleted
+                    ? 'bg-earth-100 text-earth-700 cursor-pointer hover:bg-earth-200'
+                    : 'bg-sand-100 text-sand-400 cursor-default'
+              }`}
+              disabled={i > step}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">{s.label}</span>
+            </button>
+          );
+        })}
+      </div>
 
-      <PrimaryDestinationInput
-        value={primaryDestination}
-        placeId={primaryDestinationPlaceId}
-        onChange={handlePrimaryDestinationChange}
-      />
+      {/* Step content */}
+      <div className="min-h-[280px] flex flex-col">
+        <AnimatePresence mode="wait" custom={direction}>
+          <motion.div
+            key={step}
+            custom={direction}
+            variants={variants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
+            className="flex-1"
+          >
+            {step === 0 && (
+              <div className="space-y-6">
+                <div className="text-center">
+                  <h2 className="text-2xl md:text-3xl font-display text-earth-900 mb-2">
+                    Where are you going?
+                  </h2>
+                  <p className="text-earth-500 text-sm">
+                    Search for a city or destination
+                  </p>
+                </div>
+                <PrimaryDestinationInput
+                  value={primaryDestination}
+                  placeId={primaryDestinationPlaceId}
+                  onChange={handlePrimaryDestinationChange}
+                  showLabel={false}
+                  autoFocus
+                  placeholder="e.g., Paris, Tokyo, Amalfi Coast..."
+                  inputClassName="text-center text-lg py-4"
+                />
+              </div>
+            )}
 
-      <TimingSection
-        startDate={startDate}
-        onStartDateChange={setStartDate}
-        endDate={endDate}
-        onEndDateChange={setEndDate}
-      />
+            {step === 1 && (
+              <div className="space-y-6">
+                <div className="text-center">
+                  <h2 className="text-2xl md:text-3xl font-display text-earth-900 mb-2">
+                    Name your trip
+                  </h2>
+                  <p className="text-earth-500 text-sm">
+                    Give it a name you'll remember
+                  </p>
+                </div>
+                <DestinationInput
+                  destination={tripName}
+                  setDestination={setTripName}
+                  hideLabel
+                  autoFocus
+                  placeholder={`e.g., Summer in ${primaryDestination.split(',')[0] || 'Paris'}`}
+                  inputClassName="text-center text-lg py-4"
+                />
+              </div>
+            )}
 
-      <ImageSection
-        coverImageUrl={coverImageUrl}
-        onImageChange={handleImageChange}
-        objectPosition={imagePosition}
-        onPositionChange={setImagePosition}
-      />
+            {step === 2 && (
+              <div className="space-y-6">
+                <div className="text-center">
+                  <h2 className="text-2xl md:text-3xl font-display text-earth-900 mb-2">
+                    When are you traveling?
+                  </h2>
+                  <p className="text-earth-500 text-sm">
+                    Select your departure and return dates
+                  </p>
+                </div>
+                <TimingSection
+                  startDate={startDate}
+                  onStartDateChange={setStartDate}
+                  endDate={endDate}
+                  onEndDateChange={setEndDate}
+                />
+              </div>
+            )}
 
-      <FormActions
-        isLoading={isLoading || isSubmitting}
-        onCancel={onCancel}
-      />
-    </form>
+            {step === 3 && (
+              <div className="space-y-6">
+                <div className="text-center">
+                  <h2 className="text-2xl md:text-3xl font-display text-earth-900 mb-2">
+                    Add a cover photo
+                  </h2>
+                  <p className="text-earth-500 text-sm">
+                    Optional — you can always add one later
+                  </p>
+                </div>
+                <ImageSection
+                  coverImageUrl={coverImageUrl}
+                  onImageChange={handleImageChange}
+                  objectPosition={imagePosition}
+                  onPositionChange={setImagePosition}
+                />
+              </div>
+            )}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between pt-6 mt-4 border-t border-sand-200">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={goBack}
+          disabled={isSubmitting}
+          className="text-earth-600 hover:text-earth-800 hover:bg-earth-50 gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {step === 0 ? 'Cancel' : 'Back'}
+        </Button>
+
+        <div className="flex items-center gap-3">
+          {step === TOTAL_STEPS - 1 && !coverImageUrl && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="text-earth-500 hover:text-earth-700"
+            >
+              Skip
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="sunset"
+            onClick={goNext}
+            disabled={!canProceed() || isSubmitting}
+            className="gap-2 px-6"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Creating...
+              </>
+            ) : step === TOTAL_STEPS - 1 ? (
+              'Create Trip'
+            ) : (
+              <>
+                Continue
+                <ArrowRight className="h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/trip/create/DestinationInput.tsx
+++ b/src/components/trip/create/DestinationInput.tsx
@@ -1,26 +1,41 @@
 import React from 'react';
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 interface DestinationInputProps {
   destination: string;
   setDestination: (value: string) => void;
+  hideLabel?: boolean;
+  autoFocus?: boolean;
+  placeholder?: string;
+  inputClassName?: string;
 }
 
 const DestinationInput: React.FC<DestinationInputProps> = ({
   destination,
-  setDestination
+  setDestination,
+  hideLabel,
+  autoFocus,
+  placeholder = "e.g., NYE in Paris",
+  inputClassName,
 }) => {
   return (
     <div className="space-y-3">
-      <Label htmlFor="destination" className="text-earth-700 font-semibold">Trip name<span className="text-red-500"> *</span></Label>
+      {!hideLabel && (
+        <Label htmlFor="destination" className="text-earth-700 font-semibold">Trip name<span className="text-red-500"> *</span></Label>
+      )}
       <Input
         id="destination"
-        placeholder="e.g., NYE in Paris"
+        placeholder={placeholder}
         value={destination}
         onChange={(e) => setDestination(e.target.value)}
         required
-        className="bg-white/70 border-earth-200 focus:border-earth-400 focus:ring-earth-400 rounded-xl py-3 px-4 shadow-sm"
+        autoFocus={autoFocus}
+        className={cn(
+          "bg-white/70 border-earth-200 focus:border-earth-400 focus:ring-earth-400 rounded-xl py-3 px-4 shadow-sm",
+          inputClassName
+        )}
       />
     </div>
   );

--- a/src/components/trip/create/ImageSection.tsx
+++ b/src/components/trip/create/ImageSection.tsx
@@ -84,21 +84,19 @@ const ImageSection: React.FC<ImageSectionProps> = ({
     supabase.functions.invoke('fetch-unsplash-metadata', { body: { photoId: hit.id } });
   };
 
-  // Handle image removal - only update local state, don't save empty URL
+  // Handle image removal - clear local state and notify parent
   const handleLocalRemove = () => {
     setLocalImageUrl('');
-    // Switch to upload tab so user can pick a new image
-    // (Unsplash tab with hideUploader=true won't show anything when empty)
+    onImageChange('');
     setTab('upload');
   };
 
-  // Handle new image from upload - this should save
+  // Handle new image from upload
   const handleUploadChange = (url: string) => {
+    setLocalImageUrl(url);
     if (url) {
-      setLocalImageUrl(url);
       onImageChange(url);
     }
-    // If url is empty (from remove), don't call onImageChange - let handleLocalRemove handle it
   };
 
   return (

--- a/src/components/trip/create/PrimaryDestinationInput.tsx
+++ b/src/components/trip/create/PrimaryDestinationInput.tsx
@@ -246,7 +246,7 @@ const PrimaryDestinationInput: React.FC<PrimaryDestinationInputProps> = ({
       {showLabel && (
         <Label className="text-earth-600 flex items-center gap-2">
           <MapPin className="h-4 w-4" />
-          Primary destination (optional)
+          Primary destination<span className="text-red-500"> *</span>
         </Label>
       )}
       <div className="relative" ref={containerRef}>

--- a/src/pages/CreateTrip.tsx
+++ b/src/pages/CreateTrip.tsx
@@ -1,20 +1,12 @@
-
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import CreateTripForm from '../components/trip/create/CreateTripForm';
 
 const CreateTrip = () => {
   const navigate = useNavigate();
-  const [destination, setDestination] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
-  const [coverImageUrl, setCoverImageUrl] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    // Track page view
     window.gtag('event', 'page_view', {
       page_title: 'Create Trip',
       page_location: window.location.href,
@@ -22,41 +14,20 @@ const CreateTrip = () => {
     });
   }, []);
 
-  const handleSubmit = async (tripId: string) => {
-    setIsLoading(true);
-    try {
-      // Track successful trip creation
-      window.gtag('event', 'trip_created', {
-        event_category: 'Trip',
-        event_label: destination,
-        value: 1
-      });
-      toast.success('Trip created successfully!');
-      navigate(`/trip/${tripId}`);
-    } catch (error) {
-      console.error('Error navigating to trip:', error);
-      toast.error('Failed to navigate to trip');
-    } finally {
-      setIsLoading(false);
-    }
+  const handleSubmit = (tripId: string) => {
+    window.gtag('event', 'trip_created', {
+      event_category: 'Trip',
+      event_label: 'New Trip',
+      value: 1
+    });
+    toast.success('Trip created successfully!');
+    navigate(`/trip/${tripId}`);
   };
-  
- 
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-sand-50 via-sand-50 to-earth-50 flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-xl bg-gradient-to-br from-sand-100 via-sand-50 to-earth-100 rounded-2xl shadow-warm-xl p-8 border border-sand-200">
-        <h1 className="text-3xl md:text-4xl font-bold text-center mb-2 text-earth-900">Plan Your Next Adventure</h1>
-        <p className="text-earth-600 text-center mb-8">Where will your journey take you?</p>
+      <div className="w-full max-w-xl bg-gradient-to-br from-sand-100 via-sand-50 to-earth-100 rounded-2xl shadow-warm-xl p-6 sm:p-8 border border-sand-200">
         <CreateTripForm
-          destination={destination}
-          setDestination={setDestination}
-          startDate={startDate}
-          setStartDate={setStartDate}
-          endDate={endDate}
-          setEndDate={setEndDate}
-          coverImageUrl={coverImageUrl}
-          setCoverImageUrl={setCoverImageUrl}
-          isLoading={isLoading}
           onSubmit={handleSubmit}
           onCancel={() => navigate('/my-trips')}
         />

--- a/supabase/migrations/20260405000000_fix_profiles_admin_escalation.sql
+++ b/supabase/migrations/20260405000000_fix_profiles_admin_escalation.sql
@@ -1,0 +1,14 @@
+-- Fix privilege escalation: prevent users from setting is_admin on their own profile
+-- The previous policy allowed any authenticated user to UPDATE any column on their
+-- own profile row, including is_admin. This adds a WITH CHECK constraint ensuring
+-- is_admin cannot be changed through normal user updates.
+
+DROP POLICY IF EXISTS "profiles_update_policy" ON profiles;
+
+CREATE POLICY "profiles_update_policy" ON profiles
+  FOR UPDATE TO authenticated
+  USING (id = auth.uid())
+  WITH CHECK (
+    id = auth.uid()
+    AND is_admin IS NOT DISTINCT FROM (SELECT p.is_admin FROM profiles p WHERE p.id = auth.uid())
+  );


### PR DESCRIPTION
## Summary
- **Trip creation redesigned** as a 4-step guided wizard (destination → name → dates → photo) with animated transitions via framer-motion, progress indicators, Enter key navigation, and a Skip option for the optional photo step
- **Security fix**: Patched RLS privilege escalation on `profiles` table — users could previously `UPDATE` their own `is_admin` flag to `true`. Migration applied to production.
- **Edit Trip Details fixes**: Image remove (X) button now properly clears the image and notifies the parent; Upload tab works correctly after removing an Unsplash image; dialog scroll fixed so close/action buttons stay pinned
- **Bottom nav**: Reordered to place the FAB in the center position

## Test plan
- [ ] Create a new trip — verify 4-step flow works end to end, with back/forward navigation and Enter key
- [ ] On step 4 (photo), verify Skip creates the trip without a photo
- [ ] Open an existing trip → Edit Trip Details → click X on cover image → verify it clears and you can upload a new one
- [ ] Verify the dialog close X button works and Save/Cancel buttons are visible when content is long
- [ ] Confirm admin check still works (only kevin@wanderluxe.io is admin)
- [ ] Verify bottom navigation FAB is centered on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)