### PR TITLE
fix: prevent realtime channel crash on Travelers panel

### DIFF
--- a/src/hooks/useInviteLinks.ts
+++ b/src/hooks/useInviteLinks.ts
@@ -1,6 +1,4 @@
-import { useEffect } from 'react';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
 import {
   getInviteLinks,
   createInviteLink,
@@ -9,6 +7,7 @@ import {
   deleteInviteLink,
 } from '@/services/inviteLinkService';
 import type { InviteLink } from '@/integrations/supabase/invite_link_types';
+import { useRealtimeSubscription } from '@/hooks/useRealtimeSubscription';
 
 export function useInviteLinks(tripId: string) {
   const queryClient = useQueryClient();
@@ -21,29 +20,14 @@ export function useInviteLinks(tripId: string) {
   });
 
   // Real-time subscription
-  useEffect(() => {
-    if (!tripId) return;
-
-    const channel = supabase
-      .channel(`invite-links:${tripId}`)
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'trip_invite_links',
-          filter: `trip_id=eq.${tripId}`,
-        },
-        () => {
-          queryClient.invalidateQueries({ queryKey });
-        }
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(channel);
-    };
-  }, [tripId, queryClient]);
+  useRealtimeSubscription({
+    channelKey: `invite-links:${tripId}`,
+    tables: [
+      { table: 'trip_invite_links', filterColumn: 'trip_id', filterValue: tripId },
+    ],
+    invalidateKeys: [queryKey],
+    enabled: !!tripId,
+  });
 
   const createMutation = useMutation({
     mutationFn: ({


### PR DESCRIPTION
## Summary
- Replace raw `supabase.channel()` in `useInviteLinks` with the shared `useRealtimeSubscription` hook
- Fixes `cannot add postgres_changes callbacks after subscribe()` crash when opening the Travelers panel
- The shared hook has built-in dedup that prevents duplicate channel registration across re-renders

## Test plan
- [ ] Open a trip and click Travelers — no console error about `postgres_changes` callbacks
- [ ] Invite link real-time updates still work (create/delete a link and verify UI updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)