### PR TITLE
Fix AI chat response formatting

### DIFF
--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,7 +1,24 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-import { getCorsHeaders } from '../_shared/cors.ts';
+// Inlined from _shared/cors.ts to support single-function deployment
+const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') ?? 'https://wanderluxe.io';
+const ALLOWED_ORIGIN_PATTERNS = [
+  /\.replit\.dev(:\d+)?$/,
+  /\.repl\.co(:\d+)?$/,
+  /\.replit\.app(:\d+)?$/,
+];
+function getCorsHeaders(origin: string | null): Record<string, string> {
+  let allowOrigin = ALLOWED_ORIGIN;
+  if (origin && ALLOWED_ORIGIN_PATTERNS.some(p => p.test(origin))) {
+    allowOrigin = origin;
+  }
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, GET, DELETE, OPTIONS',
+  };
+}
 
 type SupabaseClient = ReturnType<typeof createClient>;
 


### PR DESCRIPTION
## Summary

- **Fix numbered lists running together** — AI responses with numbered recommendations (e.g., "1. Place A 2. Place B") were rendering as a single paragraph. Added regex sanitization to inject line breaks before numbered items that aren't already at line start.
- **Fix malformed bold/link markdown** — Added handling for unclosed bold markers (`**[Name](url)` missing closing `**`) and orphaned closing bold markers (`[Name](url)**` missing opening `**`) that caused raw `**` to leak into rendered text.
- **Improve system prompt** — Updated AI instructions to explicitly request blank lines between numbered list items, reducing malformed output at the source.
- **Inline CORS helper** — Moved `_shared/cors.ts` inline into the edge function to fix deployment bundler error ("Module not found").

## Test plan

- [ ] Send a chat message asking for recommendations (e.g., "paint and sip options in Raleigh") and verify the response renders as a properly formatted numbered list
- [ ] Verify bold text and links render correctly without raw `**` markers showing
- [ ] Verify the ai-chat edge function deploys successfully
- [ ] Verify existing chat functionality (streaming, copy button, timestamps) still works

https://claude.ai/code/session_01BtH8X76nLUtPQyzdcaTFX5