### PR TITLE
Fix: redirect unauthenticated users back to shared trip after login

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   const { session } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -19,12 +20,14 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
     const timer = setTimeout(() => {
       if (!session) {
         setIsAuthenticated(false);
+        // Save the current URL so the user returns here after login
+        sessionStorage.setItem('pendingRedirect', location.pathname);
         navigate("/auth", { replace: true }); // Replace history entry to prevent back navigation loop
       }
     }, 1000); // 1 second grace period
 
     return () => clearTimeout(timer);
-  }, [session, navigate]);
+  }, [session, navigate, location.pathname]);
 
   // Initial loading state
   if (isAuthenticated === null) {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -26,9 +26,14 @@ const Auth = () => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session) {
         const pendingCode = sessionStorage.getItem('pendingInviteCode');
+        const pendingRedirect = sessionStorage.getItem('pendingRedirect');
         if (pendingCode && isValidInviteCode(pendingCode)) {
           sessionStorage.removeItem('pendingInviteCode');
+          sessionStorage.removeItem('pendingRedirect');
           navigate(`/invite/${pendingCode}`, { replace: true });
+        } else if (pendingRedirect && pendingRedirect.startsWith('/')) {
+          sessionStorage.removeItem('pendingRedirect');
+          navigate(pendingRedirect, { replace: true });
         } else {
           navigate("/");
         }
@@ -38,9 +43,15 @@ const Auth = () => {
 
   const navigateAfterAuth = (delay = 0) => {
     const pendingCode = sessionStorage.getItem('pendingInviteCode');
+    const pendingRedirect = sessionStorage.getItem('pendingRedirect');
     if (pendingCode && isValidInviteCode(pendingCode)) {
       sessionStorage.removeItem('pendingInviteCode');
+      sessionStorage.removeItem('pendingRedirect');
       const go = () => navigate(`/invite/${pendingCode}`, { replace: true });
+      delay ? setTimeout(go, delay) : go();
+    } else if (pendingRedirect && pendingRedirect.startsWith('/')) {
+      sessionStorage.removeItem('pendingRedirect');
+      const go = () => navigate(pendingRedirect, { replace: true });
       delay ? setTimeout(go, delay) : go();
     } else {
       const go = () => navigate("/my-trips");
@@ -113,11 +124,18 @@ const Auth = () => {
   const handleGoogleSignIn = async () => {
     try {
       const pendingCode = sessionStorage.getItem('pendingInviteCode');
-      const redirectUrl = (pendingCode && isValidInviteCode(pendingCode))
-        ? `${window.location.origin}/invite/${pendingCode}`
-        : `${window.location.origin}/my-trips`;
-      // Clear code here since OAuth redirects away from the page
-      if (pendingCode) sessionStorage.removeItem('pendingInviteCode');
+      const pendingRedirect = sessionStorage.getItem('pendingRedirect');
+      let redirectUrl: string;
+      if (pendingCode && isValidInviteCode(pendingCode)) {
+        redirectUrl = `${window.location.origin}/invite/${pendingCode}`;
+      } else if (pendingRedirect && pendingRedirect.startsWith('/')) {
+        redirectUrl = `${window.location.origin}${pendingRedirect}`;
+      } else {
+        redirectUrl = `${window.location.origin}/my-trips`;
+      }
+      // Clear stored values since OAuth redirects away from the page
+      sessionStorage.removeItem('pendingInviteCode');
+      sessionStorage.removeItem('pendingRedirect');
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -128,7 +128,10 @@ const TripDetails = () => {
               Go Back
             </Button>
             {!session && (
-              <Button onClick={() => navigate('/auth')} className="bg-earth-600 hover:bg-earth-700 text-white">
+              <Button onClick={() => {
+                sessionStorage.setItem('pendingRedirect', window.location.pathname);
+                navigate('/auth');
+              }} className="bg-earth-600 hover:bg-earth-700 text-white">
                 Sign In
               </Button>
             )}


### PR DESCRIPTION
When a user clicks a shared trip link from email without being logged in,
they were redirected to /auth but lost the trip URL. After login they'd
land on /my-trips instead of the trip they were trying to view.

Now saves the intended URL in sessionStorage as pendingRedirect before
redirecting to auth, and restores it after login (email/password and
Google OAuth). Also applies to ProtectedRoute for any protected page.

https://claude.ai/code/session_01Amcxy4XUM8ayHqvtjwVSXg