### PR TITLE
Implement opt-in chat history loading with cursor-based pagination

### DIFF
--- a/server/routes/ai-chat.ts
+++ b/server/routes/ai-chat.ts
@@ -450,6 +450,13 @@ async function streamOpenAIResponse(
 
   const decoder = new TextDecoder();
   let fullResponse = '';
+  // Buffer trailing bytes that could form a "```create_items" marker so we can
+  // suppress the whole fence atomically instead of leaking partial backticks.
+  let pendingTail = '';
+  let suppressing = false;
+
+  // Matches a tail that could still grow into "```create_items".
+  const PARTIAL_MARKER_RE = /`{1,3}(c(r(e(a(t(e(_(i(t(e(m(s)?)?)?)?)?)?)?)?)?)?)?)?$/;
 
   try {
     while (true) {
@@ -462,11 +469,39 @@ async function streamOpenAIResponse(
         if (!content) continue;
 
         fullResponse += content;
-        const shouldFilter = options.filterCreateItems && fullResponse.includes('```create_items');
-        if (!shouldFilter) {
+
+        if (!options.filterCreateItems) {
           sendSSE(res, 'message', { content });
+          continue;
+        }
+
+        if (suppressing) continue;
+
+        if (fullResponse.includes('```create_items')) {
+          // Full marker landed — stop forwarding and drop any buffered tail
+          // that was leading up to it.
+          suppressing = true;
+          pendingTail = '';
+          continue;
+        }
+
+        const combined = pendingTail + content;
+        const match = combined.match(PARTIAL_MARKER_RE);
+
+        if (match) {
+          const safe = combined.slice(0, combined.length - match[0].length);
+          pendingTail = match[0];
+          if (safe) sendSSE(res, 'message', { content: safe });
+        } else {
+          if (combined) sendSSE(res, 'message', { content: combined });
+          pendingTail = '';
         }
       }
+    }
+
+    // Stream ended without a create_items block — flush buffered tail.
+    if (options.filterCreateItems && !suppressing && pendingTail) {
+      sendSSE(res, 'message', { content: pendingTail });
     }
   } catch (streamError) {
     console.error('Stream error:', streamError);
@@ -738,28 +773,34 @@ router.get('/api/trips/:tripId/assistant/messages', async (req: Request, res: Re
       return res.json({ messages: [], thread_id: null, hasMore: false });
     }
 
-    // Support pagination
-    const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
-    const offset = parseInt(req.query.offset as string) || 0;
+    // Cursor-based pagination: "before" is an ISO timestamp; returns the newest
+    // `limit` messages created strictly before that cursor. Without a cursor,
+    // returns the newest `limit` messages overall. Responses are always in
+    // chronological (ascending) order. Fetch one extra to detect hasMore.
+    const limit = Math.min(parseInt(req.query.limit as string) || 10, 100);
+    const before = typeof req.query.before === 'string' ? req.query.before : null;
 
-    // Get total count for hasMore
-    const { count } = await supabase
-      .from('ai_chat_messages')
-      .select('id', { count: 'exact', head: true })
-      .eq('thread_id', thread.id);
-
-    // Get messages with pagination (newest first for offset, then reverse)
-    const { data: messages } = await supabase
+    let query = supabase
       .from('ai_chat_messages')
       .select('id, role, content, metadata, created_at')
-      .eq('thread_id', thread.id)
-      .order('created_at', { ascending: true })
-      .range(offset, offset + limit - 1);
+      .eq('thread_id', thread.id);
+
+    if (before) {
+      query = query.lt('created_at', before);
+    }
+
+    const { data: messages } = await query
+      .order('created_at', { ascending: false })
+      .limit(limit + 1);
+
+    const rawMessages = messages || [];
+    const hasMore = rawMessages.length > limit;
+    const chronological = rawMessages.slice(0, limit).reverse();
 
     return res.json({
-      messages: messages || [],
+      messages: chronological,
       thread_id: thread.id,
-      hasMore: (count || 0) > offset + limit
+      hasMore
     });
   } catch (error) {
     console.error('Error getting messages:', error);
@@ -950,7 +991,7 @@ router.post('/api/trips/:tripId/assistant', async (req: Request, res: Response) 
 
     setupSSEHeaders(res);
 
-    const result = await streamOpenAIResponse(openaiMessages, res, { maxTokens: 1000 });
+    const result = await streamOpenAIResponse(openaiMessages, res, { maxTokens: 1000, filterCreateItems: true });
     if (!result) return;
 
     const { cleanContent, extractedItems } = parseCreateItemsBlock(result.fullResponse);
@@ -968,7 +1009,14 @@ router.post('/api/trips/:tripId/assistant', async (req: Request, res: Response) 
       });
     }
 
-    sendSSE(res, 'done', { thread_id: threadId, message_id: assistantMessageId });
+    // Send the sanitized content so the client displays the clean version
+    // instead of the accumulated stream (which may contain a partial
+    // ```create_items marker that slipped through before the filter engaged).
+    sendSSE(res, 'done', {
+      thread_id: threadId,
+      message_id: assistantMessageId,
+      content: cleanContent
+    });
     res.end();
   } catch (error) {
     handleStreamError(res, error, 'Chat error');

--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -115,9 +115,12 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
     usage,
     hasMore,
     isLoadingMore,
+    isAnonymous,
+    historyLoaded,
     sendMessage,
     clearThread,
-    loadMoreMessages
+    loadMoreMessages,
+    loadHistory
   } = useAIAssistant({
     tripId,
     onLimitReached: handleLimitReached,
@@ -322,6 +325,8 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
                 hasMore={hasMore}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={loadMoreMessages}
+                historyLoaded={isAnonymous || historyLoaded}
+                onLoadHistory={loadHistory}
                 tripId={tripId}
                 onImportAll={handleImportAll}
                 onReviewEdit={handleReviewEdit}

--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -115,7 +115,6 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
     usage,
     hasMore,
     isLoadingMore,
-    isAnonymous,
     historyLoaded,
     sendMessage,
     clearThread,
@@ -325,7 +324,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
                 hasMore={hasMore}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={loadMoreMessages}
-                historyLoaded={isAnonymous || historyLoaded}
+                historyLoaded={historyLoaded}
                 onLoadHistory={loadHistory}
                 tripId={tripId}
                 onImportAll={handleImportAll}

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -289,7 +289,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
               hasMore={hasMore}
               isLoadingMore={isLoadingMore}
               onLoadMore={loadMoreMessages}
-              historyLoaded={isAnonymous || historyLoaded}
+              historyLoaded={historyLoaded}
               onLoadHistory={loadHistory}
               tripId={tripId}
               onImportAll={handleImportAll}

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -100,9 +100,11 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
     hasMore,
     isLoadingMore,
     isAnonymous,
+    historyLoaded,
     sendMessage,
     clearThread,
-    loadMoreMessages
+    loadMoreMessages,
+    loadHistory
   } = useAIAssistant({
     tripId,
     onLimitReached: handleLimitReached,
@@ -287,6 +289,8 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
               hasMore={hasMore}
               isLoadingMore={isLoadingMore}
               onLoadMore={loadMoreMessages}
+              historyLoaded={isAnonymous || historyLoaded}
+              onLoadHistory={loadHistory}
               tripId={tripId}
               onImportAll={handleImportAll}
               onReviewEdit={handleReviewEdit}

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -11,6 +11,8 @@ interface ChatMessageListProps {
   hasMore?: boolean;
   isLoadingMore?: boolean;
   onLoadMore?: () => void;
+  historyLoaded?: boolean;
+  onLoadHistory?: () => void;
   tripId?: string;
   onImportAll?: (items: ExtractedItem[]) => Promise<void>;
   onReviewEdit?: (items: ExtractedItem[]) => void;
@@ -26,6 +28,8 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
   hasMore = false,
   isLoadingMore = false,
   onLoadMore,
+  historyLoaded = true,
+  onLoadHistory,
   tripId,
   onImportAll,
   onReviewEdit,
@@ -103,13 +107,15 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
 
       const container = containerRef.current;
 
-      // Load more when near top
-      if (hasMore && !isLoadingMore && onLoadMore && container.scrollTop < 50) {
+      // Load more when near top — only after user has opted into history,
+      // otherwise they'd be surprised by auto-loading when the feature was
+      // supposed to be behind the "Show older chats" button.
+      if (historyLoaded && hasMore && !isLoadingMore && onLoadMore && container.scrollTop < 50) {
         prevScrollHeightRef.current = container.scrollHeight;
         onLoadMore();
       }
     });
-  }, [hasMore, isLoadingMore, onLoadMore]);
+  }, [historyLoaded, hasMore, isLoadingMore, onLoadMore]);
 
   if (isLoading) {
     return (
@@ -122,21 +128,52 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
     );
   }
 
