### PR TITLE
Fix authenticated AI chat by routing through Express server instead of edge function

### DIFF
--- a/server/routes/ai-chat.ts
+++ b/server/routes/ai-chat.ts
@@ -735,19 +735,31 @@ router.get('/api/trips/:tripId/assistant/messages', async (req: Request, res: Re
       .single();
 
     if (!thread) {
-      return res.json({ messages: [], thread_id: null });
+      return res.json({ messages: [], thread_id: null, hasMore: false });
     }
 
-    // Get messages
+    // Support pagination
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+    const offset = parseInt(req.query.offset as string) || 0;
+
+    // Get total count for hasMore
+    const { count } = await supabase
+      .from('ai_chat_messages')
+      .select('id', { count: 'exact', head: true })
+      .eq('thread_id', thread.id);
+
+    // Get messages with pagination (newest first for offset, then reverse)
     const { data: messages } = await supabase
       .from('ai_chat_messages')
       .select('id, role, content, metadata, created_at')
       .eq('thread_id', thread.id)
-      .order('created_at', { ascending: true });
+      .order('created_at', { ascending: true })
+      .range(offset, offset + limit - 1);
 
     return res.json({
       messages: messages || [],
-      thread_id: thread.id
+      thread_id: thread.id,
+      hasMore: (count || 0) > offset + limit
     });
   } catch (error) {
     console.error('Error getting messages:', error);

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -14,8 +14,7 @@ import type {
   ExtractedItem
 } from '@/types/ai-assistant';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || '';
-const EDGE_FUNCTION_BASE = `${SUPABASE_URL}/functions/v1/ai-chat`;
+const EXPRESS_BASE = '/api/trips';
 
 const ANON_STORAGE_KEY = 'anon-ai-count';
 const ANON_MESSAGE_LIMIT = 5;
@@ -232,7 +231,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
         return { messages: [], thread_id: null, hasMore: false };
       }
 
-      const response = await fetch(`${EDGE_FUNCTION_BASE}/${tripId}/messages?limit=${PAGE_SIZE}&offset=0`, {
+      const response = await fetch(`${EXPRESS_BASE}/${tripId}/assistant/messages`, {
         headers: {
           'Authorization': `Bearer ${token}`
         }
@@ -263,7 +262,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
       const offset = currentMessages.length;
 
       const response = await fetch(
-        `${EDGE_FUNCTION_BASE}/${tripId}/messages?limit=${PAGE_SIZE}&offset=${offset}`,
+        `${EXPRESS_BASE}/${tripId}/assistant/messages?limit=${PAGE_SIZE}&offset=${offset}`,
         {
           headers: {
             'Authorization': `Bearer ${token}`
@@ -308,7 +307,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
         return { used, limit: ANON_MESSAGE_LIMIT, tier: 'anon', resetAt: '' };
       }
 
-      const response = await fetch(`${EDGE_FUNCTION_BASE}/${tripId}/usage`, {
+      const response = await fetch(`${EXPRESS_BASE}/${tripId}/assistant/usage`, {
         headers: {
           'Authorization': `Bearer ${token}`
         }
@@ -506,7 +505,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
     };
 
     try {
-      await fetchEventSource(`${EDGE_FUNCTION_BASE}/${tripId}`, {
+      await fetchEventSource(`${EXPRESS_BASE}/${tripId}/assistant`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -581,7 +580,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
     if (!token) return;
 
     try {
-      const response = await fetch(`${EDGE_FUNCTION_BASE}/${tripId}/messages`, {
+      const response = await fetch(`${EXPRESS_BASE}/${tripId}/assistant/messages`, {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${token}`

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -213,7 +213,7 @@ async function callOpenAI(messages: OpenAIMessage[], stream: boolean, options: O
     messages,
     stream,
     temperature: 0.7,
-    max_tokens: 1500
+    max_completion_tokens: 1500
   };
   if (options.tools && !options.skipTools) {
     body.tools = options.tools;


### PR DESCRIPTION
The authenticated chat path was calling the Supabase Edge Function directly,
which broke after max_completion_tokens was changed to max_tokens. Route all
authenticated requests through the Express server (same origin, correct OpenAI
params) and add pagination support to the messages endpoint.

https://claude.ai/code/session_01NAXQpcGr6RiLVtphpCtNzG