### PR TITLE
Add build-time app versioning with update detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.0.0",
+  "version": "5.2.1",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"NODE_ENV=development npx tsx server/index.ts\"",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,8 @@
-const CACHE_NAME = 'wanderluxe-v4';
+// __APP_SHA__ is replaced at build time by the versionStampPlugin in
+// vite.config.ts so each deploy gets a unique cache name. In dev (unstamped)
+// it stays as the literal placeholder string, which is fine because the SW
+// is not registered in dev.
+const CACHE_NAME = 'wanderluxe-__APP_SHA__';
 const OFFLINE_URL = '/index.html';
 const URLS_TO_CACHE = [
   '/',
@@ -44,6 +48,12 @@ self.addEventListener('fetch', (event) => {
   // This avoids CSP connect-src violations for external resources (fonts, images, analytics)
   const url = new URL(event.request.url);
   if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  // Never cache version.json — it's the source of truth for update detection
+  // and must always return the freshest copy from the network.
+  if (url.pathname === '/version.json') {
     return;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import CookieConsentBanner from "@/components/CookieConsentBanner";
 import AdminRoute from "./components/AdminRoute";
 import { lazy, Suspense, useEffect } from "react";
 import { Loader2 } from "lucide-react";
+import { useVersionCheck } from "@/hooks/useVersionCheck";
 
 // Landing page loaded eagerly — it's the entry point
 import Index from "./pages/Index";
@@ -54,6 +55,7 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
+  useVersionCheck();
   return (
     <QueryClientProvider client={queryClient}>
       <ConsentProvider>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { useInviteLinks } from "@/hooks/useInviteLinks";
 import { useTripPermissions } from "@/hooks/use-trip-permissions";
+import { APP_VERSION_LABEL, APP_VERSION_FULL } from "@/config/version";
 
 export interface SidebarHandle {
   openAccommodationDialog: () => void;
@@ -353,6 +354,12 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
             </Button>
           </NavLink>
         </div>
+        <p
+          className="text-[10px] text-sand-400 font-mono text-center select-none"
+          title={APP_VERSION_FULL}
+        >
+          {APP_VERSION_LABEL}
+        </p>
       </div>
     </div>
   );

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,0 +1,21 @@
+/**
+ * App version identity, baked in at build time by vite.config.ts.
+ *
+ * - `version` is the semver from package.json (bumped manually for releases).
+ * - `sha` is the short git commit hash this bundle was built from.
+ * - `buildTime` is an ISO timestamp of when the bundle was built.
+ *
+ * These constants are compile-time replaced by Vite's `define`, so they're
+ * zero-cost at runtime and tree-shake friendly.
+ */
+export const APP_VERSION = {
+  version: __APP_VERSION__,
+  sha: __APP_GIT_SHA__,
+  buildTime: __APP_BUILD_TIME__,
+} as const;
+
+/** Short label for UI display, e.g. "v1.4.0 · a1b2c3d". */
+export const APP_VERSION_LABEL = `v${APP_VERSION.version} · ${APP_VERSION.sha}`;
+
+/** Full label with build time, for tooltips. */
+export const APP_VERSION_FULL = `v${APP_VERSION.version} · ${APP_VERSION.sha} · ${APP_VERSION.buildTime}`;

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { APP_VERSION } from "@/config/version";
+
+interface RemoteVersion {
+  version: string;
+  sha: string;
+  buildTime: string;
+}
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Polls /version.json and shows a toast when a newer build is deployed.
+ *
+ * - Only runs in production builds (dev has HMR).
+ * - Compares the git SHA bundled into the app against the one on the server.
+ * - Polls on an interval and whenever the tab becomes visible again.
+ * - Toast is shown once per detected version, with a "Refresh" action.
+ */
+export function useVersionCheck() {
+  const notifiedShaRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+
+    let cancelled = false;
+
+    const checkVersion = async () => {
+      try {
+        const res = await fetch(`/version.json?t=${Date.now()}`, {
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const remote: RemoteVersion = await res.json();
+        if (cancelled) return;
+
+        // Different SHA = new build available.
+        if (
+          remote.sha &&
+          remote.sha !== APP_VERSION.sha &&
+          remote.sha !== notifiedShaRef.current
+        ) {
+          notifiedShaRef.current = remote.sha;
+          toast.info("A new version of WanderLuxe is available", {
+            description: `v${remote.version} · ${remote.sha}`,
+            duration: Infinity,
+            action: {
+              label: "Refresh",
+              onClick: () => {
+                // Ask the active SW (if any) to update, then hard reload.
+                if ("serviceWorker" in navigator) {
+                  navigator.serviceWorker
+                    .getRegistration()
+                    .then((reg) => reg?.update())
+                    .finally(() => window.location.reload());
+                } else {
+                  window.location.reload();
+                }
+              },
+            },
+          });
+        }
+      } catch {
+        // Network error — silently ignore, we'll try again next tick.
+      }
+    };
+
+    // Initial check shortly after mount (give the app a beat to settle).
+    const initialTimer = window.setTimeout(checkVersion, 10_000);
+    const interval = window.setInterval(checkVersion, POLL_INTERVAL_MS);
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") checkVersion();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(initialTimer);
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,8 @@ declare module '*.ttf?url' {
   const src: string;
   export default src;
 }
+
+// Injected at build time by vite.config.ts `define`.
+declare const __APP_VERSION__: string;
+declare const __APP_GIT_SHA__: string;
+declare const __APP_BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,68 @@
 
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import fs from "node:fs";
+import { execSync } from "node:child_process";
 import { componentTagger } from "lovable-tagger";
+import pkg from "./package.json" with { type: "json" };
+
+// --- Version stamping ------------------------------------------------------
+// Inject version identity at build time so the running app knows exactly
+// which commit it came from, and ships a /version.json for update polling.
+function readGitSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "dev";
+  }
+}
+
+const APP_VERSION = pkg.version;
+const APP_GIT_SHA = readGitSha();
+const APP_BUILD_TIME = new Date().toISOString();
+
+function versionStampPlugin(): Plugin {
+  return {
+    name: "wanderluxe-version-stamp",
+    apply: "build",
+    writeBundle(options) {
+      const outDir = options.dir ?? "dist";
+      // Skip the server bundle — only stamp the client output.
+      if (outDir.includes(`${path.sep}server`) || outDir.endsWith("/server")) {
+        return;
+      }
+      // Emit version.json for runtime polling
+      fs.writeFileSync(
+        path.join(outDir, "version.json"),
+        JSON.stringify(
+          { version: APP_VERSION, sha: APP_GIT_SHA, buildTime: APP_BUILD_TIME },
+          null,
+          2,
+        ),
+      );
+      // Replace the __APP_SHA__ placeholder in the service worker so its
+      // cache name is keyed to this build.
+      const swPath = path.join(outDir, "sw.js");
+      if (fs.existsSync(swPath)) {
+        const contents = fs.readFileSync(swPath, "utf-8");
+        fs.writeFileSync(swPath, contents.replace(/__APP_SHA__/g, APP_GIT_SHA));
+      }
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+    __APP_GIT_SHA__: JSON.stringify(APP_GIT_SHA),
+    __APP_BUILD_TIME__: JSON.stringify(APP_BUILD_TIME),
+  },
   server: {
     host: "0.0.0.0",
     port: 8080,
@@ -68,6 +125,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
+    versionStampPlugin(),
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),


### PR DESCRIPTION
## Summary
- Injects `version` (from package.json) + short git SHA + build timestamp into the bundle at build time via Vite's `define`, exposed through `src/config/version.ts`
- Emits `dist/version.json` on build; a new `useVersionCheck` hook polls it (every 5 min + on tab-visibility change) and shows a persistent Sonner toast with a Refresh action whenever the deployed SHA differs from the running one
- Keys the service worker cache to the build's git SHA so every deploy evicts old caches on `activate`; `/version.json` is explicitly excluded from SW caching so it's always network-fresh
- Displays `v{version} · {sha}` in the sidebar footer, with full build time in the hover tooltip
- Bumps `package.json` version to `5.2.1` as the starting semver

## Test plan
- [ ] `bun run build` succeeds; verify `dist/version.json` is written and `dist/sw.js` contains the real SHA (not `__APP_SHA__`)
- [ ] `bun run preview` — sidebar footer shows `v5.2.1 · <sha>`, tooltip shows full build time
- [ ] Deploy, then deploy again from a new commit — running clients see the "new version available" toast within ~5 minutes (or immediately on tab refocus)
- [ ] Clicking Refresh reloads into the new build
- [ ] Old SW caches (`wanderluxe-<old-sha>`) are cleaned up after the new SW activates
- [ ] `bun run type-check` and `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)