+  // "Show older chats" control — shown before history has been loaded. Once
+  // the user clicks it we fetch the newest page and hand further loading off
+  // to the scroll-to-top behavior (hasMore).
+  const showLoadHistoryButton = !historyLoaded && !!onLoadHistory;
+
+  const loadHistoryControl = showLoadHistoryButton ? (
+    <div className="flex justify-center py-2">
+      <button
+        type="button"
+        onClick={onLoadHistory}
+        disabled={isLoadingMore}
+        className="flex items-center gap-1.5 text-xs text-sand-500 hover:text-earth-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors px-3 py-1.5 rounded-full hover:bg-sand-100"
+      >
+        {isLoadingMore ? (
+          <>
+            <Loader2 className="w-3 h-3 animate-spin" />
+            <span>Loading older chats...</span>
+          </>
+        ) : (
+          <>
+            <ChevronUp className="w-3 h-3" />
+            <span>Show older chats</span>
+          </>
+        )}
+      </button>
+    </div>
+  ) : null;
+
   if (messages.length === 0 && !isStreaming) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center px-5 py-4 gap-5">
-        <div className="flex flex-col items-center gap-2 text-center">
-          <div className="w-10 h-10 rounded-full bg-sand-100 flex items-center justify-center">
-            <Sparkles className="w-5 h-5 text-earth-500" />
+      <div className="flex-1 flex flex-col min-h-0 overflow-y-auto">
+        {loadHistoryControl}
+        <div className="flex-1 flex flex-col items-center justify-center px-5 py-4 gap-5">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <div className="w-10 h-10 rounded-full bg-sand-100 flex items-center justify-center">
+              <Sparkles className="w-5 h-5 text-earth-500" />
+            </div>
+            <p className="text-sm text-sand-500 max-w-[260px]">
+              Ask me anything about your trip — recommendations, scheduling, packing tips, and more.
+            </p>
           </div>
