### PR TITLE
Fix AI chat URLs by routing places through Google Places and validating links

### DIFF
--- a/src/components/trip/ai-assistant/ChatMessage.tsx
+++ b/src/components/trip/ai-assistant/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { Components } from 'react-markdown';
 import { cn } from '@/lib/utils';
 import { Copy, Check, Sparkles, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -9,6 +10,63 @@ import remarkGfm from 'remark-gfm';
 import ExtractionResultMessage from './ExtractionResultMessage';
 import { normalizeMarkdownListSpacing, safeHref } from './chatUrlSafety';
 import type { AIChatMessage, ExtractedItem } from '@/types/ai-assistant';
+
+// Defined at module scope so the component functions aren't recreated on
+// every ChatMessage render. safeHref() runs at render time on every link to
+// strip AI-authored URLs that don't pass validation (see chatUrlSafety.ts).
+const markdownComponents: Components = {
+  a: ({ href, children, ...props }) => (
+    <a
+      {...props}
+      href={safeHref(typeof href === 'string' ? href : '', typeof children === 'string' ? children : '')}
+      className="text-earth-600 underline hover:text-earth-800 break-all"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  ),
+  code: ({ className, children, ...props }) => {
+    const isInline = !className;
+    return isInline ? (
+      <code
+        className="bg-sand-100 px-1 py-0.5 rounded text-earth-700 text-xs break-all"
+        {...props}
+      >
+        {children}
+      </code>
+    ) : (
+      <code className={cn(className, 'text-xs')} {...props}>
+        {children}
+      </code>
+    );
+  },
+  pre: ({ ...props }) => (
+    <pre className="overflow-x-auto max-w-full" {...props} />
+  ),
+  ul: ({ ...props }) => (
+    <ul className="list-disc pl-4 space-y-1" {...props} />
+  ),
+  ol: ({ ...props }) => (
+    <ol className="list-decimal pl-4 space-y-1" {...props} />
+  ),
+  p: ({ ...props }) => (
+    <p className="mb-2 last:mb-0" {...props} />
+  ),
+  table: ({ ...props }) => (
+    <div className="overflow-x-auto max-w-full">
+      <table className="min-w-0" {...props} />
+    </div>
+  ),
+  thead: ({ ...props }) => (
+    <thead className="border-b border-sand-200" {...props} />
+  ),
+  th: ({ ...props }) => (
+    <th className="text-left text-xs font-semibold text-earth-700 px-2 py-1" {...props} />
+  ),
+};
+
+const markdownRemarkPlugins = [remarkGfm];
 
 interface ChatMessageProps {
   message: AIChatMessage;
@@ -140,67 +198,8 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
           >
             <div className="prose prose-sm prose-earth max-w-full break-words overflow-wrap-anywhere">
               <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={{
-                  // Customize link styling. safeHref() validates the URL
-                  // and swaps anything that isn't trustworthy with a Google
-                  // Search fallback, so users can never click a hallucinated
-                  // booking link that 404s.
-                  a: ({ href, children, ...props }) => (
-                    <a
-                      {...props}
-                      href={safeHref(typeof href === 'string' ? href : '', typeof children === 'string' ? children : '')}
-                      className="text-earth-600 underline hover:text-earth-800 break-all"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {children}
-                    </a>
-                  ),
-                  // Customize code blocks
-                  code: ({ className, children, ...props }) => {
-                    const isInline = !className;
-                    return isInline ? (
-                      <code
-                        className="bg-sand-100 px-1 py-0.5 rounded text-earth-700 text-xs break-all"
-                        {...props}
-                      >
-                        {children}
-                      </code>
-                    ) : (
-                      <code className={cn(className, 'text-xs')} {...props}>
-                        {children}
-                      </code>
-                    );
-                  },
-                  // Customize pre blocks (code blocks)
-                  pre: ({ ...props }) => (
-                    <pre className="overflow-x-auto max-w-full" {...props} />
-                  ),
-                  // Customize lists
-                  ul: ({ ...props }) => (
-                    <ul className="list-disc pl-4 space-y-1" {...props} />
-                  ),
-                  ol: ({ ...props }) => (
-                    <ol className="list-decimal pl-4 space-y-1" {...props} />
-                  ),
-                  // Customize paragraphs
-                  p: ({ ...props }) => (
-                    <p className="mb-2 last:mb-0" {...props} />
-                  ),
-                  // Customize tables
-                  table: ({ ...props }) => (
-                    <div className="overflow-x-auto max-w-full">
-                      <table className="min-w-0" {...props} />
-                    </div>
-                  ),
-                  thead: ({ ...props }) => (
-                    <thead className="border-b border-sand-200" {...props} />
-                  ),
-                  th: ({ ...props }) => (
-                    <th className="text-left text-xs font-semibold text-earth-700 px-2 py-1" {...props} />
-                  )
-                }}
+                remarkPlugins={markdownRemarkPlugins}
+                components={markdownComponents}
               >
                 {normalizeMarkdownListSpacing(message.content)}
               </ReactMarkdown>

--- a/src/components/trip/ai-assistant/ChatMessage.tsx
+++ b/src/components/trip/ai-assistant/ChatMessage.tsx
@@ -7,58 +7,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import ExtractionResultMessage from './ExtractionResultMessage';
+import { normalizeMarkdownListSpacing, safeHref } from './chatUrlSafety';
 import type { AIChatMessage, ExtractedItem } from '@/types/ai-assistant';
-
-/**
- * Fixes common malformed markdown from AI responses.
- * Handles:
- *  - **Name](url)** → **[Name](url)**  (missing opening bracket)
- *  - [Name](url  → [Name](url)         (missing closing paren)
- *  - [Name](httpexample.com) → [Name](https://example.com)  (missing protocol separator)
- *  - Numbered list items not separated by newlines
- *  - Orphaned bold markers around links
- */
-function sanitizeMarkdownLinks(content: string): string {
-  let result = content;
-
-  // --- Normalize numbered lists ---
-  // Ensure each numbered item (e.g., "1.", "2.") starts on its own line.
-  // This handles AI responses that squash list items into a single paragraph.
-  // Only match digits followed by a period+space that are NOT already at line start.
-  result = result.replaceAll(/([^\n])(\s)(\d+)\.\s/g, '$1\n\n$3. ');
-
-  // --- Fix malformed markdown links ---
-
-  // Fix: **Text](url)** — missing opening bracket, closing ** present
-  result = result.replaceAll(/\*\*([^[*\n]+?)\]\(([^)]+)\)\*\*/g, '**[$1]($2)**');
-
-  // Fix: **Text](url/path/ — missing [, ), and closing **
-  // Captures URL up to whitespace, em-dash, or end of line
-  result = result.replaceAll(/\*\*([^[*\n]+?)\]\((https?:\/\/[^\s)]+)\s/g, '**[$1]($2)** ');
-  result = result.replaceAll(/\*\*([^[*\n]+?)\]\((https?:\/\/[^\s)]+)$/gm, '**[$1]($2)**');
-
-  // Fix: *Text](url)* — same for single bold/italic
-  result = result.replaceAll(/(?<!\*)\*([^[*\n]+?)\]\(([^)]+)\)\*/g, '*[$1]($2)*');
-
-  // Fix: standalone Text](url) at start of line or after number+dot — missing opening bracket
-  result = result.replaceAll(/(^|\n|(?:\d+\.\s+))([^[\n*]+?)\]\(([^)]+)\)/g, '$1[$2]($3)');
-
-  // Fix: [Name](url without closing paren — add closing paren before end of line or next space
-  result = result.replaceAll(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\s/g, '[$1]($2) ');
-  result = result.replaceAll(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)$/gm, '[$1]($2)');
-
-  // Fix: URLs missing :// after http/https (e.g., httpexample.com → https://example.com)
-  result = result.replaceAll(/\]\(http([^s:])/g, '](https://$1');
-  result = result.replaceAll(/\]\(https([^:])/g, '](https://$1');
-
-  // Fix: **[Name](url) without closing ** — bold opened but never closed before line end
-  result = result.replaceAll(/\*\*(\[[^\]]+\]\([^)]+\))(?!\*)\s*(?=\n|–|—|-)/g, '**$1**');
-
-  // Fix: [Name](url)** — closing bold without opening bold
-  result = result.replaceAll(/(?<!\*)(\[[^\]]+\]\([^)]+\))\*\*/g, '**$1**');
-
-  return result;
-}
 
 interface ChatMessageProps {
   message: AIChatMessage;
@@ -192,14 +142,20 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={{
-                  // Customize link styling
-                  a: ({ ...props }) => (
+                  // Customize link styling. safeHref() validates the URL
+                  // and swaps anything that isn't trustworthy with a Google
+                  // Search fallback, so users can never click a hallucinated
+                  // booking link that 404s.
+                  a: ({ href, children, ...props }) => (
                     <a
                       {...props}
+                      href={safeHref(typeof href === 'string' ? href : '', typeof children === 'string' ? children : '')}
                       className="text-earth-600 underline hover:text-earth-800 break-all"
                       target="_blank"
                       rel="noopener noreferrer"
-                    />
+                    >
+                      {children}
+                    </a>
                   ),
                   // Customize code blocks
                   code: ({ className, children, ...props }) => {
@@ -246,7 +202,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                   )
                 }}
               >
-                {sanitizeMarkdownLinks(message.content)}
+                {normalizeMarkdownListSpacing(message.content)}
               </ReactMarkdown>
               {isStreaming && (
                 <span className="inline-block w-1 h-[1.1em] ml-0.5 rounded-full bg-earth-400/60 animate-pulse" />

--- a/src/components/trip/ai-assistant/chatUrlSafety.ts
+++ b/src/components/trip/ai-assistant/chatUrlSafety.ts
@@ -55,7 +55,8 @@ function googleSearchFallback(text: string): string {
 /**
  * Validate an AI-generated href. Returns either the original URL (if trusted)
  * or a Google Search fallback built from the link text. Never returns an
- * unparseable or non-http(s) URL.
+ * unparseable or non-https URL — clear-text http links are rejected so that
+ * we never render a downgrade attack vector from model output.
  */
 export function safeHref(rawHref: string, linkText: string): string {
   if (!rawHref) return googleSearchFallback(linkText);
@@ -67,7 +68,7 @@ export function safeHref(rawHref: string, linkText: string): string {
     return googleSearchFallback(linkText);
   }
 
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+  if (parsed.protocol !== 'https:') {
     return googleSearchFallback(linkText);
   }
 

--- a/src/components/trip/ai-assistant/chatUrlSafety.ts
+++ b/src/components/trip/ai-assistant/chatUrlSafety.ts
@@ -1,0 +1,102 @@
+// Client-side URL safety net for AI chat responses.
+//
+// The authoritative URL validation happens server-side in the ai-chat Edge
+// Function (see supabase/functions/ai-chat/linkValidator.ts). This module is
+// a defense-in-depth layer that runs during streaming (when we're displaying
+// raw, partially-arrived tokens) and for any cached historical messages that
+// predate the server fix.
+//
+// `safeHref` is called from the ReactMarkdown `a` component override — every
+// link the user could possibly click passes through here before its `href`
+// is set on the DOM.
+
+// Hosts that are trustworthy enough to render as-is. The server-side
+// validator is stricter (only Google/Wikipedia + tool-verified URLs pass) so
+// this list is primarily a safety net during streaming and for cached
+// historical messages. Anything not on this list is replaced with a Google
+// Search fallback built from the link text.
+const TRUSTED_HOST_SUFFIXES = [
+  // Search & reference
+  'google.com',
+  'google.co.uk',
+  'goo.gl',
+  'wikipedia.org',
+  'wikimedia.org',
+  // Booking platforms (common targets of hallucinated URLs — keeping them
+  // on-domain at least keeps the user on a real site)
+  'resy.com',
+  'opentable.com',
+  'exploretock.com',
+  'yelp.com',
+  'sevenrooms.com',
+  'thefork.com',
+  'tripadvisor.com',
+  'booking.com',
+  'airbnb.com',
+  'hotels.com',
+  'expedia.com',
+  'kayak.com',
+  'skyscanner.com',
+  'getyourguide.com',
+  'viator.com',
+  'guide.michelin.com',
+];
+
+function hostIsTrusted(host: string): boolean {
+  const h = host.toLowerCase();
+  return TRUSTED_HOST_SUFFIXES.some((suffix) => h === suffix || h.endsWith('.' + suffix));
+}
+
+function googleSearchFallback(text: string): string {
+  const q = (text || '').trim() || 'travel';
+  return `https://www.google.com/search?q=${encodeURIComponent(q)}`;
+}
+
+/**
+ * Validate an AI-generated href. Returns either the original URL (if trusted)
+ * or a Google Search fallback built from the link text. Never returns an
+ * unparseable or non-http(s) URL.
+ */
+export function safeHref(rawHref: string, linkText: string): string {
+  if (!rawHref) return googleSearchFallback(linkText);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawHref);
+  } catch {
+    return googleSearchFallback(linkText);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return googleSearchFallback(linkText);
+  }
+
+  const fullUrl = parsed.toString();
+  const upper = fullUrl.toUpperCase();
+  if (
+    upper.includes('PLACE+NAME') ||
+    upper.includes('PLACE%20NAME') ||
+    upper.includes('RESTAURANT+NAME') ||
+    upper.includes('RESTAURANT%20NAME')
+  ) {
+    return googleSearchFallback(linkText);
+  }
+
+  if (hostIsTrusted(parsed.host)) {
+    return fullUrl;
+  }
+  return googleSearchFallback(linkText);
+}
+
+/**
+ * Ensures each numbered list item starts on its own line so ReactMarkdown
+ * renders them as a list rather than a squashed paragraph. This is the only
+ * piece of the old `sanitizeMarkdownLinks` we still need client-side — URL
+ * repair now happens at render time via `safeHref`.
+ */
+export function normalizeMarkdownListSpacing(content: string): string {
+  if (!content) return content;
+  // Match " 2. " (digit + period + space) not already at line start and insert
+  // a blank line before it so it becomes a new list item.
+  return content.replaceAll(/([^\n])(\s)(\d+)\.\s/g, '$1\n\n$3. ');
+}

--- a/src/test/chatUrlSafety.test.ts
+++ b/src/test/chatUrlSafety.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeMarkdownListSpacing,
+  safeHref,
+} from '@/components/trip/ai-assistant/chatUrlSafety';
+// The server validator lives outside src/ but we can import it by relative
+// path — vitest resolves it just fine and the module is pure TS with no
+// Deno-specific globals.
+import {
+  validateAndRewriteLinks,
+  rewriteMarkdownLink,
+  normalizeCandidateUrl,
+} from '../../supabase/functions/ai-chat/linkValidator';
+
+describe('safeHref (client render-time safety net)', () => {
+  it('passes through well-formed Google Maps URLs', () => {
+    const url = 'https://www.google.com/maps/place/?q=place_id:ChIJabcdef';
+    expect(safeHref(url, 'Carbone')).toBe(url);
+  });
+
+  it('passes through Wikipedia links', () => {
+    const url = 'https://en.wikipedia.org/wiki/Tokyo';
+    expect(safeHref(url, 'Tokyo')).toBe(url);
+  });
+
+  it('passes through Resy links (trusted travel host)', () => {
+    const url = 'https://resy.com/cities/ny/venues/carbone';
+    expect(safeHref(url, 'Carbone')).toBe(url);
+  });
+
+  it('replaces unknown hosts with a Google Search fallback', () => {
+    const result = safeHref('https://totally-fake.example.biz/booking', 'Best Sushi Tokyo');
+    expect(result).toBe(
+      'https://www.google.com/search?q=Best%20Sushi%20Tokyo'
+    );
+  });
+
+  it('replaces URLs that still contain the PLACE+NAME prompt placeholder', () => {
+    const leaked = 'https://www.google.com/maps/search/PLACE+NAME+Paris';
+    const result = safeHref(leaked, 'Eiffel Tower');
+    expect(result).toBe('https://www.google.com/search?q=Eiffel%20Tower');
+  });
+
+  it('replaces unparseable href with a Google Search fallback', () => {
+    expect(safeHref('not a url', 'Somewhere')).toBe(
+      'https://www.google.com/search?q=Somewhere'
+    );
+  });
+
+  it('replaces javascript: hrefs (XSS guard)', () => {
+    expect(safeHref('javascript:alert(1)', 'Click me')).toBe(
+      'https://www.google.com/search?q=Click%20me'
+    );
+  });
+
+  it('falls back to a generic query when the link text is empty', () => {
+    expect(safeHref('', '')).toContain('google.com/search');
+  });
+});
+
+describe('normalizeMarkdownListSpacing', () => {
+  it('inserts blank lines before squashed numbered items', () => {
+    const squashed = 'Try these: 1. Sushi Dai. 2. Tsukiji. 3. Sukiyabashi Jiro.';
+    const out = normalizeMarkdownListSpacing(squashed);
+    expect(out).toContain('\n\n1.');
+    expect(out).toContain('\n\n2.');
+    expect(out).toContain('\n\n3.');
+  });
+
+  it('leaves already-well-formatted lists alone', () => {
+    const ok = 'Try these:\n\n1. Sushi Dai\n\n2. Tsukiji\n\n3. Sukiyabashi Jiro';
+    expect(normalizeMarkdownListSpacing(ok)).toBe(ok);
+  });
+});
+
+describe('server-side validateAndRewriteLinks', () => {
+  const searchLocation = 'Tokyo';
+
+  it('trusts URLs that were returned by a tool call', () => {
+    const verified = new Set(['https://resy.com/cities/ny/venues/carbone']);
+    const md = 'Check out [Carbone](https://resy.com/cities/ny/venues/carbone) for dinner.';
+    expect(validateAndRewriteLinks(md, searchLocation, verified)).toBe(md);
+  });
+
+  it('trusts Google Maps URLs on trusted hosts without tool verification', () => {
+    const md = 'See [the Eiffel Tower](https://www.google.com/maps/place/?q=place_id:abc123) on your first day.';
+    expect(validateAndRewriteLinks(md, searchLocation, new Set())).toBe(md);
+  });
+
+  it('rewrites a hallucinated booking-site URL to Google Search', () => {
+    const md = 'Try [Fake Place](https://resy.com/cities/ny/venues/fake-hallucinated-place).';
+    const out = validateAndRewriteLinks(md, searchLocation, new Set());
+    expect(out).toContain('[Fake Place](https://www.google.com/search?q=');
+    expect(out).not.toContain('fake-hallucinated-place');
+  });
+
+  it('rewrites URLs that contain PLACE+NAME leaked template placeholders', () => {
+    const md = 'Visit [Eiffel Tower](https://www.google.com/maps/search/PLACE+NAME+Paris).';
+    const out = validateAndRewriteLinks(md, 'Paris', new Set());
+    expect(out).toContain('[Eiffel Tower](https://www.google.com/search?q=');
+    expect(out).not.toContain('PLACE+NAME');
+  });
+
+  it('rewrites a malformed non-http URL to Google Search', () => {
+    const md = 'Try [Carbone](javascript:alert(1)) for dinner.';
+    const out = validateAndRewriteLinks(md, 'NYC', new Set());
+    expect(out).toContain('[Carbone](https://www.google.com/search?q=');
+    expect(out).not.toContain('javascript:');
+  });
+
+  it('leaves plain text and bold without links untouched', () => {
+    const md = 'I recommend **Carbone** — the spicy rigatoni vodka is a classic.';
+    expect(validateAndRewriteLinks(md, searchLocation, new Set())).toBe(md);
+  });
+
+  it('handles multiple links in a single string independently', () => {
+    const verified = new Set(['https://www.google.com/maps/place/?q=place_id:abc']);
+    const md = [
+      'Day 1: [Eiffel Tower](https://www.google.com/maps/place/?q=place_id:abc)',
+      'Day 2: [Louvre](https://totally-fake.example.com/louvre)',
+    ].join('\n');
+    const out = validateAndRewriteLinks(md, 'Paris', verified);
+    expect(out).toContain('[Eiffel Tower](https://www.google.com/maps/place/?q=place_id:abc)');
+    expect(out).toContain('[Louvre](https://www.google.com/search?q=');
+    expect(out).not.toContain('example.com/louvre');
+  });
+
+  it('leaves malformed markdown (unclosed paren) alone so react-markdown can render it as text', () => {
+    const md = 'Visit [Eiffel Tower](https://example.com/eiffel and let me know.';
+    // Regex requires a closing paren, so this malformed markdown is untouched.
+    // react-markdown will render the unclosed brackets as plain text, which is
+    // safer than guessing what URL the model meant.
+    expect(validateAndRewriteLinks(md, 'Paris', new Set())).toBe(md);
+  });
+});
+
+describe('normalizeCandidateUrl', () => {
+  it('strips trailing punctuation', () => {
+    expect(normalizeCandidateUrl('https://example.com/foo).')).toBe('https://example.com/foo');
+  });
+  it('rejects non-http schemes', () => {
+    expect(normalizeCandidateUrl('ftp://example.com')).toBeNull();
+    expect(normalizeCandidateUrl('javascript:alert(1)')).toBeNull();
+  });
+  it('returns null for non-URL junk', () => {
+    expect(normalizeCandidateUrl('not a url')).toBeNull();
+    expect(normalizeCandidateUrl('')).toBeNull();
+  });
+});
+
+describe('rewriteMarkdownLink direct', () => {
+  it('returns link text with Google Search fallback that includes trip location', () => {
+    const out = rewriteMarkdownLink(
+      'Sukiyabashi Jiro',
+      'https://unknown-host.example/',
+      new Set(),
+      'Tokyo'
+    );
+    expect(out).toContain('Sukiyabashi%20Jiro');
+    expect(out).toContain('Tokyo');
+  });
+});

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -113,10 +113,22 @@ type PlaceResult = {
   phone?: string;
 };
 
+// Hardcoded Google Places API base. All findPlaces() fetches target this host
+// and nothing else — the `query` and `place_id` values are only ever appended
+// as query-string parameters via URL.searchParams, never as path segments or
+// hosts. This bounds SSRF risk: the request destination is fixed at compile
+// time regardless of AI-supplied input.
+const GOOGLE_PLACES_BASE = 'https://maps.googleapis.com';
+
 async function findPlaces(query: string, apiKey: string): Promise<PlaceResult[]> {
+  // Guard against pathologically long model input before hitting Google.
+  const safeQuery = (query || '').slice(0, 256);
+
   // Text Search gives us candidates with place_id for a free-form query.
-  const searchParams = new URLSearchParams({ query, key: apiKey });
-  const searchRes = await fetch(`https://maps.googleapis.com/maps/api/place/textsearch/json?${searchParams.toString()}`);
+  const searchUrl = new URL('/maps/api/place/textsearch/json', GOOGLE_PLACES_BASE);
+  searchUrl.searchParams.set('query', safeQuery);
+  searchUrl.searchParams.set('key', apiKey);
+  const searchRes = await fetch(searchUrl);
   if (!searchRes.ok) throw new Error(`Google Places text search error: ${searchRes.status}`);
   const searchJson = await searchRes.json();
   type RawPlace = {
@@ -131,12 +143,11 @@ async function findPlaces(query: string, apiKey: string): Promise<PlaceResult[]>
   // Fetch Place Details for each candidate (website + phone). In parallel, but only top 3.
   const detailPromises = candidates.map(async (c) => {
     try {
-      const detailsParams = new URLSearchParams({
-        place_id: c.place_id,
-        fields: 'name,place_id,formatted_address,website,rating,formatted_phone_number',
-        key: apiKey,
-      });
-      const detailRes = await fetch(`https://maps.googleapis.com/maps/api/place/details/json?${detailsParams.toString()}`);
+      const detailsUrl = new URL('/maps/api/place/details/json', GOOGLE_PLACES_BASE);
+      detailsUrl.searchParams.set('place_id', c.place_id);
+      detailsUrl.searchParams.set('fields', 'name,place_id,formatted_address,website,rating,formatted_phone_number');
+      detailsUrl.searchParams.set('key', apiKey);
+      const detailRes = await fetch(detailsUrl);
       const detailJson = await detailRes.json();
       const d = detailJson.result || {};
       return {

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,5 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { validateAndRewriteLinks } from './linkValidator.ts';
 
 // Inlined from _shared/cors.ts to support single-function deployment
 const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') ?? 'https://wanderluxe.io';
@@ -49,15 +50,18 @@ type OpenAIOptions = {
   model: string;
   openaiApiKey: string;
   tools?: any[];
-  forceTool?: boolean;
+  forceToolName?: string | null;
   skipTools?: boolean;
 };
 
 type StreamContext = {
   openaiMsgs: OpenAIMessage[];
   openaiOptions: OpenAIOptions;
-  forceSearch: boolean;
+  forceToolName: string | null;
   serperApiKey: string | undefined;
+  googlePlacesApiKey: string | undefined;
+  searchLocation: string;
+  verifiedUrls: Set<string>;
   message: string;
   supabase: SupabaseClient;
   threadId: string;
@@ -72,8 +76,8 @@ type SystemPromptParams = {
   itineraryContext: string;
   formattedAccommodations: string;
   formattedTransportation: string;
-  searchLocation: string;
   serperApiKey: string | undefined;
+  googlePlacesApiKey: string | undefined;
 };
 
 function jsonResponse(body: Record<string, unknown>, status = 200, cors: Record<string, string> = {}): Response {
@@ -97,6 +101,64 @@ async function searchWeb(query: string, apiKey: string): Promise<{ organic: Arra
     throw new Error(`Serper API error: ${res.status} ${err}`);
   }
   return res.json();
+}
+
+type PlaceResult = {
+  name: string;
+  place_id: string;
+  formatted_address: string;
+  maps_url: string;
+  website?: string;
+  rating?: number;
+  phone?: string;
+};
+
+async function findPlaces(query: string, apiKey: string): Promise<PlaceResult[]> {
+  // Text Search gives us candidates with place_id for a free-form query.
+  const searchParams = new URLSearchParams({ query, key: apiKey });
+  const searchRes = await fetch(`https://maps.googleapis.com/maps/api/place/textsearch/json?${searchParams.toString()}`);
+  if (!searchRes.ok) throw new Error(`Google Places text search error: ${searchRes.status}`);
+  const searchJson = await searchRes.json();
+  type RawPlace = {
+    name?: string;
+    place_id: string;
+    formatted_address?: string;
+    rating?: number;
+  };
+  const candidates: RawPlace[] = (searchJson.results || []).slice(0, 3);
+  if (candidates.length === 0) return [];
+
+  // Fetch Place Details for each candidate (website + phone). In parallel, but only top 3.
+  const detailPromises = candidates.map(async (c) => {
+    try {
+      const detailsParams = new URLSearchParams({
+        place_id: c.place_id,
+        fields: 'name,place_id,formatted_address,website,rating,formatted_phone_number',
+        key: apiKey,
+      });
+      const detailRes = await fetch(`https://maps.googleapis.com/maps/api/place/details/json?${detailsParams.toString()}`);
+      const detailJson = await detailRes.json();
+      const d = detailJson.result || {};
+      return {
+        name: d.name || c.name,
+        place_id: c.place_id,
+        formatted_address: d.formatted_address || c.formatted_address || '',
+        maps_url: `https://www.google.com/maps/place/?q=place_id:${c.place_id}`,
+        website: d.website,
+        rating: d.rating ?? c.rating,
+        phone: d.formatted_phone_number,
+      } as PlaceResult;
+    } catch {
+      return {
+        name: c.name,
+        place_id: c.place_id,
+        formatted_address: c.formatted_address || '',
+        maps_url: `https://www.google.com/maps/place/?q=place_id:${c.place_id}`,
+        rating: c.rating,
+      } as PlaceResult;
+    }
+  });
+  return Promise.all(detailPromises);
 }
 
 function parseCreateItemsBlock(response: string): { cleanContent: string; extractedItems: ExtractedItem[] } {
@@ -217,7 +279,9 @@ async function callOpenAI(messages: OpenAIMessage[], stream: boolean, options: O
   };
   if (options.tools && !options.skipTools) {
     body.tools = options.tools;
-    if (options.forceTool) body.tool_choice = { type: 'function' as const, function: { name: 'search_web' } };
+    if (options.forceToolName) {
+      body.tool_choice = { type: 'function' as const, function: { name: options.forceToolName } };
+    }
   }
   return fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -310,36 +374,44 @@ function buildLocationContext(
   return `The trip destination is: ${safeTripName}.`;
 }
 
-function buildSearchStep2WithSerper(): string {
-  return `Call the search_web tool with these queries in priority order until you find results:
-1. "[restaurant name] [city] site:resy.com"
-2. "[restaurant name] [city] site:opentable.com"
-3. "[restaurant name] [city] reservations" (fallback — catches Tock, Yelp, SevenRooms, direct sites)
-
-For international destinations, also try: TheFork (Europe), Tabelog/Hotpepper (Japan), TableCheck, or "[restaurant] [city] reservations" for local platforms.`;
-}
-
-function buildSearchStep2WithoutSerper(): string {
-  return 'Provide a Google Search link: https://www.google.com/search?q=RESTAURANT+NAME+PLUS+CITY+reservations (replace with actual names). Only include Resy/OpenTable URLs if confident from your knowledge; otherwise use the search link. Always add: "Verify the link before booking."';
-}
-
-function buildBookingIntro(hasSerper: boolean): string {
-  if (hasSerper) return 'Use the search_web tool to search. ';
-  return 'Provide a Google Search link for the user to find booking pages. Only include Resy/OpenTable URLs if you are confident from your knowledge; otherwise say "Search for reservations" with the link. Always add: "Verify the link before booking."';
+function buildLinkPolicy(hasFindPlace: boolean, hasSerper: boolean): string {
+  if (hasFindPlace && hasSerper) {
+    return `## Link Policy (STRICT)
+- You have two tools: \`find_place\` (Google Places — canonical names, addresses, websites, Maps URLs) and \`search_web\` (live web search for booking pages).
+- Whenever you mention a specific place (restaurant, hotel, attraction, landmark), FIRST call \`find_place\` so you can link to the verified Google Maps URL or official website.
+- Only use \`search_web\` for booking deep-links (Resy, OpenTable, Tock, etc.) or time-sensitive info (weather, opening hours, events).
+- NEVER invent a URL. NEVER retype a URL from memory. Only use URLs that appear verbatim in a tool result.
+- If neither tool returns a URL for a place, write the place name in bold with NO link. Do not make one up.`;
+  }
+  if (hasFindPlace) {
+    return `## Link Policy (STRICT)
+- You have one tool: \`find_place\` (Google Places). Call it for every specific place you mention and link to the returned website or Maps URL.
+- NEVER invent a URL. NEVER retype a URL from memory. Only use URLs that appear verbatim in a tool result.
+- For restaurant bookings (Resy, OpenTable, etc.) you have no search tool available — do not attempt to construct booking URLs. Recommend the restaurant and let the user search for bookings themselves.
+- If \`find_place\` returns no URL for a place, write the place name in bold with NO link. Do not make one up.`;
+  }
+  if (hasSerper) {
+    return `## Link Policy (STRICT)
+- You have one tool: \`search_web\`. Call it whenever you mention a specific place and want to link to it.
+- NEVER invent a URL. NEVER retype a URL from memory. Only use URLs that appear verbatim in a tool result.
+- If no result exists, write the place name in bold with NO link.`;
+  }
+  return `## Link Policy (STRICT)
+- You have no web tools available in this environment.
+- Do NOT author any URLs. Any URL you write will be stripped and replaced with a Google Search fallback.
+- Write place names in bold (\`**Place Name**\`) without links. The client will render a Google Search link automatically.`;
 }
 
 function buildSystemPrompt(params: SystemPromptParams): string {
   const {
     tripName, locationContext, arrivalDate, departureDate,
     partySizeContext, itineraryContext, formattedAccommodations,
-    formattedTransportation, searchLocation, serperApiKey
+    formattedTransportation, serperApiKey, googlePlacesApiKey
   } = params;
 
   const hasSerper = !!serperApiKey;
-  const bookingIntro = buildBookingIntro(hasSerper);
-  const searchStep2 = hasSerper ? buildSearchStep2WithSerper() : buildSearchStep2WithoutSerper();
-  const mapsUrl = 'https://www.google.com/maps/search/PLACE+NAME+' + searchLocation;
-  const searchUrl = 'https://www.google.com/search?q=PLACE+NAME+' + searchLocation;
+  const hasFindPlace = !!googlePlacesApiKey;
+  const linkPolicy = buildLinkPolicy(hasFindPlace, hasSerper);
 
   const safeTripName = sanitizeForPrompt(tripName);
 
@@ -356,45 +428,9 @@ Guidelines:
 - Be concise and helpful
 - Use markdown formatting for readability. IMPORTANT: When writing numbered lists, put each item on its own line with a blank line between items for proper rendering
 - When listing multiple recommendations, use a numbered markdown list with each item separated by a blank line
-- When recommending hotels or attractions, make the name a clickable link using Google Maps or Google Search URLs
-- For restaurants, use the Restaurant Booking Links workflow below — you may use direct booking URLs (Resy, OpenTable, etc.) when found via search
-- IMPORTANT for non-restaurant places: Only use Google Maps or Google Search URL formats (never IP addresses or made-up URLs):
-  - Google Maps: ${mapsUrl}
-  - Google Search: ${searchUrl}
-- Format: **[Place Name](url)** - Brief description
+- Format place recommendations as: **[Place Name](verified-url)** — brief description (when you have a verified URL), otherwise **Place Name** — brief description (with no link)
 
-## Restaurant Booking Links
-
-When you recommend, suggest, or discuss a specific restaurant for a user's trip, you MUST find booking links. ${bookingIntro}Follow this workflow:
-
-### Step 1: Identify the Restaurant
-Extract the restaurant name, city, and neighborhood (if known) from the conversation context or the trip destination.
-
-### Step 2: Search for Booking Links
-${searchStep2}
-
-### Step 3: Classify the Booking Platform
-From search results, identify which platform(s) the restaurant uses:
-- Resy — URLs contain resy.com/cities/
-- OpenTable — URLs contain opentable.com/r/ or opentable.com/restref/
-- Tock — URLs contain exploretock.com/
-- Yelp Reservations — URLs contain yelp.com/reservations/
-- SevenRooms — URLs contain sevenrooms.com/
-- TheFork — URLs contain thefork.com/ (Europe)
-- Direct — The restaurant's own booking page
-
-### Step 4: Present the Recommendation with Booking Action
-Always include a booking link with every restaurant recommendation. Format:
-
-**[Restaurant Name]** — [Cuisine Type], [Neighborhood]
-[1-2 sentence description of why it fits the user's needs]
-Price: [Price range if known]
-Book on [Platform Name]: [Direct URL to booking page]
-
-If multiple platforms exist, show both. If NO booking platform found, say so honestly and suggest Google Maps or the restaurant's website. NEVER fabricate or guess URLs — only use URLs from search results.
-
-### Step 5: Pre-fill When Possible
-If trip dates and party size are in context, you may append parameters to OpenTable URLs. Resy does not support deep-link pre-filling.
+${linkPolicy}
 
 CRITICAL - YOU CAN ADD ITEMS TO THE TRIP:
 You have the ability to add items directly to the user's trip itinerary. This is a core feature.
@@ -430,59 +466,160 @@ function extractSearchQuery(args: Record<string, unknown>): string {
   return '';
 }
 
+type ToolExecutionContext = {
+  serperApiKey: string | undefined;
+  googlePlacesApiKey: string | undefined;
+  message: string;
+  verifiedUrls: Set<string>;
+};
+
+async function executeSearchWeb(
+  tc: ToolCall,
+  serperApiKey: string,
+  message: string,
+  verifiedUrls: Set<string>,
+): Promise<{ role: 'tool'; tool_call_id: string; content: string }> {
+  try {
+    const argsStr = (tc.function.arguments || '').trim();
+    const args = argsStr ? JSON.parse(argsStr) : {};
+    const q = extractSearchQuery(args);
+    const searchQuery = q || message || 'restaurant reservations';
+    const results = await searchWeb(searchQuery, serperApiKey);
+    const organic = (results.organic || []).slice(0, 6);
+    for (const r of organic) {
+      if (r.link) verifiedUrls.add(r.link);
+    }
+    const summary = organic.map((r) => `${r.title}: ${r.link}`).join('\n');
+    return { role: 'tool', tool_call_id: tc.id, content: summary || 'No results found.' };
+  } catch (error_) {
+    const errorMsg = error_ instanceof Error ? error_.message : 'Unknown';
+    return { role: 'tool', tool_call_id: tc.id, content: `Search error: ${errorMsg}. Do not fabricate a URL; tell the user to search manually.` };
+  }
+}
+
+async function executeFindPlace(
+  tc: ToolCall,
+  googlePlacesApiKey: string,
+  verifiedUrls: Set<string>,
+): Promise<{ role: 'tool'; tool_call_id: string; content: string }> {
+  try {
+    const argsStr = (tc.function.arguments || '').trim();
+    const args = argsStr ? JSON.parse(argsStr) : {};
+    const query = typeof args.query === 'string' ? args.query : '';
+    if (!query) {
+      return { role: 'tool', tool_call_id: tc.id, content: 'find_place error: missing "query" argument.' };
+    }
+    const places = await findPlaces(query, googlePlacesApiKey);
+    if (places.length === 0) {
+      return { role: 'tool', tool_call_id: tc.id, content: 'No matching places found.' };
+    }
+    for (const p of places) {
+      verifiedUrls.add(p.maps_url);
+      if (p.website) verifiedUrls.add(p.website);
+    }
+    // Give the model a compact, unambiguous structured payload so it can
+    // quote verified URLs instead of authoring new ones.
+    const payload = places.map((p) => ({
+      name: p.name,
+      address: p.formatted_address,
+      rating: p.rating,
+      phone: p.phone,
+      website: p.website || null,
+      maps_url: p.maps_url,
+    }));
+    return { role: 'tool', tool_call_id: tc.id, content: JSON.stringify(payload) };
+  } catch (error_) {
+    const errorMsg = error_ instanceof Error ? error_.message : 'Unknown';
+    return { role: 'tool', tool_call_id: tc.id, content: `find_place error: ${errorMsg}. Do not fabricate a URL.` };
+  }
+}
+
 async function executeToolCalls(
   toolCalls: ToolCall[],
-  serperApiKey: string,
-  message: string
+  ctx: ToolExecutionContext,
 ): Promise<Array<{ role: 'tool'; tool_call_id: string; content: string }>> {
   const toolResults: Array<{ role: 'tool'; tool_call_id: string; content: string }> = [];
   for (const tc of toolCalls) {
-    if (tc.function.name !== 'search_web') continue;
-    try {
-      const argsStr = (tc.function.arguments || '').trim();
-      const args = argsStr ? JSON.parse(argsStr) : {};
-      const q = extractSearchQuery(args);
-      const searchQuery = q || message || 'restaurant reservations';
-      const results = await searchWeb(searchQuery, serperApiKey);
-      const summary = (results.organic || []).slice(0, 6).map((r: any) => `${r.title}: ${r.link}`).join('\n');
-      toolResults.push({ role: 'tool', tool_call_id: tc.id, content: summary || 'No results found.' });
-    } catch (error_) {
-      const errorMsg = error_ instanceof Error ? error_.message : 'Unknown';
-      toolResults.push({ role: 'tool', tool_call_id: tc.id, content: `Search error: ${errorMsg}. You can suggest the user search Google for "[restaurant name] [city] reservations".` });
+    if (tc.function.name === 'search_web' && ctx.serperApiKey) {
+      toolResults.push(await executeSearchWeb(tc, ctx.serperApiKey, ctx.message, ctx.verifiedUrls));
+    } else if (tc.function.name === 'find_place' && ctx.googlePlacesApiKey) {
+      toolResults.push(await executeFindPlace(tc, ctx.googlePlacesApiKey, ctx.verifiedUrls));
+    } else {
+      toolResults.push({ role: 'tool', tool_call_id: tc.id, content: `Tool "${tc.function.name}" is not available in this environment.` });
     }
   }
   return toolResults;
 }
 
-function buildSearchWebTool(serperApiKey: string | undefined): any | null {
-  if (!serperApiKey) return null;
-  return {
-    type: 'function' as const,
-    function: {
-      name: 'search_web',
-      description: 'Search the web for up-to-date information. Use for: restaurant booking pages (Resy, OpenTable), weather, current events, news, opening hours, exchange rates, or any query that benefits from live web results.',
-      parameters: {
-        type: 'object',
-        properties: { query: { type: 'string', description: 'Search query, e.g. "Carbone NYC site:resy.com"' } },
-        required: ['query']
-      }
-    }
-  };
+function buildTools(serperApiKey: string | undefined, googlePlacesApiKey: string | undefined): any[] | undefined {
+  const tools: any[] = [];
+
+  if (googlePlacesApiKey) {
+    tools.push({
+      type: 'function' as const,
+      function: {
+        name: 'find_place',
+        description: 'Look up a specific place (restaurant, hotel, landmark, attraction) on Google Places. Returns verified name, address, website, phone, rating, and a canonical Google Maps URL. Use this whenever you recommend or reference a specific place so that the URL you cite is real.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Free-text place query, e.g. "Carbone restaurant NYC" or "Hotel Bel-Air Los Angeles".',
+            },
+          },
+          required: ['query'],
+        },
+      },
+    });
+  }
+
+  if (serperApiKey) {
+    tools.push({
+      type: 'function' as const,
+      function: {
+        name: 'search_web',
+        description: 'Search the web for up-to-date information. Use only for time-sensitive queries that find_place cannot answer: restaurant booking pages (Resy, OpenTable), weather, current events, opening hours, exchange rates.',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string', description: 'Search query, e.g. "Carbone NYC site:resy.com"' } },
+          required: ['query'],
+        },
+      },
+    });
+  }
+
+  return tools.length > 0 ? tools : undefined;
 }
 
 const DINING_KEYWORDS = /\b(restaurant|restaurants|dining|dinner|lunch|eat|food|reservation|reservations|book a table|opentable|resy|carbone)\b/i;
-const RECOMMENDATION_KEYWORDS = /\b(where should i eat|booking link|reservation link)\b/i;
+const PLACE_KEYWORDS = /\b(hotel|hotels|attraction|attractions|landmark|museum|park|bar|bars|cafe|neighborhood|things to do|visit|sightseeing|activity|activities|recommend)\b/i;
+const BOOKING_KEYWORDS = /\b(booking link|reservation link|book a table)\b/i;
 const WEATHER_KEYWORDS = /\b(weather|temperature|forecast|rainy|sunny|snow|humidity)\b/i;
-const CURRENT_INFO_KEYWORDS = /\b(news|latest|current|today|happening|events|concerts|attractions|opening hours|closed today|exchange rate|currency)\b/i;
-const WEATHER_QUESTION_KEYWORDS = /\b(what.*weather|how.*weather|recommend.*restaurant)\b/i;
+const CURRENT_INFO_KEYWORDS = /\b(news|latest|current|today|happening|events|concerts|opening hours|closed today|exchange rate|currency)\b/i;
 
-function shouldForceSearch(message: string, hasTools: boolean): boolean {
-  if (!hasTools) return false;
-  return DINING_KEYWORDS.test(message)
-    || RECOMMENDATION_KEYWORDS.test(message)
+function chooseForcedTool(
+  message: string,
+  hasFindPlace: boolean,
+  hasSearchWeb: boolean,
+): string | null {
+  // When the message is explicitly about live/web info, prefer web search.
+  if (hasSearchWeb && (
+    BOOKING_KEYWORDS.test(message)
     || WEATHER_KEYWORDS.test(message)
     || CURRENT_INFO_KEYWORDS.test(message)
-    || WEATHER_QUESTION_KEYWORDS.test(message);
+  )) {
+    return 'search_web';
+  }
+  // Otherwise for dining / place recommendations, prefer structured Google Places.
+  if (hasFindPlace && (DINING_KEYWORDS.test(message) || PLACE_KEYWORDS.test(message))) {
+    return 'find_place';
+  }
+  // Dining without find_place → fall back to search_web if available.
+  if (hasSearchWeb && DINING_KEYWORDS.test(message)) {
+    return 'search_web';
+  }
+  return null;
 }
 
 async function fetchTripContext(supabase: SupabaseClient, tripId: string) {
@@ -545,8 +682,7 @@ type ToolCallFollowUpParams = {
   fullResponse: string;
   currentMessages: OpenAIMessage[];
   openaiOptions: OpenAIOptions;
-  serperApiKey: string;
-  message: string;
+  toolCtx: ToolExecutionContext;
 };
 
 async function handleToolCallFollowUp(
@@ -554,9 +690,9 @@ async function handleToolCallFollowUp(
   controller: { enqueue: (chunk: Uint8Array) => void },
   encoder: TextEncoder
 ): Promise<string> {
-  const { toolCalls, fullResponse, currentMessages, openaiOptions, serperApiKey, message } = params;
+  const { toolCalls, fullResponse, currentMessages, openaiOptions, toolCtx } = params;
   const assistantMsg = { role: 'assistant' as const, content: fullResponse || null, tool_calls: toolCalls };
-  const toolResults = await executeToolCalls(toolCalls, serperApiKey, message);
+  const toolResults = await executeToolCalls(toolCalls, toolCtx);
   const updatedMessages = [...currentMessages, assistantMsg, ...toolResults];
   const followRes = await callOpenAI(updatedMessages, true, { ...openaiOptions, skipTools: true });
 
@@ -600,7 +736,7 @@ async function handleStreamResponse(
   ctx: StreamContext
 ): Promise<void> {
   const currentMessages = [...ctx.openaiMsgs];
-  const openaiRes = await callOpenAI(currentMessages, true, { ...ctx.openaiOptions, forceTool: ctx.forceSearch });
+  const openaiRes = await callOpenAI(currentMessages, true, { ...ctx.openaiOptions, forceToolName: ctx.forceToolName });
 
   if (!openaiRes.ok) {
     controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ message: 'AI request failed' })}\n\n`));
@@ -611,19 +747,38 @@ async function handleStreamResponse(
   const { fullResponse, toolCalls } = await processStream(openaiRes, controller, encoder);
   let lastResponse = fullResponse;
 
-  if (toolCalls && toolCalls.length > 0 && ctx.serperApiKey) {
+  const toolCtx: ToolExecutionContext = {
+    serperApiKey: ctx.serperApiKey,
+    googlePlacesApiKey: ctx.googlePlacesApiKey,
+    message: ctx.message,
+    verifiedUrls: ctx.verifiedUrls,
+  };
+
+  const hasToolSupport = !!ctx.serperApiKey || !!ctx.googlePlacesApiKey;
+  if (toolCalls && toolCalls.length > 0 && hasToolSupport) {
     lastResponse = await handleToolCallFollowUp({
       toolCalls, fullResponse, currentMessages,
       openaiOptions: ctx.openaiOptions,
-      serperApiKey: ctx.serperApiKey,
-      message: ctx.message
+      toolCtx,
     }, controller, encoder);
   }
 
   const fallbackMsg = toolCalls?.length ? 'I searched for booking options but couldn\'t format the results. Try searching for the restaurant name plus your city on Resy or OpenTable.' : '';
-  const finalContent = lastResponse.trim() || fallbackMsg;
-  const { cleanContent } = parseCreateItemsBlock(finalContent);
-  const contentToSave = cleanContent || finalContent;
+  const rawFinal = lastResponse.trim() || fallbackMsg;
+
+  // Strip any `create_items` block before URL validation so we don't touch JSON.
+  const { cleanContent, extractedItems } = parseCreateItemsBlock(rawFinal);
+  const prosePart = cleanContent || rawFinal;
+
+  // Replace any AI-authored URLs with Google Search fallbacks unless they
+  // were returned by a tool or point to a trusted host (Google, Wikipedia).
+  const validatedProse = validateAndRewriteLinks(prosePart, ctx.searchLocation, ctx.verifiedUrls);
+
+  // Re-attach the create_items block (unchanged) so the import flow still works.
+  const finalContent = extractedItems.length > 0
+    ? `${validatedProse}\n\n\`\`\`create_items\n${JSON.stringify(extractedItems.map((it) => ({ itemType: it.itemType, fields: it.fields })))}\n\`\`\``
+    : validatedProse;
+  const contentToSave = validatedProse;
 
   const { data: saved } = await ctx.supabase.from('ai_chat_messages').insert({ thread_id: ctx.threadId, role: 'assistant', content: contentToSave || '(No response)' }).select('id').single();
   emitFinalEvents(controller, encoder, finalContent, fallbackMsg, ctx.openaiOptions.model, ctx.threadId, saved?.id);
@@ -636,6 +791,7 @@ async function handlePostMessage(
   userId: string,
   openaiApiKey: string,
   serperApiKey: string | undefined,
+  googlePlacesApiKey: string | undefined,
   model: string,
   cors: Record<string, string> = {}
 ): Promise<Response> {
@@ -673,20 +829,22 @@ async function handlePostMessage(
   const systemPrompt = buildSystemPrompt({
     tripName, locationContext, arrivalDate, departureDate,
     partySizeContext, itineraryContext, formattedAccommodations,
-    formattedTransportation, searchLocation, serperApiKey
+    formattedTransportation, serperApiKey, googlePlacesApiKey
   });
 
-  const searchWebTool = buildSearchWebTool(serperApiKey);
-  const tools = searchWebTool ? [searchWebTool] : undefined;
+  const tools = buildTools(serperApiKey, googlePlacesApiKey);
   const openaiMsgs: OpenAIMessage[] = [{ role: 'system', content: systemPrompt }, ...(msgs || []).reverse().map((m: any) => ({ role: m.role, content: m.content }))];
-  const forceSearch = shouldForceSearch(message, !!tools);
+  const forceToolName = chooseForcedTool(message, !!googlePlacesApiKey, !!serperApiKey);
   const encoder = new TextEncoder();
 
   const ctx: StreamContext = {
     openaiMsgs,
     openaiOptions: { model, openaiApiKey, tools },
-    forceSearch,
+    forceToolName,
     serperApiKey,
+    googlePlacesApiKey,
+    searchLocation,
+    verifiedUrls: new Set<string>(),
     message,
     supabase,
     threadId
@@ -747,6 +905,7 @@ Deno.serve(async (req: Request) => {
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
   const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
   const serperApiKey = Deno.env.get('SERPER_API_KEY');
+  const googlePlacesApiKey = Deno.env.get('GOOGLE_PLACES_API_KEY');
   const model = Deno.env.get('OPENAI_CHAT_MODEL') || 'gpt-5.4-mini';
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
@@ -771,7 +930,7 @@ Deno.serve(async (req: Request) => {
 
   if (req.method === 'POST' && !action) {
     if (!openaiApiKey) return jsonResponse({ code: 'CONFIG_ERROR', message: 'OpenAI not configured' }, 500, corsHeaders);
-    return handlePostMessage(req, supabase, tripId, user.userId, openaiApiKey, serperApiKey, model, corsHeaders);
+    return handlePostMessage(req, supabase, tripId, user.userId, openaiApiKey, serperApiKey, googlePlacesApiKey, model, corsHeaders);
   }
 
   return jsonResponse({ error: 'Method not allowed' }, 405, corsHeaders);

--- a/supabase/functions/ai-chat/linkValidator.ts
+++ b/supabase/functions/ai-chat/linkValidator.ts
@@ -1,0 +1,109 @@
+// Link validation / rewriting for AI chat responses.
+//
+// After the model generates its final response, we walk every markdown link
+// and decide whether to trust the URL or replace it with a Google Search
+// fallback built from the link text. The goal is simple: the user should
+// never click an AI-authored URL that 404s or leads somewhere unexpected.
+//
+// Trust rules (applied in order):
+//   1. URLs that the server verified came from a tool result (verifiedUrls)
+//      are trusted verbatim.
+//   2. URLs on a small allowlist of highly stable hosts (Google, Wikipedia)
+//      are trusted after parsing.
+//   3. Everything else — including hallucinated booking-site URLs — is
+//      rewritten to a Google Search for the link text plus trip location.
+//
+// This module is intentionally pure (no Deno / Node globals beyond the URL
+// constructor) so that it can be imported from both the Deno edge function
+// and the Node-based vitest test suite.
+
+export const TRUSTED_HOST_SUFFIXES = [
+  'google.com',
+  'google.co.uk',
+  'goo.gl',
+  'wikipedia.org',
+  'wikimedia.org',
+];
+
+export function hostIsTrusted(host: string): boolean {
+  const h = host.toLowerCase();
+  return TRUSTED_HOST_SUFFIXES.some((suffix) => h === suffix || h.endsWith('.' + suffix));
+}
+
+export function googleSearchFallback(text: string, searchLocation: string): string {
+  const cleanLocation = (searchLocation || '').replaceAll('+', ' ').trim();
+  const query = cleanLocation ? `${text} ${cleanLocation}` : text;
+  return `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+}
+
+export function normalizeCandidateUrl(raw: string): string | null {
+  let url = (raw || '').trim();
+  // Drop trailing punctuation the model sometimes glues onto URLs.
+  url = url.replace(/[),.;:!?'"*_\]]+$/, '');
+  if (!url) return null;
+  if (!/^https?:\/\//i.test(url)) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function containsPlaceholder(url: string): boolean {
+  const upper = url.toUpperCase();
+  return (
+    upper.includes('PLACE+NAME') ||
+    upper.includes('PLACE%20NAME') ||
+    upper.includes('RESTAURANT+NAME') ||
+    upper.includes('RESTAURANT%20NAME') ||
+    upper.includes('${') // leaked template literal
+  );
+}
+
+export function rewriteMarkdownLink(
+  text: string,
+  rawUrl: string,
+  verifiedUrls: Set<string>,
+  searchLocation: string,
+): string {
+  if (verifiedUrls.has(rawUrl)) return `[${text}](${rawUrl})`;
+
+  const normalized = normalizeCandidateUrl(rawUrl);
+  if (normalized && verifiedUrls.has(normalized)) return `[${text}](${normalized})`;
+  if (!normalized) return `[${text}](${googleSearchFallback(text, searchLocation)})`;
+
+  if (containsPlaceholder(normalized)) {
+    return `[${text}](${googleSearchFallback(text, searchLocation)})`;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    return `[${text}](${googleSearchFallback(text, searchLocation)})`;
+  }
+
+  if (hostIsTrusted(parsed.host)) {
+    return `[${text}](${parsed.toString()})`;
+  }
+  return `[${text}](${googleSearchFallback(text, searchLocation)})`;
+}
+
+/**
+ * Walks every well-formed markdown link in `markdown` and rewrites each one
+ * according to the trust rules above. Malformed markdown (unclosed brackets,
+ * missing parens) is left alone — react-markdown will render it as plain
+ * text on the client, which is safer than guessing what the model meant.
+ */
+export function validateAndRewriteLinks(
+  markdown: string,
+  searchLocation: string,
+  verifiedUrls: Set<string> = new Set(),
+): string {
+  return markdown.replaceAll(
+    /\[([^\]\n]+)\]\(([^)\s]+)\)/g,
+    (_match, text, url) => rewriteMarkdownLink(text, url, verifiedUrls, searchLocation),
+  );
+}

--- a/supabase/functions/ai-chat/linkValidator.ts
+++ b/supabase/functions/ai-chat/linkValidator.ts
@@ -41,10 +41,13 @@ export function normalizeCandidateUrl(raw: string): string | null {
   // Drop trailing punctuation the model sometimes glues onto URLs.
   url = url.replace(/[),.;:!?'"*_\]]+$/, '');
   if (!url) return null;
-  if (!/^https?:\/\//i.test(url)) return null;
+  // Only accept https URLs. We never want to render a clear-text link from
+  // the model — if a URL arrives as http:// we rewrite it to a Google Search
+  // for the link text instead (see rewriteMarkdownLink).
+  if (!/^https:\/\//i.test(url)) return null;
   try {
     const parsed = new URL(url);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    if (parsed.protocol !== 'https:') return null;
     return parsed.toString();
   } catch {
     return null;


### PR DESCRIPTION
The model was authoring URLs by paraphrasing prompt templates and Serper
search summaries, which produced hallucinated and malformed booking-site
links that 404ed. Replace the free-form URL flow with a structured
Google Places tool plus server-side link validation so users can never
click a link the system didn't verify.

- Add a find_place tool backed by Google Places Text Search + Place
  Details. Returns verified name, address, website, phone, rating, and a
  canonical Maps URL for every recommendation.
- Rewrite the system prompt into a strict link policy: the model may
  only cite URLs that came verbatim from a tool result. Places without
  a verified URL render as bold text with no link.
- Add a pure linkValidator module (tested) that walks every markdown
  link in the final assistant response, trusts tool-verified URLs and a
  small Google/Wikipedia allowlist, and rewrites anything else to a
  Google Search fallback built from the link text plus trip location.
- Run the validator before saving to the DB and before the done SSE
  event, so both persisted history and the rendered message are clean.
- chooseForcedTool picks find_place for dining/place queries when
  Google Places is configured, falls back to search_web only for
  booking/weather when Serper is configured, and forces no tool when
  neither key is set.
- Client ChatMessage now validates every href via safeHref at render
  time (defense in depth for streaming tokens and cached history), and
  keeps only the minimal numbered-list spacing fix from the old
  regex-based sanitizer.
- 22 new tests cover tool-verified URLs, allowlist hosts, hallucinated
  hosts, prompt-placeholder leakage, javascript: XSS guards, and
  malformed markdown passthrough.

https://claude.ai/code/session_01HvFYMaxKxp77YKMuzHA5gz