### PR TITLE
Fix AI chat response formatting: numbered lists and malformed markdown

### DIFF
--- a/src/components/trip/ai-assistant/ChatMessage.tsx
+++ b/src/components/trip/ai-assistant/ChatMessage.tsx
@@ -10,14 +10,24 @@ import ExtractionResultMessage from './ExtractionResultMessage';
 import type { AIChatMessage, ExtractedItem } from '@/types/ai-assistant';
 
 /**
- * Fixes common malformed markdown links from AI responses.
- * Examples of issues fixed:
+ * Fixes common malformed markdown from AI responses.
+ * Handles:
  *  - **Name](url)** → **[Name](url)**  (missing opening bracket)
  *  - [Name](url  → [Name](url)         (missing closing paren)
  *  - [Name](httpexample.com) → [Name](https://example.com)  (missing protocol separator)
+ *  - Numbered list items not separated by newlines
+ *  - Orphaned bold markers around links
  */
 function sanitizeMarkdownLinks(content: string): string {
   let result = content;
+
+  // --- Normalize numbered lists ---
+  // Ensure each numbered item (e.g., "1.", "2.") starts on its own line.
+  // This handles AI responses that squash list items into a single paragraph.
+  // Only match digits followed by a period+space that are NOT already at line start.
+  result = result.replaceAll(/([^\n])(\s)(\d+)\.\s/g, '$1\n\n$3. ');
+
+  // --- Fix malformed markdown links ---
 
   // Fix: **Text](url)** — missing opening bracket, closing ** present
   result = result.replaceAll(/\*\*([^[*\n]+?)\]\(([^)]+)\)\*\*/g, '**[$1]($2)**');
@@ -40,6 +50,12 @@ function sanitizeMarkdownLinks(content: string): string {
   // Fix: URLs missing :// after http/https (e.g., httpexample.com → https://example.com)
   result = result.replaceAll(/\]\(http([^s:])/g, '](https://$1');
   result = result.replaceAll(/\]\(https([^:])/g, '](https://$1');
+
+  // Fix: **[Name](url) without closing ** — bold opened but never closed before line end
+  result = result.replaceAll(/\*\*(\[[^\]]+\]\([^)]+\))(?!\*)\s*(?=\n|–|—|-)/g, '**$1**');
+
+  // Fix: [Name](url)** — closing bold without opening bold
+  result = result.replaceAll(/(?<!\*)(\[[^\]]+\]\([^)]+\))\*\*/g, '**$1**');
 
   return result;
 }

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -337,7 +337,8 @@ ${formattedTransportation}
 
 Guidelines:
 - Be concise and helpful
-- Use markdown formatting for readability
+- Use markdown formatting for readability. IMPORTANT: When writing numbered lists, put each item on its own line with a blank line between items for proper rendering
+- When listing multiple recommendations, use a numbered markdown list with each item separated by a blank line
 - When recommending hotels or attractions, make the name a clickable link using Google Maps or Google Search URLs
 - For restaurants, use the Restaurant Booking Links workflow below — you may use direct booking URLs (Resy, OpenTable, etc.) when found via search
 - IMPORTANT for non-restaurant places: Only use Google Maps or Google Search URL formats (never IP addresses or made-up URLs):


### PR DESCRIPTION
The AI assistant responses were rendering poorly because:
1. Numbered list items ran together as a single paragraph instead of
   rendering as a proper list - added regex to inject line breaks before
   numbered items that aren't already at line start
2. Bold/link markdown patterns had edge cases the sanitizer didn't catch -
   added fixes for unclosed bold markers and orphaned closing bold markers
3. Updated the system prompt to explicitly instruct the AI to put each
   numbered list item on its own line with blank line separation

https://claude.ai/code/session_01BtH8X76nLUtPQyzdcaTFX5