-          <p className="text-sm text-sand-500 max-w-[260px]">
-            Ask me anything about your trip — recommendations, scheduling, packing tips, and more.
+          {emptyStateSlot}
+          <p className="text-[11px] text-sand-400 max-w-[280px] text-center leading-relaxed">
+            Your trip details are shared with OpenAI to provide personalized recommendations. Messages are not used to train AI models.
           </p>
         </div>
-        {emptyStateSlot}
-        <p className="text-[11px] text-sand-400 max-w-[280px] text-center leading-relaxed">
-          Your trip details are shared with OpenAI to provide personalized recommendations. Messages are not used to train AI models.
-        </p>
       </div>
     );
   }
@@ -160,8 +197,11 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
       className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain px-4 py-2 space-y-1 touch-pan-y"
       style={{ WebkitOverflowScrolling: 'touch', overscrollBehavior: 'contain' }}
     >
-      {/* Load more indicator at top */}
-      {hasMore && (
+      {/* "Show older chats" button (before history loaded) */}
+      {loadHistoryControl}
+
+      {/* Load more indicator at top (after history loaded, more exist) */}
+      {historyLoaded && hasMore && (
         <div className="flex justify-center py-2">
           {isLoadingMore ? (
             <div className="flex items-center gap-2 text-sand-400 text-xs">

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -668,7 +668,9 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
     hasMore,
     isLoadingMore,
     isAnonymous,
-    historyLoaded,
+    // Anonymous sessions have no persisted history to load, so treat them as
+    // "already loaded" to suppress the Show older chats control.
+    historyLoaded: historyLoaded || isAnonymous,
     sendMessage,
     clearThread,
     refreshUsage,

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -33,7 +33,7 @@ interface UseAIAssistantOptions {
   onItemsExtracted?: (items: ExtractedItem[]) => void;
 }
 
-const PAGE_SIZE = 5;
+const PAGE_SIZE = 10;
 
 // Helper to read/write anonymous usage from sessionStorage
 function getAnonUsageCount(): number {
@@ -194,6 +194,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
   const [hasMore, setHasMore] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isAnonymous, setIsAnonymous] = useState(false);
+  const [historyLoaded, setHistoryLoaded] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   // Helper to get auth token
@@ -217,52 +218,92 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
     return () => subscription.unsubscribe();
   }, [getAuthToken]);
 
-  // Fetch messages (initial load - last PAGE_SIZE messages)
+  // Chat messages are not auto-fetched — users opt in via `loadHistory`. The
+  // cache still backs optimistic adds and assistant streaming responses, so we
+  // keep the query wired up but disabled.
   const {
     data: messagesData,
-    isLoading: isLoadingMessages,
-    refetch: refetchMessages
+    isLoading: isLoadingMessages
   } = useQuery({
     queryKey: ['ai-assistant-messages', tripId],
     queryFn: async (): Promise<{ messages: AIChatMessage[]; thread_id: string | null; hasMore: boolean }> => {
-      const token = await getAuthToken();
-      if (!token) {
-        // Anonymous: return empty - messages are only in local cache
-        return { messages: [], thread_id: null, hasMore: false };
-      }
-
-      const response = await fetch(`${EXPRESS_BASE}/${tripId}/assistant/messages`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to load messages');
-      }
-
-      const data = await response.json();
-      setHasMore(data.hasMore || false);
-      return data;
+      // Never actually runs (enabled: false) — defensive default.
+      return { messages: [], thread_id: null, hasMore: false };
     },
-    enabled: !!tripId,
-    staleTime: 30000 // 30 seconds
+    enabled: false,
+    initialData: { messages: [], thread_id: null, hasMore: false },
+    staleTime: 30000
   });
 
-  // Load more (older) messages
-  const loadMoreMessages = useCallback(async (): Promise<void> => {
-    if (isLoadingMore || !hasMore || isAnonymous) return;
+  // Load the most recent PAGE_SIZE messages when the user opts in.
+  const loadHistory = useCallback(async (): Promise<void> => {
+    if (historyLoaded || isLoadingMore || isAnonymous) return;
 
     const token = await getAuthToken();
     if (!token) return;
 
     setIsLoadingMore(true);
     try {
-      const currentMessages = messagesData?.messages || [];
-      const offset = currentMessages.length;
-
       const response = await fetch(
-        `${EXPRESS_BASE}/${tripId}/assistant/messages?limit=${PAGE_SIZE}&offset=${offset}`,
+        `${EXPRESS_BASE}/${tripId}/assistant/messages?limit=${PAGE_SIZE}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${token}`
+          }
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('Failed to load history');
+      }
+
+      const data = await response.json();
+      setHasMore(data.hasMore || false);
+      setHistoryLoaded(true);
+
+      // Merge server messages with any session-only optimistic messages that
+      // the server hasn't sent back (e.g. streaming in-flight).
+      queryClient.setQueryData(
+        ['ai-assistant-messages', tripId],
+        (old: { messages: AIChatMessage[]; thread_id: string | null; hasMore: boolean } | undefined) => {
+          const serverMessages: AIChatMessage[] = data.messages || [];
+          const serverIds = new Set(serverMessages.map(m => m.id));
+          const localOnly = (old?.messages || []).filter(m => !serverIds.has(m.id));
+          const merged = [...serverMessages, ...localOnly].sort(
+            (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+          );
+          return {
+            messages: merged,
+            thread_id: data.thread_id ?? old?.thread_id ?? null,
+            hasMore: data.hasMore ?? false
+          };
+        }
+      );
+    } catch (err) {
+      console.error('Error loading history:', err);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [tripId, historyLoaded, isLoadingMore, isAnonymous, getAuthToken, queryClient]);
+
+  // Load older messages using cursor-based pagination anchored on the oldest
+  // message currently in the cache. Stable across new messages being sent.
+  const loadMoreMessages = useCallback(async (): Promise<void> => {
+    if (isLoadingMore || !hasMore || isAnonymous || !historyLoaded) return;
+
+    const token = await getAuthToken();
+    if (!token) return;
+
+    const currentMessages = messagesData?.messages || [];
+    if (currentMessages.length === 0) return;
+
+    // First message in cache is the oldest (messages are chronological).
+    const cursor = currentMessages[0].created_at;
+
+    setIsLoadingMore(true);
+    try {
+      const response = await fetch(
+        `${EXPRESS_BASE}/${tripId}/assistant/messages?limit=${PAGE_SIZE}&before=${encodeURIComponent(cursor)}`,
         {
           headers: {
             'Authorization': `Bearer ${token}`
@@ -291,7 +332,7 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
     } finally {
       setIsLoadingMore(false);
     }
-  }, [tripId, hasMore, isLoadingMore, isAnonymous, getAuthToken, messagesData?.messages, queryClient]);
+  }, [tripId, hasMore, isLoadingMore, isAnonymous, historyLoaded, getAuthToken, messagesData?.messages, queryClient]);
 
   // Fetch usage
   const {
@@ -627,9 +668,11 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
     hasMore,
     isLoadingMore,
     isAnonymous,
+    historyLoaded,
     sendMessage,
     clearThread,
     refreshUsage,
-    loadMoreMessages
+    loadMoreMessages,
+    loadHistory
   };
 }

--- a/src/types/ai-assistant.ts
+++ b/src/types/ai-assistant.ts
@@ -158,12 +158,14 @@ export interface UseAIAssistantReturn {
   hasMore: boolean;
   isLoadingMore: boolean;
   isAnonymous: boolean;
+  historyLoaded: boolean;
 
   // Actions
   sendMessage: (content: string) => Promise<void>;
   clearThread: () => Promise<void>;
   refreshUsage: () => Promise<void>;
   loadMoreMessages: () => Promise<void>;
+  loadHistory: () => Promise<void>;
 }
 
 // Prompt chip type


### PR DESCRIPTION
## Summary
This PR refactors the AI Assistant chat history loading to use an opt-in model instead of auto-fetching on mount, and replaces offset-based pagination with cursor-based pagination for better stability when new messages arrive.

## Key Changes

**Frontend (useAIAssistant hook & components):**
- Added `historyLoaded` state to track whether the user has opted into loading chat history
- Introduced `loadHistory()` callback that fetches the most recent `PAGE_SIZE` messages when explicitly called
- Changed initial query to be disabled (`enabled: false`) with empty initial data, preventing auto-fetch on mount
- Updated `loadMoreMessages()` to use cursor-based pagination with `before` timestamp parameter instead of offset
- Added logic to merge server messages with optimistic/streaming messages in the cache
- Increased `PAGE_SIZE` from 5 to 10 for better UX
- Updated `ChatMessageList` to show a "Show older chats" button before history is loaded
- Auto-load behavior (scroll-to-top) only triggers after user has explicitly opted in via the button

**Backend (ai-chat.ts):**
- Replaced offset-based pagination with cursor-based pagination using `before` timestamp
- Messages endpoint now returns newest `limit` messages created before the cursor, in chronological order
- Fetch one extra message to reliably detect `hasMore` without separate count query
- Improved `streamOpenAIResponse()` to properly filter `create_items` blocks by buffering partial markers and suppressing output atomically
- Added `filterCreateItems: true` option to the main chat endpoint
- Send sanitized content in the `done` SSE event to prevent partial markers from reaching the client

## Notable Implementation Details

- **Cursor stability**: Using `created_at` timestamp as cursor ensures pagination remains stable even when new messages are sent, unlike offset-based pagination
- **Message merging**: When loading history, optimistic messages already in the cache are preserved and merged with server messages to avoid losing in-flight streaming responses
- **Partial marker buffering**: The filter now buffers trailing bytes that could form a `create_items` marker, preventing incomplete backticks from leaking to the client
- **Anonymous users**: History loading is skipped for anonymous users (they only see session-local messages), but the UI treats them as if history is loaded to avoid showing the load button

https://claude.ai/code/session_01Jk8pwZMmR847gvgNytcLqH