### PR TITLE
GDPR compliance: consent gating, account deletion, data export, privacy policy

### DIFF
--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -1,0 +1,223 @@
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || '';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function getServiceClient() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+async function getUserFromToken(authHeader: string): Promise<{ id: string; email: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { id: data.user.id, email: data.user.email || '' };
+}
+
+// ── DELETE /api/account ──────────────────────────────────────────────
+// Permanently deletes the authenticated user's account and all associated data.
+router.delete('/api/account', async (req: Request, res: Response) => {
+  try {
+    const user = await getUserFromToken(req.headers.authorization || '');
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const supabase = getServiceClient();
+    const userId = user.id;
+
+    // Delete user data in dependency order (children before parents).
+    // Using service role key bypasses RLS so we can clean up everything.
+
+    // 1. AI chat messages & threads
+    const { data: threads } = await supabase
+      .from('ai_chat_threads')
+      .select('id')
+      .eq('user_id', userId);
+    if (threads?.length) {
+      const threadIds = threads.map(t => t.id);
+      await supabase.from('ai_chat_messages').delete().in('thread_id', threadIds);
+      await supabase.from('ai_chat_threads').delete().eq('user_id', userId);
+    }
+
+    // 2. AI usage tracking
+    await supabase.from('user_ai_usage').delete().eq('user_id', userId);
+
+    // 3. Engagement & analytics
+    await supabase.from('user_engagement_events').delete().eq('user_id', userId);
+    await supabase.from('trip_view_status').delete().eq('user_id', userId);
+
+    // 4. Trip shares (both directions)
+    await supabase.from('trip_shares').delete().eq('shared_with_user_id', userId);
+
+    // 5. Trips owned by this user and all sub-entities
+    const { data: trips } = await supabase
+      .from('trips')
+      .select('id')
+      .eq('user_id', userId);
+
+    if (trips?.length) {
+      const tripIds = trips.map(t => t.id);
+
+      // Sub-entity travelers
+      for (const tripId of tripIds) {
+        const { data: activities } = await supabase
+          .from('day_activities')
+          .select('id, day_id')
+          .in('day_id', (
+            await supabase.from('trip_days').select('id').eq('trip_id', tripId)
+          ).data?.map(d => d.id) || []);
+
+        if (activities?.length) {
+          await supabase.from('day_activity_travelers').delete().in('activity_id', activities.map(a => a.id));
+        }
+
+        const { data: accommodations } = await supabase
+          .from('accommodations')
+          .select('id')
+          .eq('trip_id', tripId);
+        if (accommodations?.length) {
+          const accIds = accommodations.map(a => a.id);
+          await supabase.from('accommodation_travelers').delete().in('accommodation_id', accIds);
+          await supabase.from('accommodations_days').delete().in('accommodation_id', accIds);
+        }
+
+        const { data: transports } = await supabase
+          .from('transportation')
+          .select('id')
+          .eq('trip_id', tripId);
+        if (transports?.length) {
+          await supabase.from('transportation_travelers').delete().in('transportation_id', transports.map(t => t.id));
+        }
+
+        const { data: reservations } = await supabase
+          .from('reservations')
+          .select('id')
+          .eq('trip_id', tripId);
+        if (reservations?.length) {
+          await supabase.from('reservation_travelers').delete().in('reservation_id', reservations.map(r => r.id));
+        }
+
+        // Delete sub-entities
+        await supabase.from('day_activities').delete().in('day_id',
+          (await supabase.from('trip_days').select('id').eq('trip_id', tripId)).data?.map(d => d.id) || []
+        );
+        await supabase.from('trip_days').delete().eq('trip_id', tripId);
+        await supabase.from('accommodations').delete().eq('trip_id', tripId);
+        await supabase.from('transportation').delete().eq('trip_id', tripId);
+        await supabase.from('reservations').delete().eq('trip_id', tripId);
+        await supabase.from('other_expenses').delete().eq('trip_id', tripId);
+        await supabase.from('trip_shares').delete().eq('trip_id', tripId);
+        await supabase.from('trip_invite_links').delete().eq('trip_id', tripId);
+      }
+
+      // Delete the trips themselves
+      await supabase.from('trips').delete().eq('user_id', userId);
+    }
+
+    // 6. Profile
+    await supabase.from('profiles').delete().eq('id', userId);
+
+    // 7. Delete the auth user (must be last)
+    const { error: deleteError } = await supabase.auth.admin.deleteUser(userId);
+    if (deleteError) {
+      console.error('Failed to delete auth user:', deleteError);
+      return res.status(500).json({ error: 'Failed to delete account. Please contact support.' });
+    }
+
+    return res.json({ success: true });
+  } catch (error) {
+    console.error('Account deletion error:', error);
+    return res.status(500).json({ error: 'Failed to delete account. Please contact support.' });
+  }
+});
+
+// ── GET /api/account/export ──────────────────────────────────────────
+// Returns all personal data for the authenticated user as JSON (GDPR Article 20).
+router.get('/api/account/export', async (req: Request, res: Response) => {
+  try {
+    const user = await getUserFromToken(req.headers.authorization || '');
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const supabase = getServiceClient();
+    const userId = user.id;
+
+    // Collect all user data
+    const [
+      profileResult,
+      tripsResult,
+      sharesResult,
+      chatThreadsResult,
+      usageResult,
+      engagementResult,
+    ] = await Promise.all([
+      supabase.from('profiles').select('*').eq('id', userId).single(),
+      supabase.from('trips').select('*').eq('user_id', userId),
+      supabase.from('trip_shares').select('*').eq('shared_with_user_id', userId),
+      supabase.from('ai_chat_threads').select('*').eq('user_id', userId),
+      supabase.from('user_ai_usage').select('*').eq('user_id', userId),
+      supabase.from('user_engagement_events').select('*').eq('user_id', userId),
+    ]);
+
+    // For each trip, gather sub-entities
+    const tripDetails = [];
+    for (const trip of tripsResult.data || []) {
+      const [days, accommodations, transportation, reservations, expenses] = await Promise.all([
+        supabase.from('trip_days').select('*, day_activities(*)').eq('trip_id', trip.id),
+        supabase.from('accommodations').select('*').eq('trip_id', trip.id),
+        supabase.from('transportation').select('*').eq('trip_id', trip.id),
+        supabase.from('reservations').select('*').eq('trip_id', trip.id),
+        supabase.from('other_expenses').select('*').eq('trip_id', trip.id),
+      ]);
+
+      tripDetails.push({
+        ...trip,
+        days: days.data || [],
+        accommodations: accommodations.data || [],
+        transportation: transportation.data || [],
+        reservations: reservations.data || [],
+        expenses: expenses.data || [],
+      });
+    }
+
+    // Gather chat messages for each thread
+    const chatData = [];
+    for (const thread of chatThreadsResult.data || []) {
+      const { data: messages } = await supabase
+        .from('ai_chat_messages')
+        .select('*')
+        .eq('thread_id', thread.id)
+        .order('created_at', { ascending: true });
+
+      chatData.push({ ...thread, messages: messages || [] });
+    }
+
+    const exportData = {
+      exported_at: new Date().toISOString(),
+      account: {
+        email: user.email,
+        user_id: userId,
+      },
+      profile: profileResult.data || null,
+      trips: tripDetails,
+      shared_trips: sharesResult.data || [],
+      ai_chat: chatData,
+      ai_usage: usageResult.data || [],
+      engagement_events: engagementResult.data || [],
+    };
+
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="wanderluxe-data-export-${new Date().toISOString().split('T')[0]}.json"`);
+    return res.json(exportData);
+  } catch (error) {
+    console.error('Data export error:', error);
+    return res.status(500).json({ error: 'Failed to export data' });
+  }
+});
+
+export default router;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import aiChatRoutes from './ai-chat';
 import stripeRoutes from './stripe';
 import invitePreviewRoutes from './invite-preview';
 import adminInsightsRoutes from './admin-insights';
+import accountRoutes from './account';
 
 export function registerRoutes(app: Express) {
   // Invite preview must be registered before the SPA catch-all
@@ -13,4 +14,5 @@ export function registerRoutes(app: Express) {
   app.use(aiChatRoutes);
   app.use(stripeRoutes);
   app.use(adminInsightsRoutes);
+  app.use(accountRoutes);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ProtectedRoute from "@/components/ProtectedRoute";
 import AppLayout from "@/components/layout/AppLayout";
 import PWAInstallPrompt from "@/components/PWAInstallPrompt";
 import CookieConsentBanner from "@/components/CookieConsentBanner";
+import PostHogConsentSync from "@/components/PostHogConsentSync";
 import AdminRoute from "./components/AdminRoute";
 import { lazy, Suspense, useEffect } from "react";
 import { Loader2 } from "lucide-react";
@@ -59,6 +60,7 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <ConsentProvider>
+        <PostHogConsentSync />
         <AuthProvider>
           <TooltipProvider>
             <Toaster />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useConsent } from '@/contexts/ConsentContext';
 
 const Footer = () => {
+  const { resetConsent } = useConsent();
+
   return (
     <footer className="py-6 border-t mt-auto">
       <div className="w-full">
@@ -25,12 +28,18 @@ const Footer = () => {
             >
               Terms of Service
             </Link>
-            <Link 
-              to="/privacy" 
+            <Link
+              to="/privacy"
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               Privacy Policy
             </Link>
+            <button
+              onClick={resetConsent}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Manage Cookies
+            </button>
           </div>
           <p className="text-xs text-muted-foreground text-center mt-4">
             This site uses <i>Google Maps</i>. By using this site, you agree to their <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="underline">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer" className="underline">Terms of Service</a>.

--- a/src/components/PostHogConsentSync.tsx
+++ b/src/components/PostHogConsentSync.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import posthog from 'posthog-js';
+import { useConsent } from '@/contexts/ConsentContext';
+
+/**
+ * Syncs PostHog capturing state with the user's cookie consent preferences.
+ * Opts in to capturing only when the user has explicitly consented to analytics.
+ * Must be rendered inside ConsentProvider.
+ */
+export default function PostHogConsentSync() {
+  const { hasConsented, preferences } = useConsent();
+
+  useEffect(() => {
+    if (!import.meta.env.VITE_POSTHOG_KEY) return;
+
+    if (hasConsented && preferences.analytics) {
+      posthog.opt_in_capturing();
+      posthog.capture('$pageview');
+    } else {
+      posthog.opt_out_capturing();
+    }
+  }, [hasConsented, preferences.analytics]);
+
+  return null;
+}

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -134,6 +134,9 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
           </p>
         </div>
         {emptyStateSlot}
+        <p className="text-[11px] text-sand-400 max-w-[280px] text-center leading-relaxed">
+          Your trip details are shared with OpenAI to provide personalized recommendations. Messages are not used to train AI models.
+        </p>
       </div>
     );
   }

--- a/src/contexts/ConsentContext.tsx
+++ b/src/contexts/ConsentContext.tsx
@@ -24,6 +24,8 @@ interface ConsentContextType {
   acceptCustom: (preferences: Omit<ConsentPreferences, 'essential'>) => void;
   // Check if a specific category is consented
   hasConsentFor: (category: keyof ConsentPreferences) => boolean;
+  // Reset consent so the banner reappears (for "Manage Cookies")
+  resetConsent: () => void;
 }
 
 const STORAGE_KEY = "wlx:gdpr:consent";
@@ -44,6 +46,7 @@ const ConsentContext = createContext<ConsentContextType>({
   acceptEssentialOnly: () => {},
   acceptCustom: () => {},
   hasConsentFor: () => false,
+  resetConsent: () => {},
 });
 
 // Helper to safely access localStorage
@@ -126,6 +129,7 @@ export const ConsentProvider = ({ children }: { children: React.ReactNode }) => 
   const [preferences, setPreferences] = useState<ConsentPreferences>(defaultPreferences);
   const [isUSBased, setIsUSBased] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [manuallyReset, setManuallyReset] = useState(false);
 
   // Load stored consent on mount
   useEffect(() => {
@@ -176,6 +180,7 @@ export const ConsentProvider = ({ children }: { children: React.ReactNode }) => 
     setStorageItem(STORAGE_KEY, JSON.stringify(stored));
     setPreferences(newPreferences);
     setHasConsented(true);
+    setManuallyReset(false);
   }, []);
 
   const acceptAll = useCallback(() => {
@@ -206,11 +211,23 @@ export const ConsentProvider = ({ children }: { children: React.ReactNode }) => 
     return hasConsented && preferences[category];
   }, [hasConsented, preferences]);
 
+  const resetConsent = useCallback(() => {
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // Ignore storage errors
+    }
+    setPreferences(defaultPreferences);
+    setHasConsented(false);
+    setManuallyReset(true);
+  }, []);
+
   // Determine if banner should show:
-  // - User hasn't consented yet
-  // - User is not in the US (or geo check failed)
+  // - User hasn't consented yet AND (not US-based OR user manually opened cookie settings)
   // - Geo check has completed
-  const shouldShowBanner = !isLoading && !hasConsented && !isUSBased;
+  const shouldShowBanner = !isLoading && !hasConsented && (!isUSBased || manuallyReset);
 
   const contextValue = useMemo(
     () => ({
@@ -222,8 +239,9 @@ export const ConsentProvider = ({ children }: { children: React.ReactNode }) => 
       acceptEssentialOnly,
       acceptCustom,
       hasConsentFor,
+      resetConsent,
     }),
-    [hasConsented, shouldShowBanner, preferences, isLoading, acceptAll, acceptEssentialOnly, acceptCustom, hasConsentFor]
+    [hasConsented, shouldShowBanner, preferences, isLoading, acceptAll, acceptEssentialOnly, acceptCustom, hasConsentFor, resetConsent]
   );
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,18 @@ import { PostHogProvider } from 'posthog-js/react'
 import App from './App.tsx'
 import './index.css'
 
-// Initialize PostHog analytics
+// Initialize PostHog with capturing disabled by default.
+// The PostHogConsentSync component (inside the React tree) will
+// opt-in only after the user grants analytics consent.
 const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
 if (posthogKey) {
   posthog.init(posthogKey, {
     api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
     person_profiles: 'identified_only',
-    capture_pageview: true,
-    capture_pageleave: true,
+    capture_pageview: false,
+    capture_pageleave: false,
+    autocapture: false,
+    opt_out_capturing_by_default: true,
   });
 }
 

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -9,62 +9,186 @@ const PrivacyPolicy: React.FC = () => {
       <div className="container mx-auto px-4 md:px-6 py-12 flex-grow">
         <div className="max-w-4xl mx-auto p-6 md:p-8">
           <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">
-            Privacy Policy for WanderLuxe
+            Privacy Policy
           </h1>
-          <section className="space-y-10">
+          <section className="space-y-10 text-sm leading-relaxed text-muted-foreground">
             <div className="pb-6 border-b">
               <h2 className="text-2xl font-semibold mb-4 text-foreground">1. Introduction</h2>
               <p>
-                Welcome to <strong>WanderLuxe</strong>, operated by <strong>Wanderluxe Travel LLC</strong>. This Privacy Policy explains how we collect, use, and safeguard your information when you visit our website.
+                Welcome to <strong>WanderLuxe</strong>, operated by <strong>Wanderluxe Travel LLC</strong> ("we", "us", "our"). This Privacy Policy explains how we collect, use, store, share, and protect your personal data when you use our website and services at <strong>wanderluxe.io</strong>.
+              </p>
+              <p className="mt-2">
+                We are committed to protecting your privacy and processing your data in accordance with the General Data Protection Regulation (GDPR), the California Consumer Privacy Act (CCPA/CPRA), and other applicable data protection laws.
               </p>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">2. Information We Collect</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">2. Data Controller</h2>
               <p>
-                We may collect personal data such as your name, email address, and other relevant details when you register for an account or use our services. Additionally, non-personal data is collected automatically via cookies and similar technologies.
+                Wanderluxe Travel LLC is the data controller for the personal data collected through our services. For questions about this policy or to exercise your rights, contact us at:{' '}
+                <a href="mailto:privacy@wanderluxe.io" className="text-primary hover:underline">
+                  privacy@wanderluxe.io
+                </a>
               </p>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">3. How We Use Your Information</h2>
-              <p>
-                Your information is used to provide, enhance, and personalize our services, as well as to communicate with you about updates or promotions. We may also use your data for internal analytics.
-              </p>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">3. Personal Data We Collect</h2>
+              <p className="mb-3">We collect the following categories of personal data:</p>
+
+              <h3 className="font-semibold text-foreground mt-4 mb-2">Data you provide directly</h3>
+              <ul className="list-disc list-inside space-y-1">
+                <li><strong>Account information:</strong> name, email address, profile photo</li>
+                <li><strong>Trip data:</strong> destinations, travel dates, itineraries, bookings, dining reservations, transportation details, and expenses</li>
+                <li><strong>AI chat conversations:</strong> messages you send to our AI travel assistant, along with trip context used to generate responses</li>
+                <li><strong>Payment information:</strong> processed by Stripe (we do not store your card details)</li>
+                <li><strong>Shared trip data:</strong> email addresses and names of people you share trips with</li>
+              </ul>
+
+              <h3 className="font-semibold text-foreground mt-4 mb-2">Data collected automatically</h3>
+              <ul className="list-disc list-inside space-y-1">
+                <li><strong>Usage analytics:</strong> page views, feature usage, and engagement events (only with your consent for non-essential tracking)</li>
+                <li><strong>Device information:</strong> browser type, operating system, screen resolution</li>
+                <li><strong>Location data:</strong> approximate country (via IP address) for consent banner display only; not stored</li>
+              </ul>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">4. Sharing Your Information</h2>
-              <p>
-                We do not sell your personal information. We may share your data with trusted third-party providers who assist in operating our website and delivering our services, under strict confidentiality agreements.
-              </p>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">4. How We Use Your Data</h2>
+              <p className="mb-3">We process your data for the following purposes and lawful bases:</p>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-2 pr-4 font-semibold text-foreground">Purpose</th>
+                      <th className="text-left py-2 font-semibold text-foreground">Lawful Basis (GDPR)</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    <tr><td className="py-2 pr-4">Providing and maintaining our services</td><td className="py-2">Contract performance</td></tr>
+                    <tr><td className="py-2 pr-4">Processing payments</td><td className="py-2">Contract performance</td></tr>
+                    <tr><td className="py-2 pr-4">AI-powered trip recommendations</td><td className="py-2">Contract performance</td></tr>
+                    <tr><td className="py-2 pr-4">Sending service-related emails (trip shares, invites)</td><td className="py-2">Contract performance</td></tr>
+                    <tr><td className="py-2 pr-4">Analytics and product improvement</td><td className="py-2">Consent</td></tr>
+                    <tr><td className="py-2 pr-4">Marketing communications</td><td className="py-2">Consent</td></tr>
+                    <tr><td className="py-2 pr-4">Fraud prevention and security</td><td className="py-2">Legitimate interest</td></tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">5. Data Security</h2>
-              <p>
-                We implement various security measures to protect your information. However, no method of transmission over the internet is completely secure, and we cannot guarantee absolute security.
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">5. Third-Party Data Processors</h2>
+              <p className="mb-3">We share your data with the following third-party service providers who process data on our behalf:</p>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-2 pr-4 font-semibold text-foreground">Provider</th>
+                      <th className="text-left py-2 pr-4 font-semibold text-foreground">Purpose</th>
+                      <th className="text-left py-2 font-semibold text-foreground">Data Shared</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    <tr><td className="py-2 pr-4">Supabase</td><td className="py-2 pr-4">Database and authentication</td><td className="py-2">Account data, trip data, all stored information</td></tr>
+                    <tr><td className="py-2 pr-4">OpenAI</td><td className="py-2 pr-4">AI travel assistant</td><td className="py-2">Chat messages and trip context (destination, dates, itinerary)</td></tr>
+                    <tr><td className="py-2 pr-4">Stripe</td><td className="py-2 pr-4">Payment processing</td><td className="py-2">Email, payment details</td></tr>
+                    <tr><td className="py-2 pr-4">PostHog</td><td className="py-2 pr-4">Analytics (consent-gated)</td><td className="py-2">Usage events, device info</td></tr>
+                    <tr><td className="py-2 pr-4">Google</td><td className="py-2 pr-4">Places API (location search)</td><td className="py-2">Search queries</td></tr>
+                    <tr><td className="py-2 pr-4">SendGrid</td><td className="py-2 pr-4">Transactional email</td><td className="py-2">Recipient email, message content</td></tr>
+                    <tr><td className="py-2 pr-4">Unsplash</td><td className="py-2 pr-4">Trip imagery</td><td className="py-2">Search queries (no personal data)</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-3">
+                We do not sell your personal data to any third party. Data shared with processors is limited to what is necessary for the specified purpose.
               </p>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">6. Your Rights</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">6. International Data Transfers</h2>
               <p>
-                You have the right to access, update, or delete your personal information. If you have any questions or concerns regarding our privacy practices, please contact us at{' '}
-                <a href="mailto:info@wanderluxe.io" className="text-primary hover:underline">
-                  info@wanderluxe.io
-                </a>.
+                Your data may be transferred to and processed in the United States, where our service providers are located. For transfers from the EU/EEA, we rely on Standard Contractual Clauses (SCCs) and processor agreements to ensure adequate protection of your data.
               </p>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">7. Cookies and Tracking Technologies</h2>
-              <p>
-                We use cookies and similar tracking technologies to enhance your experience on our site and to gather data on usage patterns. You can adjust your browser settings to refuse cookies, though this may impact site functionality.
-              </p>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">7. Data Retention</h2>
+              <ul className="list-disc list-inside space-y-1">
+                <li><strong>Account and trip data:</strong> retained while your account is active; deleted upon account deletion</li>
+                <li><strong>AI chat history:</strong> retained while your account is active; deleted upon account deletion</li>
+                <li><strong>Analytics data:</strong> retained for up to 12 months</li>
+                <li><strong>Payment records:</strong> retained as required by applicable tax and financial regulations</li>
+                <li><strong>Weather cache:</strong> automatically purged after 7 days</li>
+              </ul>
             </div>
+
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">8. Changes to This Privacy Policy</h2>
-              <p>
-                We may update this Privacy Policy from time to time. Any changes will be posted on this page along with an updated effective date.
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">8. Your Rights</h2>
+              <p className="mb-3">Under GDPR, CCPA/CPRA, and other applicable laws, you have the right to:</p>
+              <ul className="list-disc list-inside space-y-1">
+                <li><strong>Access:</strong> request a copy of your personal data</li>
+                <li><strong>Portability:</strong> download your data in a structured, machine-readable format (JSON)</li>
+                <li><strong>Rectification:</strong> correct inaccurate personal data</li>
+                <li><strong>Erasure:</strong> permanently delete your account and all associated data</li>
+                <li><strong>Restriction:</strong> restrict how we process your data</li>
+                <li><strong>Objection:</strong> object to processing based on legitimate interest</li>
+                <li><strong>Withdraw consent:</strong> withdraw consent for analytics and marketing cookies at any time</li>
+                <li><strong>Opt-out of sale/sharing:</strong> we do not sell or share your personal information for cross-context behavioral advertising</li>
+              </ul>
+              <p className="mt-3">
+                <strong>How to exercise your rights:</strong> You can download your data and delete your account directly from your{' '}
+                <a href="/profile" className="text-primary hover:underline">Profile page</a>. You can manage cookie preferences via the "Manage Cookies" link in the footer. For other requests, email{' '}
+                <a href="mailto:privacy@wanderluxe.io" className="text-primary hover:underline">privacy@wanderluxe.io</a>.
+              </p>
+              <p className="mt-2">
+                We will respond to data subject requests within 30 days (GDPR) or 45 days (CCPA). You also have the right to lodge a complaint with your local supervisory authority.
               </p>
             </div>
+
+            <div className="pb-6 border-b">
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">9. Cookies and Tracking</h2>
+              <p className="mb-3">We use the following categories of cookies:</p>
+              <ul className="list-disc list-inside space-y-1">
+                <li><strong>Essential cookies:</strong> required for authentication and core functionality (always active)</li>
+                <li><strong>Analytics cookies:</strong> help us understand usage patterns via PostHog (requires your consent)</li>
+                <li><strong>Marketing cookies:</strong> used for personalized content (requires your consent)</li>
+              </ul>
+              <p className="mt-3">
+                You can manage your cookie preferences at any time using the "Manage Cookies" link in the website footer. Non-US users are prompted to set preferences before any optional cookies are activated. Analytics tracking is completely disabled until you opt in.
+              </p>
+            </div>
+
+            <div className="pb-6 border-b">
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">10. AI Data Processing</h2>
+              <p>
+                When you use our AI travel assistant, your trip details (destination, dates, itinerary, accommodations, and transportation) are sent to OpenAI to generate personalized recommendations. Your messages are processed in real-time and are not used to train OpenAI's models. AI chat history is stored in your account and can be deleted at any time by deleting your account.
+              </p>
+            </div>
+
+            <div className="pb-6 border-b">
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">11. Data Security</h2>
+              <p>
+                We implement security measures to protect your data, including: encrypted data transmission (HTTPS/TLS), database-level Row Level Security (RLS) policies ensuring you can only access your own data, secure authentication via Supabase Auth with Google OAuth support, and automatic session token refresh. No method of transmission over the internet is completely secure, and we cannot guarantee absolute security.
+              </p>
+            </div>
+
+            <div className="pb-6 border-b">
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">12. Children's Privacy</h2>
+              <p>
+                Our services are not directed at children under 16. We do not knowingly collect personal data from children. If you believe a child has provided us with personal data, contact us and we will delete it.
+              </p>
+            </div>
+
+            <div className="pb-6 border-b">
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">13. Changes to This Policy</h2>
+              <p>
+                We may update this Privacy Policy from time to time. Material changes will be communicated via email or an in-app notice. The "Last updated" date below indicates the most recent revision.
+              </p>
+            </div>
+
             <div className="pt-8 border-t text-center text-sm text-muted-foreground">
-              Last updated: February 2025
+              Last updated: April 2026
             </div>
           </section>
         </div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -11,7 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
-import { Crown, Check, Camera, Calendar, AlertCircle, ChevronRight, Clock } from "lucide-react";
+import { Crown, Check, Camera, Calendar, AlertCircle, ChevronRight, Clock, Download, Trash2, ShieldAlert } from "lucide-react";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useNavigate } from "react-router-dom";
@@ -400,6 +400,204 @@ const ContactRow: React.FC<{ contact: ContactItem; onClick: (c: ContactItem) => 
         <ChevronRight className="h-4 w-4 text-muted-foreground inline-block" />
       </TableCell>
     </TableRow>
+  );
+};
+
+const DataPrivacySection: React.FC = () => {
+  const [exportingData, setExportingData] = useState(false);
+  const [deletingAccount, setDeletingAccount] = useState(false);
+  const [showDeleteWarning, setShowDeleteWarning] = useState(false);
+  const [showFinalConfirm, setShowFinalConfirm] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+
+  const handleExportData = async () => {
+    try {
+      setExportingData(true);
+      const token = await getAuthToken();
+      if (!token) { toast.error('Please sign in'); return; }
+
+      const resp = await fetch('/api/account/export', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!resp.ok) {
+        const data = await resp.json();
+        toast.error(data.error || 'Failed to export data');
+        return;
+      }
+
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `wanderluxe-data-export-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.success('Data exported successfully');
+    } catch {
+      toast.error('Failed to export data');
+    } finally {
+      setExportingData(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    try {
+      setDeletingAccount(true);
+      const token = await getAuthToken();
+      if (!token) { toast.error('Please sign in'); return; }
+
+      const resp = await fetch('/api/account', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!resp.ok) {
+        const data = await resp.json();
+        toast.error(data.error || 'Failed to delete account');
+        return;
+      }
+
+      // Sign out and redirect
+      await supabase.auth.signOut();
+      toast.success('Your account has been permanently deleted');
+      window.location.href = '/';
+    } catch {
+      toast.error('Failed to delete account');
+    } finally {
+      setDeletingAccount(false);
+    }
+  };
+
+  return (
+    <div className="bg-background rounded-lg shadow">
+      <div className="p-6">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="p-2 rounded-full bg-sand-100">
+            <ShieldAlert className="h-5 w-5 text-sand-600" />
+          </div>
+          <div>
+            <h2 className="text-lg font-medium">Data & Privacy</h2>
+            <p className="text-sm text-muted-foreground">
+              Manage your personal data and account
+            </p>
+          </div>
+        </div>
+
+        <Separator className="mb-4" />
+
+        <div className="space-y-4">
+          {/* Download My Data */}
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">Download my data</p>
+              <p className="text-xs text-muted-foreground">
+                Get a copy of all your personal data in JSON format
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleExportData}
+              disabled={exportingData}
+              className="border-sand-300"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              {exportingData ? 'Exporting...' : 'Export'}
+            </Button>
+          </div>
+
+          <Separator />
+
+          {/* Delete Account */}
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-destructive">Delete account</p>
+              <p className="text-xs text-muted-foreground">
+                Permanently delete your account and all associated data
+              </p>
+            </div>
+            <AlertDialog open={showDeleteWarning} onOpenChange={(open) => {
+              setShowDeleteWarning(open);
+              if (!open) { setShowFinalConfirm(false); setConfirmText(''); }
+            }}>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-red-200 text-destructive hover:bg-red-50"
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle className="flex items-center gap-2 text-destructive">
+                    <AlertCircle className="h-5 w-5" />
+                    Delete your account?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription asChild>
+                    <div className="space-y-3">
+                      <p>
+                        This action is <strong>permanent and cannot be undone</strong>. The following will be deleted:
+                      </p>
+                      <ul className="list-disc list-inside text-sm space-y-1 text-muted-foreground">
+                        <li>Your profile and account information</li>
+                        <li>All trips you created (including itineraries, bookings, and expenses)</li>
+                        <li>All AI chat conversations</li>
+                        <li>Your subscription (if applicable)</li>
+                        <li>All shared trip connections</li>
+                      </ul>
+                      <p className="text-sm font-medium">
+                        We recommend downloading your data first before proceeding.
+                      </p>
+
+                      {!showFinalConfirm ? (
+                        <Button
+                          variant="destructive"
+                          className="w-full mt-2"
+                          onClick={() => setShowFinalConfirm(true)}
+                        >
+                          I understand, continue
+                        </Button>
+                      ) : (
+                        <div className="space-y-3 mt-2 p-3 bg-red-50 rounded-lg border border-red-200">
+                          <p className="text-sm font-medium text-destructive">
+                            Type <strong>DELETE</strong> to confirm:
+                          </p>
+                          <Input
+                            value={confirmText}
+                            onChange={(e) => setConfirmText(e.target.value)}
+                            placeholder="Type DELETE"
+                            className="border-red-200"
+                            autoFocus
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  {showFinalConfirm && (
+                    <Button
+                      variant="destructive"
+                      onClick={handleDeleteAccount}
+                      disabled={confirmText !== 'DELETE' || deletingAccount}
+                    >
+                      {deletingAccount ? 'Deleting...' : 'Permanently delete my account'}
+                    </Button>
+                  )}
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -847,6 +1045,9 @@ const Profile = () => {
               />
             </div>
           </div>
+
+          {/* Data & Privacy Card */}
+          <DataPrivacySection />
 
           {/* Sign Out Link */}
           <div className="mt-8 text-center">


### PR DESCRIPTION
## Summary
- **Gate PostHog on consent** — analytics disabled by default, only activated after user opts in via cookie banner. Fixes the #1 GDPR violation.
- **Account deletion** — new "Data & Privacy" section on Profile page with 2-step confirmation (warning screen + type DELETE). Server-side cascade deletes all user data across all tables.
- **Data export** — "Download my data" button on Profile page, exports all personal data as JSON (GDPR Article 20 portability).
- **Manage Cookies** — footer link to reopen cookie consent banner and change preferences (works for all users including US).
- **AI data disclosure** — notice in chat empty state informing users their trip details are shared with OpenAI.
- **Privacy policy rewrite** — full GDPR-compliant policy with lawful bases, named third-party processors, data retention periods, full rights enumeration, international transfer disclosure, AI processing section.

## Test plan
- [ ] Verify PostHog does NOT capture events before cookie consent is given
- [ ] Verify PostHog starts capturing after accepting analytics cookies
- [ ] Test "Manage Cookies" footer link reopens the consent banner
- [ ] Test "Download my data" exports a JSON file with all user data
- [ ] Test "Delete account" flow: warning screen → type DELETE → account deleted
- [ ] Verify deleted user cannot log in and data is gone from DB
- [ ] Check AI chat empty state shows OpenAI data disclosure notice
- [ ] Review updated privacy policy at /privacy for completeness
- [ ] All 159 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)