### PR TITLE
Hide drag handle on mobile timeline events

### DIFF
--- a/src/components/trip/day/components/SortableTimelineRow.tsx
+++ b/src/components/trip/day/components/SortableTimelineRow.tsx
@@ -49,7 +49,7 @@ const SortableTimelineRow: React.FC<Props> = (props) => {
         {...listeners}
         className={cn(
           "absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1 z-20 p-1 rounded cursor-grab active:cursor-grabbing",
-          "sm:opacity-0 sm:group-hover:opacity-100 transition-opacity",
+          "hidden sm:block sm:opacity-0 sm:group-hover:opacity-100 transition-opacity",
           "text-earth-400 hover:text-earth-600"
         )}
       >


### PR DESCRIPTION
The GripVertical drag indicator was always visible on mobile where
drag-and-drop isn't useful. Now hidden on mobile, shown on hover
on desktop only.

https://claude.ai/code/session_011ps3MzmTp2LYbyY3mi6bBv