### PR TITLE
Migrate AI assistant from OpenAI to Google Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,11 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 # Required for: Location autocomplete, accommodation search, restaurant search
 VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
-# OpenAI API (required for AI Assistant feature)
-# Get your API key from: https://platform.openai.com/api-keys
-# Required for: AI travel assistant chat functionality
-OPENAI_API_KEY=your_openai_api_key_here
+# Gemini API (required for AI Assistant feature)
+# Get your API key from: https://aistudio.google.com/app/apikey
+# Required for: AI travel assistant chat + travel document OCR
+# Model is hardcoded to gemini-2.5-flash in the Edge Function.
+GEMINI_API_KEY=your_gemini_api_key_here
 
 # Supabase Service Role Key (required for server-side operations)
 # Get this from: Supabase Dashboard → Settings → API → service_role key (secret)
@@ -46,11 +47,6 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 # =============================================================================
 # OPTIONAL VARIABLES
 # =============================================================================
-
-# OpenAI Model (optional - for AI assistant)
-# Default: gpt-4o-mini
-# Options: gpt-4o-mini, gpt-4o, gpt-4-turbo, gpt-3.5-turbo
-# OPENAI_CHAT_MODEL=gpt-4o-mini
 
 # Serper API (optional - for AI restaurant booking link search)
 # Get your API key from: https://serper.dev/api-key
@@ -97,13 +93,13 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 #   - VITE_SUPABASE_URL
 #   - VITE_SUPABASE_ANON_KEY
 #   - VITE_GOOGLE_MAPS_API_KEY
-#   - OPENAI_API_KEY (for AI assistant)
+#   - GEMINI_API_KEY (for AI assistant + travel doc OCR)
 #   - SUPABASE_SERVICE_ROLE_KEY (for server-side operations)
 #   - STRIPE_SECRET_KEY (for Pro subscriptions)
 #   - STRIPE_WEBHOOK_SECRET (for payment webhooks)
 #
 # Optional Replit Secrets:
-#   - OPENAI_CHAT_MODEL (defaults to gpt-4o-mini)
+#   - SERPER_API_KEY (for restaurant booking link search)
 #   - VITE_UNSPLASH_ACCESS_KEY
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ bun run test:coverage   # Coverage report
 - **Database**: Supabase (PostgreSQL) with Row Level Security (RLS)
 - **Real-time**: Supabase real-time subscriptions via WebSocket
 - **Backend**: Express.js + Supabase Edge Functions (Deno)
-- **AI**: OpenAI GPT-4o-mini
+- **AI**: Google Gemini 2.5 Flash (hardcoded in Edge Function + Express; no env override)
 - **Payments**: Stripe
 - **External APIs**: Google Places, SendGrid, Unsplash
 - **Testing**: Vitest
@@ -88,7 +88,7 @@ server/
 
 supabase/
 ├── functions/            # Serverless Deno functions (10 functions)
-│   ├── ai-chat/                  # AI chat via OpenAI
+│   ├── ai-chat/                  # AI chat via Gemini 2.5 Flash
 │   ├── fetch-unsplash-metadata/  # Unsplash image metadata
 │   ├── fetch-url-metadata/       # URL metadata extraction
 │   ├── generate-image/           # AI image generation
@@ -144,7 +144,7 @@ PostgreSQL database
 
 #### 5. **AI Chat Integration**
 - Chat interface: `ChatView` component in trip details
-- Backend: Calls OpenAI via `ai-chat` Edge Function
+- Backend: Calls Gemini 2.5 Flash via `ai-chat` Edge Function (with `find_place` + `search_web` function calling)
 - Data: `ai_chat_threads` + `ai_chat_messages` tables; `user_ai_usage` tracks usage
 - Real-time: Subscription to chat messages for instant updates
 - Context: Includes trip details in system prompt for location-specific recommendations
@@ -274,7 +274,7 @@ All tables have RLS policies: users can only access their own trips or shared tr
 2. Add endpoint to Express server in `server/index.ts`
 3. Handle CORS and error responses
 4. Call Supabase client for database operations
-5. Use Edge Functions for external API calls (Google Places, OpenAI, SendGrid)
+5. Use Edge Functions for external API calls (Google Places, Gemini, SendGrid)
 
 ### Adding Database Table/Migration
 1. Create SQL file in `supabase/migrations/`
@@ -336,8 +336,7 @@ Required in `.env`:
 - `VITE_SUPABASE_URL` - Supabase project URL
 - `VITE_SUPABASE_ANON_KEY` - Supabase anonymous key
 - `VITE_GOOGLE_MAPS_API_KEY` - Google Places API
-- `OPENAI_API_KEY` - OpenAI API for chat
-- `OPENAI_CHAT_MODEL` - OpenAI model selection
+- `GEMINI_API_KEY` - Google Gemini API key (used by both the chat Edge Function and `parse-travel-doc`). Model is hardcoded to `gemini-2.5-flash` in each function; no env override.
 - `SERPER_API_KEY` - (optional, Edge Function secret) Serper API for web search when recommending restaurants; enables direct Resy/OpenTable booking links
 - `STRIPE_SECRET_KEY` - Stripe payment processing
 - `STRIPE_WEBHOOK_SECRET` - Stripe webhook verification

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 # Google Places (Required for location search)
 VITE_GOOGLE_MAPS_API_KEY=your-google-api-key
 
-# OpenAI (Required for AI assistant)
-OPENAI_API_KEY=sk-your-openai-api-key
+# Gemini (Required for AI assistant + travel-doc OCR)
+# Model is hardcoded to gemini-2.5-flash in the Edge Function.
+GEMINI_API_KEY=your-gemini-api-key
 
 # SendGrid (Required for email notifications)
 SENDGRID_API_KEY=SG.your-sendgrid-api-key

--- a/server/routes/admin-insights.ts
+++ b/server/routes/admin-insights.ts
@@ -4,8 +4,11 @@ import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
-const MODEL = process.env.OPENAI_CHAT_MODEL || 'gpt-5.4-mini';
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || '';
+// Hardcoded model — locked in-process so the request path cannot redirect to
+// a different (potentially unvetted) model.
+const MODEL = 'gemini-2.5-flash';
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL || '';
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
@@ -212,35 +215,35 @@ router.post('/api/admin/insights', adminInsightsLimiter, async (req: Request, re
     res.setHeader('X-Accel-Buffering', 'no');
     res.flushHeaders();
 
-    // Call OpenAI with streaming
-    const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+    // Call Gemini with streaming
+    const geminiUrl = `${GEMINI_BASE}/models/${MODEL}:streamGenerateContent?alt=sse`;
+    const geminiResponse = await fetch(geminiUrl, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${OPENAI_API_KEY}`,
+        'x-goog-api-key': GEMINI_API_KEY,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: MODEL,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userMessage }
-        ],
-        stream: true,
-        temperature: 0.3,
-        max_completion_tokens: 1500
+        contents: [{ role: 'user', parts: [{ text: userMessage }] }],
+        systemInstruction: { parts: [{ text: systemPrompt }] },
+        generationConfig: {
+          temperature: 0.3,
+          maxOutputTokens: 1500
+        }
       })
     });
 
-    if (!openaiResponse.ok) {
-      const errorText = await openaiResponse.text();
-      console.error('OpenAI error:', openaiResponse.status, errorText);
+    if (!geminiResponse.ok) {
+      const errorText = await geminiResponse.text();
+      console.error('Gemini error:', geminiResponse.status, errorText);
       sendSSE(res, 'error', { message: 'Failed to generate insight' });
       return res.end();
     }
 
-    // Process streaming response
+    // Process streaming response — Gemini SSE messages are \n\n delimited
+    // and each `data:` line contains a JSON chunk with candidates[].content.parts[].
     let fullResponse = '';
-    const reader = openaiResponse.body?.getReader();
+    const reader = geminiResponse.body?.getReader();
     const decoder = new TextDecoder();
 
     if (!reader) {
@@ -248,32 +251,41 @@ router.post('/api/admin/insights', adminInsightsLimiter, async (req: Request, re
       return res.end();
     }
 
+    let sseBuffer = '';
+    const handleSSEMessage = (message: string): void => {
+      for (const line of message.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        const payload = line.slice(6).trim();
+        if (!payload) continue;
+        try {
+          const parsed = JSON.parse(payload);
+          const parts = parsed?.candidates?.[0]?.content?.parts || [];
+          for (const part of parts) {
+            if (typeof part?.text === 'string' && part.text.length > 0) {
+              fullResponse += part.text;
+              sendSSE(res, 'message', { content: part.text });
+            }
+          }
+        } catch {
+          // Skip invalid JSON chunks
+        }
+      }
+    };
+
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        const chunk = decoder.decode(value, { stream: true });
-        const lines = chunk.split('\n');
-
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            if (data === '[DONE]') continue;
-
-            try {
-              const parsed = JSON.parse(data);
-              const content = parsed.choices?.[0]?.delta?.content;
-              if (content) {
-                fullResponse += content;
-                sendSSE(res, 'message', { content });
-              }
-            } catch {
-              // Skip invalid JSON chunks
-            }
-          }
+        sseBuffer += decoder.decode(value, { stream: true });
+        let boundary: number;
+        while ((boundary = sseBuffer.indexOf('\n\n')) !== -1) {
+          const message = sseBuffer.slice(0, boundary);
+          sseBuffer = sseBuffer.slice(boundary + 2);
+          handleSSEMessage(message);
         }
       }
+      if (sseBuffer.trim()) handleSSEMessage(sseBuffer);
     } catch (streamError) {
       console.error('Stream error:', streamError);
     }

--- a/server/routes/ai-chat.ts
+++ b/server/routes/ai-chat.ts
@@ -268,117 +268,6 @@ async function getTripContext(supabase: ReturnType<typeof createClient>, tripId:
   };
 }
 
-// Get or create thread for user and trip
-async function getOrCreateThread(
-  supabase: ReturnType<typeof createClient>,
-  userId: string,
-  tripId: string,
-  providedThreadId?: string
-): Promise<string | null> {
-  // If thread ID provided, verify it belongs to user
-  if (providedThreadId) {
-    const { data: existingThread } = await supabase
-      .from('ai_chat_threads')
-      .select('id')
-      .eq('id', providedThreadId)
-      .eq('user_id', userId)
-      .single();
-
-    if (existingThread) return existingThread.id;
-  }
-
-  // Look for existing thread for this user/trip combination
-  const { data: thread } = await supabase
-    .from('ai_chat_threads')
-    .select('id')
-    .eq('trip_id', tripId)
-    .eq('user_id', userId)
-    .single();
-
-  if (thread) return thread.id;
-
-  // Create new thread
-  const { data: newThread, error } = await supabase
-    .from('ai_chat_threads')
-    .insert({
-      trip_id: tripId,
-      user_id: userId
-    })
-    .select('id')
-    .single();
-
-  if (error || !newThread) return null;
-  return newThread.id;
-}
-
-// Get recent messages for context
-async function getRecentMessages(
-  supabase: ReturnType<typeof createClient>,
-  threadId: string,
-  limit: number = 10
-): Promise<Array<{ role: string; content: string }>> {
-  const { data: messages } = await supabase
-    .from('ai_chat_messages')
-    .select('role, content')
-    .eq('thread_id', threadId)
-    .order('created_at', { ascending: false })
-    .limit(limit);
-
-  // Return in chronological order (oldest first)
-  return (messages || []).reverse();
-}
-
-// Save message to database
-async function saveMessage(
-  supabase: ReturnType<typeof createClient>,
-  threadId: string,
-  role: 'user' | 'assistant',
-  content: string,
-  metadata?: Record<string, unknown>
-): Promise<string | null> {
-  const { data, error } = await supabase
-    .from('ai_chat_messages')
-    .insert({
-      thread_id: threadId,
-      role,
-      content,
-      metadata: metadata || {}
-    })
-    .select('id')
-    .single();
-
-  if (error) {
-    console.error('Error saving message:', error);
-    return null;
-  }
-  return data.id;
-}
-
-// Check and increment usage
-async function checkAndIncrementUsage(
-  supabase: ReturnType<typeof createClient>,
-  userId: string
-): Promise<{ allowed: boolean; used: number; limit: number }> {
-  const today = new Date().toISOString().split('T')[0];
-
-  const { data, error } = await supabase.rpc('increment_ai_usage', {
-    check_user_id: userId,
-    check_date: today
-  });
-
-  if (error || !data || data.length === 0) {
-    console.error('Error checking usage:', error);
-    // Deny on error to enforce limits
-    return { allowed: false, used: 0, limit: 10 };
-  }
-
-  return {
-    allowed: data[0].allowed,
-    used: data[0].current_count,
-    limit: data[0].daily_limit
-  };
-}
-
 // Send SSE event helper
 function sendSSE(res: Response, event: string, data: unknown): void {
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
@@ -524,68 +413,6 @@ function handleStreamError(res: Response, error: unknown, label: string): void {
 
   sendSSE(res, 'error', { code: 'INTERNAL_ERROR', message: errorMessage || 'An unexpected error occurred' });
   res.end();
-}
-
-// Parse create_items block from AI response
-interface ExtractedItem {
-  id: string;
-  itemType: 'accommodation' | 'transportation' | 'activity' | 'reservation';
-  fields: Record<string, unknown>;
-  missingRequired: string[];
-  confidence: number;
-  status: 'pending';
-}
-
-interface ParsedResponse {
-  cleanContent: string;
-  extractedItems: ExtractedItem[];
-}
-
-const REQUIRED_FIELDS_BY_TYPE: Record<string, string[]> = {
-  accommodation: ['name', 'check_in_date', 'check_out_date'],
-  transportation: ['type', 'departure_location', 'arrival_location', 'departure_date'],
-  activity: ['name', 'date'],
-  reservation: ['restaurant_name', 'date', 'time']
-};
-
-function mapRawItemToExtracted(item: Record<string, unknown>, idx: number): ExtractedItem {
-  const itemType = (item.itemType as string) || 'activity';
-  const fields = (item.fields as Record<string, unknown>) || item;
-  const required = REQUIRED_FIELDS_BY_TYPE[itemType] || [];
-  const missingRequired = required.filter(k => !fields[k]);
-
-  return {
-    id: `ai-item-${idx}-${Date.now()}`,
-    itemType: itemType as ExtractedItem['itemType'],
-    fields,
-    missingRequired,
-    confidence: 0.85,
-    status: 'pending' as const
-  };
-}
-
-const CREATE_ITEMS_REGEX = /```create_items\s*([\s\S]*?)```/;
-
-function parseCreateItemsBlock(response: string): ParsedResponse {
-  const match = response.match(CREATE_ITEMS_REGEX);
-
-  if (!match) {
-    return { cleanContent: response, extractedItems: [] };
-  }
-
-  const jsonStr = match[1].trim();
-  let items: ExtractedItem[] = [];
-
-  try {
-    const parsed = JSON.parse(jsonStr);
-    const rawItems = Array.isArray(parsed) ? parsed : [parsed];
-    items = rawItems.map(mapRawItemToExtracted);
-  } catch (e) {
-    console.error('Failed to parse create_items JSON:', e);
-  }
-
-  const cleanContent = response.replace(CREATE_ITEMS_REGEX, '').trim();
-  return { cleanContent, extractedItems: items };
 }
 
 function buildAnonSystemPrompt(basePrompt: string): string {
@@ -795,7 +622,12 @@ router.get('/api/trips/:tripId/assistant/messages', async (req: Request, res: Re
 
     const rawMessages = messages || [];
     const hasMore = rawMessages.length > limit;
-    const chronological = rawMessages.slice(0, limit).reverse();
+    // Hydrate placeCards from metadata so the client can rehydrate rich
+    // recommendation cards without re-streaming.
+    const chronological = rawMessages.slice(0, limit).reverse().map((m: any) => ({
+      ...m,
+      placeCards: m.metadata && Array.isArray(m.metadata.placeCards) ? m.metadata.placeCards : undefined,
+    }));
 
     return res.json({
       messages: chronological,
@@ -928,98 +760,71 @@ router.post('/api/trips/:tripId/assistant/anon', anonChatLimiter, async (req: Re
   }
 });
 
-// Main streaming chat endpoint
+// Main streaming chat endpoint — proxies to the ai-chat Supabase Edge Function,
+// which owns auth, tool-calling (find_place / search_web), message persistence,
+// and SSE emission (including `place_cards` for rich recommendation rendering).
+// Express stays in the path so rate limiting and CORS live in one place, but
+// does not duplicate auth/usage/thread logic.
+const EDGE_CHAT_BASE = `${SUPABASE_URL}/functions/v1/ai-chat`;
+
+async function pipeSSEStream(upstream: Response, res: Response): Promise<void> {
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+  const reader = upstream.body.getReader();
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(decoder.decode(value, { stream: true }));
+    }
+  } catch (streamErr) {
+    console.error('Upstream chat stream error:', streamErr);
+  } finally {
+    res.end();
+  }
+}
+
 router.post('/api/trips/:tripId/assistant', async (req: Request, res: Response) => {
   try {
     const { tripId } = req.params;
     if (!isValidUUID(tripId)) return res.status(400).json({ error: 'Invalid trip ID' });
-    const { message, thread_id }: SendMessageRequest = req.body;
 
+    const authHeader = req.headers.authorization || '';
+    if (!authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ code: 'UNAUTHORIZED', message: 'Please sign in to use the assistant' });
+    }
+
+    const { message, thread_id }: SendMessageRequest = req.body || {};
     if (!message || typeof message !== 'string' || message.trim().length === 0) {
       return res.status(400).json({ error: 'Message is required' });
     }
-
     if (message.length > 4000) {
       return res.status(400).json({ error: 'Message exceeds maximum length' });
     }
 
-    const authUser = await getUserFromToken(req.headers.authorization || '');
-    if (!authUser) {
-      return res.status(401).json({ code: 'UNAUTHORIZED', message: 'Please sign in to use the assistant' });
+    const upstream = await fetch(`${EDGE_CHAT_BASE}/${tripId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': authHeader,
+      },
+      body: JSON.stringify({ message: message.trim(), thread_id }),
+    });
+
+    if (!upstream.ok || !upstream.body) {
+      const text = await upstream.text().catch(() => '');
+      let parsed: unknown = { error: `Upstream ${upstream.status}` };
+      try { parsed = text ? JSON.parse(text) : parsed; } catch { parsed = { error: text || `Upstream ${upstream.status}` }; }
+      return res.status(upstream.status).json(parsed);
     }
-    const userId = authUser.id;
-
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-
-    const hasAccess = await canAccessTrip(supabase, userId, tripId, authUser.email);
-    if (!hasAccess) {
-      return res.status(403).json({ code: 'TRIP_ACCESS_DENIED', message: 'You do not have access to this trip' });
-    }
-
-    const usage = await checkAndIncrementUsage(supabase, userId);
-    if (!usage.allowed) {
-      const tomorrow = new Date();
-      tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-      tomorrow.setUTCHours(0, 0, 0, 0);
-
-      return res.status(429).json({
-        code: 'DAILY_LIMIT_REACHED',
-        message: 'You have reached your daily message limit',
-        limit: usage.limit,
-        used: usage.used,
-        resetAt: tomorrow.toISOString()
-      });
-    }
-
-    const threadId = await getOrCreateThread(supabase, userId, tripId, thread_id);
-    if (!threadId) {
-      return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to create conversation thread' });
-    }
-
-    const userMessageId = await saveMessage(supabase, threadId, 'user', message.trim());
-    if (!userMessageId) {
-      return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to save message' });
-    }
-
-    const tripContext = await getTripContext(supabase, tripId);
-    if (!tripContext) {
-      return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to load trip data' });
-    }
-
-    const recentMessages = await getRecentMessages(supabase, threadId, 10);
-    const openaiMessages = buildOpenAIMessages(buildSystemPrompt(tripContext), recentMessages);
 
     setupSSEHeaders(res);
-
-    const result = await streamOpenAIResponse(openaiMessages, res, { maxTokens: 1000, filterCreateItems: true });
-    if (!result) return;
-
-    const { cleanContent, extractedItems } = parseCreateItemsBlock(result.fullResponse);
-
-    const assistantMessageId = await saveMessage(supabase, threadId, 'assistant', cleanContent, {
-      model: MODEL,
-      tokens: { completion: result.fullResponse.length },
-      hasExtractedItems: extractedItems.length > 0
-    });
-
-    if (extractedItems.length > 0) {
-      sendSSE(res, 'extracted_items', {
-        items: extractedItems,
-        meta: { model: MODEL, source: 'conversation' }
-      });
-    }
-
-    // Send the sanitized content so the client displays the clean version
-    // instead of the accumulated stream (which may contain a partial
-    // ```create_items marker that slipped through before the filter engaged).
-    sendSSE(res, 'done', {
-      thread_id: threadId,
-      message_id: assistantMessageId,
-      content: cleanContent
-    });
-    res.end();
+    await pipeSSEStream(upstream, res);
   } catch (error) {
-    handleStreamError(res, error, 'Chat error');
+    handleStreamError(res, error, 'Chat proxy error');
   }
 });
 

--- a/server/routes/ai-chat.ts
+++ b/server/routes/ai-chat.ts
@@ -7,8 +7,11 @@ const router = Router();
 const isValidUUID = (s: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
 
 // Environment variables
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
-const MODEL = process.env.OPENAI_CHAT_MODEL || 'gpt-5.4-mini';
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || '';
+// Hardcoded model — locked in-process so the request path cannot redirect
+// chat traffic to a different (potentially unvetted) model.
+const MODEL = 'gemini-2.5-flash';
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL || '';
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
@@ -281,19 +284,25 @@ function setupSSEHeaders(res: Response): void {
   res.flushHeaders();
 }
 
-interface OpenAIStreamResult {
+interface GeminiStreamResult {
   fullResponse: string;
 }
 
-function extractDeltaContent(line: string): string | null {
+// Extract text from a single Gemini SSE line (`data: {...}`). Gemini chunks can
+// carry multiple parts (text, functionCall); here we only handle text since
+// the anon path doesn't use tools.
+function extractGeminiTextDelta(line: string): string | null {
   if (!line.startsWith('data: ')) return null;
-
-  const data = line.slice(6);
-  if (data === '[DONE]') return null;
-
+  const payload = line.slice(6).trim();
+  if (!payload) return null;
   try {
-    const parsed = JSON.parse(data);
-    return parsed.choices?.[0]?.delta?.content || null;
+    const parsed = JSON.parse(payload);
+    const parts = parsed?.candidates?.[0]?.content?.parts || [];
+    let text = '';
+    for (const part of parts) {
+      if (typeof part?.text === 'string') text += part.text;
+    }
+    return text || null;
   } catch {
     return null;
   }
@@ -304,34 +313,37 @@ function sendSSEError(res: Response, message: string): void {
   res.end();
 }
 
-async function streamOpenAIResponse(
-  messages: Array<{ role: string; content: string }>,
+async function streamGeminiResponse(
+  systemInstruction: string,
+  contents: Array<{ role: 'user' | 'model'; parts: Array<{ text: string }> }>,
   res: Response,
   options: { maxTokens: number; filterCreateItems?: boolean }
-): Promise<OpenAIStreamResult | null> {
-  const openaiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+): Promise<GeminiStreamResult | null> {
+  const url = `${GEMINI_BASE}/models/${MODEL}:streamGenerateContent?alt=sse`;
+  const geminiResponse = await fetch(url, {
     method: 'POST',
     headers: {
-      'Authorization': `Bearer ${OPENAI_API_KEY}`,
+      'x-goog-api-key': GEMINI_API_KEY,
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      model: MODEL,
-      messages,
-      stream: true,
-      temperature: 0.7,
-      max_completion_tokens: options.maxTokens
+      contents,
+      systemInstruction: { parts: [{ text: systemInstruction }] },
+      generationConfig: {
+        temperature: 0.7,
+        maxOutputTokens: options.maxTokens
+      }
     })
   });
 
-  if (!openaiResponse.ok) {
-    const errorText = await openaiResponse.text();
-    console.error('OpenAI error:', openaiResponse.status, errorText);
+  if (!geminiResponse.ok) {
+    const errorText = await geminiResponse.text();
+    console.error('Gemini error:', geminiResponse.status, errorText);
     sendSSEError(res, 'Failed to generate response');
     return null;
   }
 
-  const reader = openaiResponse.body?.getReader();
+  const reader = geminiResponse.body?.getReader();
   if (!reader) {
     sendSSEError(res, 'Failed to read response stream');
     return null;
@@ -343,48 +355,66 @@ async function streamOpenAIResponse(
   // suppress the whole fence atomically instead of leaking partial backticks.
   let pendingTail = '';
   let suppressing = false;
+  // SSE buffer — Gemini delimits messages with \n\n.
+  let sseBuffer = '';
 
   // Matches a tail that could still grow into "```create_items".
   const PARTIAL_MARKER_RE = /`{1,3}(c(r(e(a(t(e(_(i(t(e(m(s)?)?)?)?)?)?)?)?)?)?)?)?$/;
+
+  const forwardDelta = (content: string): void => {
+    if (!content) return;
+    fullResponse += content;
+
+    if (!options.filterCreateItems) {
+      sendSSE(res, 'message', { content });
+      return;
+    }
+
+    if (suppressing) return;
+
+    if (fullResponse.includes('```create_items')) {
+      // Full marker landed — stop forwarding and drop any buffered tail
+      // that was leading up to it.
+      suppressing = true;
+      pendingTail = '';
+      return;
+    }
+
+    const combined = pendingTail + content;
+    const match = combined.match(PARTIAL_MARKER_RE);
+
+    if (match) {
+      const safe = combined.slice(0, combined.length - match[0].length);
+      pendingTail = match[0];
+      if (safe) sendSSE(res, 'message', { content: safe });
+    } else {
+      if (combined) sendSSE(res, 'message', { content: combined });
+      pendingTail = '';
+    }
+  };
 
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
 
-      const chunk = decoder.decode(value, { stream: true });
-      for (const line of chunk.split('\n')) {
-        const content = extractDeltaContent(line);
-        if (!content) continue;
-
-        fullResponse += content;
-
-        if (!options.filterCreateItems) {
-          sendSSE(res, 'message', { content });
-          continue;
+      sseBuffer += decoder.decode(value, { stream: true });
+      let boundary: number;
+      while ((boundary = sseBuffer.indexOf('\n\n')) !== -1) {
+        const message = sseBuffer.slice(0, boundary);
+        sseBuffer = sseBuffer.slice(boundary + 2);
+        for (const line of message.split('\n')) {
+          const delta = extractGeminiTextDelta(line);
+          if (delta) forwardDelta(delta);
         }
+      }
+    }
 
-        if (suppressing) continue;
-
-        if (fullResponse.includes('```create_items')) {
-          // Full marker landed — stop forwarding and drop any buffered tail
-          // that was leading up to it.
-          suppressing = true;
-          pendingTail = '';
-          continue;
-        }
-
-        const combined = pendingTail + content;
-        const match = combined.match(PARTIAL_MARKER_RE);
-
-        if (match) {
-          const safe = combined.slice(0, combined.length - match[0].length);
-          pendingTail = match[0];
-          if (safe) sendSSE(res, 'message', { content: safe });
-        } else {
-          if (combined) sendSSE(res, 'message', { content: combined });
-          pendingTail = '';
-        }
+    // Flush any trailing partial SSE message
+    if (sseBuffer.trim()) {
+      for (const line of sseBuffer.split('\n')) {
+        const delta = extractGeminiTextDelta(line);
+        if (delta) forwardDelta(delta);
       }
     }
 
@@ -422,19 +452,25 @@ function buildAnonSystemPrompt(basePrompt: string): string {
   );
 }
 
-function buildOpenAIMessages(
-  systemPrompt: string,
+type GeminiTextContent = { role: 'user' | 'model'; parts: Array<{ text: string }> };
+
+// Convert chat history (role: 'user' | 'assistant') into Gemini `contents`
+// (role: 'user' | 'model'). Gemini has no `system` role — the system prompt
+// ships separately in `systemInstruction`.
+function buildGeminiContents(
   history: Array<{ role: string; content: string }>,
   userMessage?: string
-): Array<{ role: string; content: string }> {
-  const messages: Array<{ role: string; content: string }> = [
-    { role: 'system', content: systemPrompt },
-    ...history.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
-  ];
+): GeminiTextContent[] {
+  const contents: GeminiTextContent[] = history
+    .filter(m => m.role === 'user' || m.role === 'assistant')
+    .map(m => ({
+      role: m.role === 'assistant' ? 'model' as const : 'user' as const,
+      parts: [{ text: m.content }],
+    }));
   if (userMessage) {
-    messages.push({ role: 'user', content: userMessage });
+    contents.push({ role: 'user', parts: [{ text: userMessage }] });
   }
-  return messages;
+  return contents;
 }
 
 // Health check endpoint
@@ -746,11 +782,11 @@ router.post('/api/trips/:tripId/assistant/anon', anonChatLimiter, async (req: Re
     }
 
     const anonSystemPrompt = buildAnonSystemPrompt(buildSystemPrompt(tripContext));
-    const openaiMessages = buildOpenAIMessages(anonSystemPrompt, historyMessages, message.trim());
+    const contents = buildGeminiContents(historyMessages, message.trim());
 
     setupSSEHeaders(res);
 
-    const result = await streamOpenAIResponse(openaiMessages, res, { maxTokens: 800, filterCreateItems: true });
+    const result = await streamGeminiResponse(anonSystemPrompt, contents, res, { maxTokens: 800, filterCreateItems: true });
     if (!result) return;
 
     sendSSE(res, 'done', { thread_id: null, message_id: `anon-${Date.now()}` });

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { useAIAssistant } from '@/hooks/useAIAssistant';
 import { useDocumentExtraction } from '@/hooks/useDocumentExtraction';
 import { bulkImportItems } from '@/services/bulkImportService';
+import { addPlaceCardItem, undoPlaceCardItem } from '@/services/placeCardAddService';
 import ChatMessageList from './ChatMessageList';
 import ChatInput from './ChatInput';
 import PromptChips from './PromptChips';
@@ -13,7 +14,7 @@ import UsageMeter from './UsageMeter';
 import PaywallModal from './PaywallModal';
 import ExtractionResultMessage from './ExtractionResultMessage';
 import ItemStepperDialog from './ItemStepperDialog';
-import type { AIUsageInfo, AIChatMessage, ChatFileAttachment, ExtractedItem } from '@/types/ai-assistant';
+import type { AIUsageInfo, AIChatMessage, ChatFileAttachment, ExtractedItem, PlaceCard } from '@/types/ai-assistant';
 
 interface AIAssistantPanelProps {
   tripId: string;
@@ -216,6 +217,41 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
     }
   }, [tripId, queryClient]);
 
+  const invalidateTripQueries = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['trip', tripId] });
+    queryClient.invalidateQueries({ queryKey: ['accommodations', tripId] });
+    queryClient.invalidateQueries({ queryKey: ['transportation', tripId] });
+    queryClient.invalidateQueries({ queryKey: ['activities', tripId] });
+    queryClient.invalidateQueries({ queryKey: ['reservations', tripId] });
+  }, [queryClient, tripId]);
+
+  // One-tap add from a place card. Date/time validation already happened on
+  // the server (suggested_add is stripped when invalid), so this path should
+  // only fire for cards we know can be added. Shows an undo toast for 5s.
+  const handleAddPlaceCard = useCallback(async (card: PlaceCard): Promise<void> => {
+    try {
+      const added = await addPlaceCardItem(tripId, card);
+      invalidateTripQueries();
+      toast.success(`Added ${added.label} to your trip`, {
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            undoPlaceCardItem(added)
+              .then(() => {
+                invalidateTripQueries();
+                toast.message('Removed from trip');
+              })
+              .catch((e) => toast.error(e?.message || 'Undo failed'));
+          },
+        },
+        duration: 5000,
+      });
+    } catch (e: any) {
+      toast.error(e?.message || 'Could not add this recommendation');
+      throw e;
+    }
+  }, [tripId, invalidateTripQueries]);
+
   // Handle review & edit flow
   const handleReviewEdit = useCallback((items: ExtractedItem[]) => {
     setItemsToProcess(items);
@@ -294,6 +330,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
               tripId={tripId}
               onImportAll={handleImportAll}
               onReviewEdit={handleReviewEdit}
+              onAddPlaceCard={handleAddPlaceCard}
               isImporting={isImporting}
               emptyStateSlot={
                 <PromptChips

--- a/src/components/trip/ai-assistant/ChatMessage.tsx
+++ b/src/components/trip/ai-assistant/ChatMessage.tsx
@@ -8,8 +8,9 @@ import { useAuth } from '@/contexts/AuthContext';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import ExtractionResultMessage from './ExtractionResultMessage';
+import PlaceCardCarousel from './PlaceCardCarousel';
 import { normalizeMarkdownListSpacing, safeHref } from './chatUrlSafety';
-import type { AIChatMessage, ExtractedItem } from '@/types/ai-assistant';
+import type { AIChatMessage, ExtractedItem, PlaceCard } from '@/types/ai-assistant';
 
 // Defined at module scope so the component functions aren't recreated on
 // every ChatMessage render. safeHref() runs at render time on every link to
@@ -73,6 +74,7 @@ interface ChatMessageProps {
   isStreaming?: boolean;
   onImportAll?: (items: ExtractedItem[]) => Promise<void>;
   onReviewEdit?: (items: ExtractedItem[]) => void;
+  onAddPlaceCard?: (card: PlaceCard) => Promise<void>;
   isImporting?: boolean;
 }
 
@@ -81,12 +83,14 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
   isStreaming = false,
   onImportAll,
   onReviewEdit,
+  onAddPlaceCard,
   isImporting = false
 }) => {
   const [copied, setCopied] = useState(false);
   const { avatarUrl, fullName, session } = useAuth();
   const isUser = message.role === 'user';
   const hasExtractedItems = message.extractedItems && message.extractedItems.length > 0;
+  const hasPlaceCards = !isUser && Array.isArray(message.placeCards) && message.placeCards.length > 0;
   const hasAttachment = !!message.attachmentPreviewUrl;
 
   const getUserInitials = () => {
@@ -189,24 +193,34 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
           </div>
         ) : (
           // Regular assistant message
-          <div
-            className={cn(
-              'rounded-2xl px-4 py-2.5 text-sm overflow-hidden',
-              'bg-sand-50 text-earth-700 border border-sand-200 rounded-tl-sm',
-              isStreaming && 'transition-all duration-150 ease-out'
-            )}
-          >
-            <div className="prose prose-sm prose-earth max-w-full break-words overflow-wrap-anywhere">
-              <ReactMarkdown
-                remarkPlugins={markdownRemarkPlugins}
-                components={markdownComponents}
+          <div className="w-full">
+            {message.content.trim().length > 0 && (
+              <div
+                className={cn(
+                  'rounded-2xl px-4 py-2.5 text-sm overflow-hidden',
+                  'bg-sand-50 text-earth-700 border border-sand-200 rounded-tl-sm',
+                  isStreaming && 'transition-all duration-150 ease-out'
+                )}
               >
-                {normalizeMarkdownListSpacing(message.content)}
-              </ReactMarkdown>
-              {isStreaming && (
-                <span className="inline-block w-1 h-[1.1em] ml-0.5 rounded-full bg-earth-400/60 animate-pulse" />
-              )}
-            </div>
+                <div className="prose prose-sm prose-earth max-w-full break-words overflow-wrap-anywhere">
+                  <ReactMarkdown
+                    remarkPlugins={markdownRemarkPlugins}
+                    components={markdownComponents}
+                  >
+                    {normalizeMarkdownListSpacing(message.content)}
+                  </ReactMarkdown>
+                  {isStreaming && (
+                    <span className="inline-block w-1 h-[1.1em] ml-0.5 rounded-full bg-earth-400/60 animate-pulse" />
+                  )}
+                </div>
+              </div>
+            )}
+            {hasPlaceCards && (
+              <PlaceCardCarousel
+                cards={message.placeCards!}
+                onAdd={onAddPlaceCard}
+              />
+            )}
           </div>
         )}
 

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -173,7 +173,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
           </div>
           {emptyStateSlot}
           <p className="text-[11px] text-sand-400 max-w-[280px] text-center leading-relaxed">
-            Your trip details are shared with OpenAI to provide personalized recommendations. Messages are not used to train AI models.
+            Your trip details are shared with Google's Gemini API to provide personalized recommendations. Messages are not used to train AI models.
           </p>
         </div>
       </div>

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import ChatMessage from './ChatMessage';
 import { Loader2, Sparkles, ChevronUp } from 'lucide-react';
-import type { AIChatMessage, ExtractedItem } from '@/types/ai-assistant';
+import type { AIChatMessage, ExtractedItem, PlaceCard } from '@/types/ai-assistant';
 
 interface ChatMessageListProps {
   messages: AIChatMessage[];
@@ -16,6 +16,7 @@ interface ChatMessageListProps {
   tripId?: string;
   onImportAll?: (items: ExtractedItem[]) => Promise<void>;
   onReviewEdit?: (items: ExtractedItem[]) => void;
+  onAddPlaceCard?: (card: PlaceCard) => Promise<void>;
   isImporting?: boolean;
   emptyStateSlot?: React.ReactNode;
 }
@@ -33,6 +34,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
   tripId,
   onImportAll,
   onReviewEdit,
+  onAddPlaceCard,
   isImporting = false,
   emptyStateSlot
 }) => {
@@ -223,6 +225,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
           message={message}
           onImportAll={onImportAll}
           onReviewEdit={onReviewEdit}
+          onAddPlaceCard={onAddPlaceCard}
           isImporting={isImporting}
         />
       ))}

--- a/src/components/trip/ai-assistant/PlaceCard.tsx
+++ b/src/components/trip/ai-assistant/PlaceCard.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import { Star, MapPin, ExternalLink, Plus, Loader2, Check, Phone } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { PlaceCard as PlaceCardType } from '@/types/ai-assistant';
+
+type AddStatus = 'idle' | 'adding' | 'added';
+
+interface PlaceCardProps {
+  card: PlaceCardType;
+  onAdd?: (card: PlaceCardType) => Promise<void>;
+  compact?: boolean;
+}
+
+function priceLevelToDollars(level: number | undefined): string | null {
+  if (typeof level !== 'number' || level < 1 || level > 4) return null;
+  return '$'.repeat(level);
+}
+
+function formatRating(rating: number | undefined): string | null {
+  if (typeof rating !== 'number') return null;
+  return rating.toFixed(1);
+}
+
+const PlaceCard: React.FC<PlaceCardProps> = ({ card, onAdd, compact = false }) => {
+  const [addStatus, setAddStatus] = useState<AddStatus>('idle');
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageFailed, setImageFailed] = useState(false);
+
+  const canAdd = !!card.suggested_add && !!onAdd;
+  const bookingUrl = card.booking_url || card.website;
+  const ratingStr = formatRating(card.rating);
+  const priceStr = priceLevelToDollars(card.price_level);
+
+  const handleAdd = async () => {
+    if (!canAdd || addStatus !== 'idle') return;
+    setAddStatus('adding');
+    try {
+      await onAdd!(card);
+      setAddStatus('added');
+    } catch {
+      setAddStatus('idle');
+    }
+  };
+
+  return (
+    <article
+      className={cn(
+        'flex flex-col rounded-card border border-sand-200 bg-background overflow-hidden shadow-warm-sm',
+        compact ? 'w-[240px]' : 'w-[280px]',
+        'flex-none snap-start'
+      )}
+    >
+      {/* Photo */}
+      <div className="relative aspect-[16/10] bg-sand-100">
+        {card.photo_url && !imageFailed ? (
+          <>
+            {!imageLoaded && <div className="absolute inset-0 bg-grain bg-sand-100" />}
+            <img
+              src={card.photo_url}
+              alt={card.name}
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageFailed(true)}
+              className={cn(
+                'h-full w-full object-cover img-warm transition-opacity duration-300',
+                imageLoaded ? 'opacity-100' : 'opacity-0'
+              )}
+            />
+            {/* Per Google TOS, photos must carry an attribution. */}
+            <span className="absolute bottom-1 right-1.5 text-[10px] text-white/80 drop-shadow">
+              Google
+            </span>
+          </>
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sand-400">
+            <MapPin className="h-8 w-8" />
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col gap-1.5 p-3">
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="font-display text-base font-semibold text-earth-700 leading-tight line-clamp-2">
+            {card.name}
+          </h4>
+        </div>
+
+        {(ratingStr || priceStr) && (
+          <div className="flex items-center gap-2 text-xs text-sand-600">
+            {ratingStr && (
+              <span className="inline-flex items-center gap-0.5">
+                <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                <span className="font-medium text-earth-700">{ratingStr}</span>
+              </span>
+            )}
+            {ratingStr && priceStr && <span className="text-sand-300">·</span>}
+            {priceStr && <span className="font-medium text-earth-600">{priceStr}</span>}
+          </div>
+        )}
+
+        {card.blurb && (
+          <p className="text-xs leading-relaxed text-sand-700 line-clamp-3">{card.blurb}</p>
+        )}
+
+        {card.address && (
+          <p className="mt-auto pt-1 text-[11px] text-sand-500 line-clamp-1" title={card.address}>
+            {card.address}
+          </p>
+        )}
+
+        {/* Actions */}
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {canAdd && (
+            <Button
+              size="sm"
+              onClick={handleAdd}
+              disabled={addStatus !== 'idle'}
+              className="h-8 flex-1 min-w-[96px] bg-earth-500 hover:bg-earth-600 text-white text-xs"
+            >
+              {addStatus === 'adding' && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+              {addStatus === 'added' && <Check className="mr-1 h-3 w-3" />}
+              {addStatus === 'idle' && <Plus className="mr-1 h-3 w-3" />}
+              {addStatus === 'added' ? 'Added' : addStatus === 'adding' ? 'Adding…' : 'Add to trip'}
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            asChild
+            className="h-8 flex-none px-2 text-xs"
+            title="Open in Google Maps"
+          >
+            <a href={card.maps_url} target="_blank" rel="noopener noreferrer">
+              <MapPin className="h-3 w-3" />
+            </a>
+          </Button>
+          {bookingUrl && (
+            <Button
+              size="sm"
+              variant="outline"
+              asChild
+              className="h-8 flex-none px-2 text-xs"
+              title={card.booking_url ? 'Book' : 'Website'}
+            >
+              <a href={bookingUrl} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </Button>
+          )}
+          {card.phone && !bookingUrl && (
+            <Button
+              size="sm"
+              variant="outline"
+              asChild
+              className="h-8 flex-none px-2 text-xs"
+              title="Call"
+            >
+              <a href={`tel:${card.phone.replace(/\s/g, '')}`}>
+                <Phone className="h-3 w-3" />
+              </a>
+            </Button>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default PlaceCard;

--- a/src/components/trip/ai-assistant/PlaceCardCarousel.tsx
+++ b/src/components/trip/ai-assistant/PlaceCardCarousel.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PlaceCard from './PlaceCard';
+import type { PlaceCard as PlaceCardType } from '@/types/ai-assistant';
+
+interface PlaceCardCarouselProps {
+  cards: PlaceCardType[];
+  onAdd?: (card: PlaceCardType) => Promise<void>;
+}
+
+const PlaceCardCarousel: React.FC<PlaceCardCarouselProps> = ({ cards, onAdd }) => {
+  if (!cards || cards.length === 0) return null;
+
+  // Single card: render without a scroller so it can breathe in the bubble.
+  if (cards.length === 1) {
+    return (
+      <div className="mt-2 max-w-[320px]">
+        <PlaceCard card={cards[0]} onAdd={onAdd} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mt-2 -mx-1 flex snap-x snap-mandatory gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      role="list"
+      aria-label="Place recommendations"
+    >
+      {cards.map((card) => (
+        <div key={card.id} role="listitem">
+          <PlaceCard card={card} onAdd={onAdd} compact={cards.length > 3} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PlaceCardCarousel;

--- a/src/components/trip/chat/ChatView.tsx
+++ b/src/components/trip/chat/ChatView.tsx
@@ -479,7 +479,7 @@ export default function ChatView({ tripId, canEdit = true }: Props) {
                 2. Drag & drop an image/PDF here, or use the buttons below.
               </p>
               <p className= "text-xs text-sand-500 italic">
-                All files are securely passed to OpenAI; we do not store any uploads
+                All files are securely passed to Google's Gemini API; we do not store any uploads
               </p>
 
               {/* Live preview (image or first page of PDF) */}

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -11,7 +11,8 @@ import type {
   SSEDoneEvent,
   SSEErrorEvent,
   StreamingErrorResponse,
-  ExtractedItem
+  ExtractedItem,
+  PlaceCard
 } from '@/types/ai-assistant';
 
 const EXPRESS_BASE = '/api/trips';
@@ -25,6 +26,10 @@ interface SSEExtractedItemsEvent {
     model: string;
     source: string;
   };
+}
+
+interface SSEPlaceCardsEvent {
+  cards: PlaceCard[];
 }
 
 interface UseAIAssistantOptions {
@@ -62,6 +67,7 @@ function handleSSEOpen(response: Response): void {
 
 interface SSEStreamAccumulator {
   fullContent: string;
+  placeCards?: PlaceCard[];
 }
 
 interface AnonSSEContext {
@@ -138,7 +144,8 @@ function handleAuthSSEMessage(event: { event: string; data: string }, ctx: AuthS
         role: 'assistant',
         content: messageContent,
         metadata: {},
-        created_at: new Date().toISOString()
+        created_at: new Date().toISOString(),
+        placeCards: ctx.accumulator.placeCards
       };
 
       ctx.queryClient.setQueryData(
@@ -156,6 +163,11 @@ function handleAuthSSEMessage(event: { event: string; data: string }, ctx: AuthS
       const data = JSON.parse(event.data) as SSEExtractedItemsEvent;
       if (data.items && data.items.length > 0 && ctx.onItemsExtracted) {
         ctx.onItemsExtracted(data.items);
+      }
+    } else if (event.event === 'place_cards') {
+      const data = JSON.parse(event.data) as SSEPlaceCardsEvent;
+      if (Array.isArray(data.cards) && data.cards.length > 0) {
+        ctx.accumulator.placeCards = data.cards;
       }
     } else if (event.event === 'error') {
       const data = JSON.parse(event.data) as SSEErrorEvent;

--- a/src/pages/LLMTraining.tsx
+++ b/src/pages/LLMTraining.tsx
@@ -166,9 +166,9 @@ const LLMTraining = () => {
                   <div className="flex items-start gap-2">
                     <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
                     <div>
-                      <strong>Confirmation Importing:</strong> OpenAI GPT-4o-mini integration provides the ability 
+                      <strong>Confirmation Importing:</strong> Google Gemini 2.5 Flash integration provides the ability
                       to take an uploaded booking confirmation—like a flight, hotel, or restaurant reservation—
-                      and automatically extract relevant details to create items on your trip timeline, 
+                      and automatically extract relevant details to create items on your trip timeline,
                       streamlining the planning process.
                     </div>
                   </div>
@@ -306,7 +306,7 @@ const LLMTraining = () => {
                 <h4 className="font-semibold text-earth-800 mb-3">External Integrations</h4>
                 <ul className="text-sm text-earth-700 space-y-1">
                   <li>Google Places API for location services</li>
-                  <li>OpenAI GPT-4o-mini for AI assistance</li>
+                  <li>Google Gemini 2.5 Flash for AI assistance and travel-doc OCR</li>
                   <li>SendGrid for email notifications</li>
                   <li>Unsplash API for trip imagery</li>
                   <li>PDF generation for professional itineraries</li>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -91,7 +91,7 @@ const PrivacyPolicy: React.FC = () => {
                   </thead>
                   <tbody className="divide-y">
                     <tr><td className="py-2 pr-4">Supabase</td><td className="py-2 pr-4">Database and authentication</td><td className="py-2">Account data, trip data, all stored information</td></tr>
-                    <tr><td className="py-2 pr-4">OpenAI</td><td className="py-2 pr-4">AI travel assistant</td><td className="py-2">Chat messages and trip context (destination, dates, itinerary)</td></tr>
+                    <tr><td className="py-2 pr-4">Google (Gemini API)</td><td className="py-2 pr-4">AI travel assistant + travel document OCR</td><td className="py-2">Chat messages, trip context (destination, dates, itinerary), and uploaded booking documents</td></tr>
                     <tr><td className="py-2 pr-4">Stripe</td><td className="py-2 pr-4">Payment processing</td><td className="py-2">Email, payment details</td></tr>
                     <tr><td className="py-2 pr-4">PostHog</td><td className="py-2 pr-4">Analytics (consent-gated)</td><td className="py-2">Usage events, device info</td></tr>
                     <tr><td className="py-2 pr-4">Google</td><td className="py-2 pr-4">Places API (location search)</td><td className="py-2">Search queries</td></tr>
@@ -162,7 +162,7 @@ const PrivacyPolicy: React.FC = () => {
             <div className="pb-6 border-b">
               <h2 className="text-2xl font-semibold mb-4 text-foreground">10. AI Data Processing</h2>
               <p>
-                When you use our AI travel assistant, your trip details (destination, dates, itinerary, accommodations, and transportation) are sent to OpenAI to generate personalized recommendations. Your messages are processed in real-time and are not used to train OpenAI's models. AI chat history is stored in your account and can be deleted at any time by deleting your account.
+                When you use our AI travel assistant, your trip details (destination, dates, itinerary, accommodations, and transportation) are sent to Google's Gemini API to generate personalized recommendations. Uploaded booking documents (images or PDFs) are also processed by Gemini for OCR-based field extraction. Your messages and documents are processed in real-time and, per Google's paid API terms, are not used to train their models. AI chat history is stored in your account and can be deleted at any time by deleting your account.
               </p>
             </div>
 

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -50,13 +50,13 @@ const TermsOfService: React.FC = () => {
                 <div>
                   <h3 className="text-lg font-semibold mb-2">Receipt and Document Analysis</h3>
                   <p>
-                    Our platform includes receipt analysis functionality powered by <strong>OpenAI's GPT-4 Vision</strong> technology. When you upload receipts, booking confirmations, or other travel documents, they are:
+                    Our platform includes receipt analysis functionality powered by <strong>Google's Gemini 2.5 Flash</strong> vision model. When you upload receipts, booking confirmations, or other travel documents, they are:
                   </p>
                   <ul className="list-disc ml-6 mt-2 space-y-1">
                     <li>Securely stored on our servers using Supabase storage infrastructure</li>
-                    <li>Processed by OpenAI's vision AI to extract travel-related information</li>
+                    <li>Processed by Google's Gemini API to extract travel-related information</li>
                     <li>Accessible only to you and authorized WanderLuxe systems</li>
-                    <li>Subject to both our privacy practices and OpenAI's data usage policies</li>
+                    <li>Subject to both our privacy practices and Google's data usage policies for the Gemini API</li>
                   </ul>
                 </div>
                 <div>
@@ -76,7 +76,7 @@ const TermsOfService: React.FC = () => {
             <div className="pb-6 border-b">
               <h2 className="text-2xl font-semibold mb-4 text-foreground">5. Third‑Party APIs and Services</h2>
               <p>
-                Our Site integrates with various third‑party services and APIs including but not limited to Perplexity AI, OpenAI, Google services, and mapping providers. Your use of these services is subject to their respective terms and conditions. We do not control these third‑party services and are not responsible for their availability, accuracy, or practices.
+                Our Site integrates with various third‑party services and APIs including but not limited to Google (Gemini API, Places API, and mapping providers) and other service providers. Your use of these services is subject to their respective terms and conditions. We do not control these third‑party services and are not responsible for their availability, accuracy, or practices.
               </p>
             </div>
             <div className="pb-6 border-b">

--- a/src/services/placeCardAddService.ts
+++ b/src/services/placeCardAddService.ts
@@ -1,0 +1,113 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { PlaceCard } from '@/types/ai-assistant';
+
+const toDbTime = (t: unknown): string | null =>
+  typeof t === 'string' && /^\d{2}:\d{2}$/.test(t) ? t : null;
+
+const strOrNull = (v: unknown): string | null =>
+  typeof v === 'string' && v.length > 0 ? v : null;
+
+const numOrNull = (v: unknown): number | null =>
+  typeof v === 'number' && Number.isFinite(v) ? v : null;
+
+async function findOrCreateDay(tripId: string, date: string): Promise<string> {
+  const { data: existing } = await supabase
+    .from('trip_days')
+    .select('day_id')
+    .eq('trip_id', tripId)
+    .eq('date', date)
+    .single();
+  if (existing?.day_id) return existing.day_id;
+
+  const { data: created, error } = await supabase
+    .from('trip_days')
+    .insert({ trip_id: tripId, date, title: null })
+    .select('day_id')
+    .single();
+  if (error || !created?.day_id) throw new Error('Could not create trip day');
+  return created.day_id;
+}
+
+async function nextOrderIndex(table: 'day_activities' | 'reservations', dayId: string): Promise<number> {
+  const { data } = await supabase
+    .from(table)
+    .select('order_index')
+    .eq('day_id', dayId)
+    .order('order_index', { ascending: false })
+    .limit(1);
+  return (data?.[0]?.order_index ?? -1) + 1;
+}
+
+export type AddedPlaceCardItem = {
+  table: 'reservations' | 'day_activities';
+  rowId: string;
+  label: string;
+};
+
+export async function addPlaceCardItem(
+  tripId: string,
+  card: PlaceCard
+): Promise<AddedPlaceCardItem> {
+  const suggestion = card.suggested_add;
+  if (!suggestion) throw new Error('This recommendation has no date. Add it manually instead.');
+
+  const date = suggestion.fields.date;
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error('Missing or invalid date on this recommendation.');
+  }
+  const dayId = await findOrCreateDay(tripId, date);
+
+  if (suggestion.itemType === 'reservation') {
+    const time = toDbTime(suggestion.fields.time);
+    if (!time) throw new Error('Reservations need a time — open the full form to add this.');
+
+    const orderIndex = await nextOrderIndex('reservations', dayId);
+    const { data, error } = await supabase
+      .from('reservations')
+      .insert({
+        trip_id: tripId,
+        day_id: dayId,
+        restaurant_name: strOrNull(suggestion.fields.restaurant_name) || card.name,
+        reservation_time: time,
+        number_of_people: numOrNull(suggestion.fields.party_size),
+        address: strOrNull(suggestion.fields.address) || card.address || null,
+        phone_number: strOrNull(suggestion.fields.phone) || card.phone || null,
+        website: strOrNull(suggestion.fields.website) || card.booking_url || card.website || null,
+        notes: strOrNull(suggestion.fields.notes),
+        place_id: card.place_id || null,
+        rating: numOrNull(card.rating),
+        order_index: orderIndex,
+        created_at: new Date().toISOString(),
+      })
+      .select('id')
+      .single();
+    if (error || !data?.id) throw new Error(error?.message || 'Failed to add reservation');
+    return { table: 'reservations', rowId: data.id, label: card.name };
+  }
+
+  // activity
+  const orderIndex = await nextOrderIndex('day_activities', dayId);
+  const { data, error } = await supabase
+    .from('day_activities')
+    .insert({
+      trip_id: tripId,
+      day_id: dayId,
+      title: strOrNull(suggestion.fields.name) || card.name,
+      description: strOrNull(suggestion.fields.notes),
+      start_time: toDbTime(suggestion.fields.start_time),
+      end_time: toDbTime(suggestion.fields.end_time),
+      location_address: strOrNull(suggestion.fields.location) || card.address || null,
+      order_index: orderIndex,
+      created_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single();
+  if (error || !data?.id) throw new Error(error?.message || 'Failed to add activity');
+  return { table: 'day_activities', rowId: data.id, label: card.name };
+}
+
+export async function undoPlaceCardItem(item: AddedPlaceCardItem): Promise<void> {
+  const pk = item.table === 'reservations' ? 'id' : 'id';
+  const { error } = await supabase.from(item.table).delete().eq(pk, item.rowId);
+  if (error) throw new Error(error.message);
+}

--- a/src/services/placeCardAddService.ts
+++ b/src/services/placeCardAddService.ts
@@ -107,7 +107,6 @@ export async function addPlaceCardItem(
 }
 
 export async function undoPlaceCardItem(item: AddedPlaceCardItem): Promise<void> {
-  const pk = item.table === 'reservations' ? 'id' : 'id';
-  const { error } = await supabase.from(item.table).delete().eq(pk, item.rowId);
+  const { error } = await supabase.from(item.table).delete().eq('id', item.rowId);
   if (error) throw new Error(error.message);
 }

--- a/src/types/ai-assistant.ts
+++ b/src/types/ai-assistant.ts
@@ -54,6 +54,30 @@ export interface AIChatThread {
   updated_at: string;
 }
 
+// Rich place recommendation card. All URLs + structured fields are populated
+// server-side from verified Google Places results — the model only authors
+// blurb, tags, an optional booking_url, and an optional suggested_add payload
+// that is validated against the trip's date window before being offered.
+export interface PlaceCard {
+  id: string;
+  place_id: string;
+  name: string;
+  address: string;
+  maps_url: string;
+  website?: string;
+  rating?: number;
+  price_level?: number;
+  phone?: string;
+  photo_url?: string;
+  booking_url?: string;
+  blurb?: string;
+  tags?: string[];
+  suggested_add?: {
+    itemType: 'reservation' | 'activity';
+    fields: Record<string, unknown>;
+  };
+}
+
 export interface AIChatMessage {
   id: string;
   thread_id: string;
@@ -69,6 +93,8 @@ export interface AIChatMessage {
     pagesUsed: number;
     originalFileName: string;
   };
+  // Rich place cards streamed alongside the assistant response.
+  placeCards?: PlaceCard[];
   // For user messages with file attachments
   attachmentPreviewUrl?: string;
   attachmentFileName?: string;

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -62,6 +62,10 @@ type StreamContext = {
   googlePlacesApiKey: string | undefined;
   searchLocation: string;
   verifiedUrls: Set<string>;
+  placesById: Map<string, PlaceResult>;
+  supabaseUrl: string;
+  arrivalDate: string;
+  departureDate: string;
   message: string;
   supabase: SupabaseClient;
   threadId: string;
@@ -111,6 +115,30 @@ type PlaceResult = {
   website?: string;
   rating?: number;
   phone?: string;
+  price_level?: number;
+  photo_reference?: string;
+};
+
+// Enriched place card shipped to the client. All URLs are either derived from
+// Google Places (verified) or booking_url that survived the verifiedUrls gate.
+type PlaceCard = {
+  id: string;
+  place_id: string;
+  name: string;
+  address: string;
+  maps_url: string;
+  website?: string;
+  rating?: number;
+  price_level?: number;
+  phone?: string;
+  photo_url?: string;
+  booking_url?: string;
+  blurb?: string;
+  tags?: string[];
+  suggested_add?: {
+    itemType: 'reservation' | 'activity';
+    fields: Record<string, unknown>;
+  };
 };
 
 // Hardcoded Google Places API base. All findPlaces() fetches target this host
@@ -145,11 +173,12 @@ async function findPlaces(query: string, apiKey: string): Promise<PlaceResult[]>
     try {
       const detailsUrl = new URL('/maps/api/place/details/json', GOOGLE_PLACES_BASE);
       detailsUrl.searchParams.set('place_id', c.place_id);
-      detailsUrl.searchParams.set('fields', 'name,place_id,formatted_address,website,rating,formatted_phone_number');
+      detailsUrl.searchParams.set('fields', 'name,place_id,formatted_address,website,rating,formatted_phone_number,photos,price_level');
       detailsUrl.searchParams.set('key', apiKey);
       const detailRes = await fetch(detailsUrl);
       const detailJson = await detailRes.json();
       const d = detailJson.result || {};
+      const firstPhoto = Array.isArray(d.photos) && d.photos.length > 0 ? d.photos[0] : null;
       return {
         name: d.name || c.name,
         place_id: c.place_id,
@@ -158,6 +187,8 @@ async function findPlaces(query: string, apiKey: string): Promise<PlaceResult[]>
         website: d.website,
         rating: d.rating ?? c.rating,
         phone: d.formatted_phone_number,
+        price_level: typeof d.price_level === 'number' ? d.price_level : undefined,
+        photo_reference: firstPhoto?.photo_reference,
       } as PlaceResult;
     } catch {
       return {
@@ -199,6 +230,139 @@ function parseCreateItemsBlock(response: string): { cleanContent: string; extrac
 
   const cleanContent = response.replace(createItemsRegex, '').trim();
   return { cleanContent, extractedItems: items };
+}
+
+type RawPlaceCard = {
+  place_id?: unknown;
+  blurb?: unknown;
+  tags?: unknown;
+  booking_url?: unknown;
+  suggested_add?: {
+    itemType?: unknown;
+    date?: unknown;
+    time?: unknown;
+    end_time?: unknown;
+    party_size?: unknown;
+    notes?: unknown;
+  };
+};
+
+function parsePlaceCardsBlock(response: string): { cleanContent: string; rawCards: RawPlaceCard[] } {
+  const regex = /```place_cards\s*([\s\S]*?)```/;
+  const match = response.match(regex);
+  if (!match) return { cleanContent: response, rawCards: [] };
+  const jsonStr = match[1].trim();
+  let rawCards: RawPlaceCard[] = [];
+  try {
+    const parsed = JSON.parse(jsonStr);
+    rawCards = (Array.isArray(parsed) ? parsed : [parsed]) as RawPlaceCard[];
+  } catch { /* ignore parse errors */ }
+  const cleanContent = response.replace(regex, '').trim();
+  return { cleanContent, rawCards };
+}
+
+function isDateInRange(date: string, arrival: string, departure: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(arrival) || !/^\d{4}-\d{2}-\d{2}$/.test(departure)) {
+    return true; // Trip has no fixed dates — trust the model's date.
+  }
+  return date >= arrival && date <= departure;
+}
+
+function isValidTime(time: unknown): time is string {
+  return typeof time === 'string' && /^\d{2}:\d{2}$/.test(time);
+}
+
+function buildSuggestedAdd(
+  raw: RawPlaceCard['suggested_add'],
+  place: PlaceResult,
+  bookingUrl: string | undefined,
+  arrival: string,
+  departure: string,
+): PlaceCard['suggested_add'] | undefined {
+  if (!raw || typeof raw.date !== 'string') return undefined;
+  if (!isDateInRange(raw.date, arrival, departure)) return undefined;
+
+  const itemType = raw.itemType === 'activity' ? 'activity' : 'reservation';
+
+  if (itemType === 'reservation') {
+    if (!isValidTime(raw.time)) return undefined;
+    return {
+      itemType: 'reservation',
+      fields: {
+        restaurant_name: place.name,
+        date: raw.date,
+        time: raw.time,
+        party_size: typeof raw.party_size === 'number' ? raw.party_size : undefined,
+        address: place.formatted_address || undefined,
+        phone: place.phone || undefined,
+        website: bookingUrl || place.website || undefined,
+        notes: typeof raw.notes === 'string' ? raw.notes : undefined,
+      },
+    };
+  }
+
+  // activity
+  return {
+    itemType: 'activity',
+    fields: {
+      name: place.name,
+      date: raw.date,
+      start_time: isValidTime(raw.time) ? raw.time : undefined,
+      end_time: isValidTime(raw.end_time) ? raw.end_time : undefined,
+      location: place.formatted_address || undefined,
+      notes: typeof raw.notes === 'string' ? raw.notes : undefined,
+    },
+  };
+}
+
+function enrichPlaceCards(
+  rawCards: RawPlaceCard[],
+  placesById: Map<string, PlaceResult>,
+  verifiedUrls: Set<string>,
+  supabaseUrl: string,
+  arrival: string,
+  departure: string,
+): PlaceCard[] {
+  const cards: PlaceCard[] = [];
+  rawCards.forEach((raw, idx) => {
+    if (typeof raw.place_id !== 'string') return;
+    const place = placesById.get(raw.place_id);
+    if (!place) return;
+
+    const photo_url = place.photo_reference
+      ? `${supabaseUrl}/functions/v1/google-places-proxy?photo_reference=${encodeURIComponent(place.photo_reference)}&maxwidth=800`
+      : undefined;
+
+    const bookingUrlRaw = typeof raw.booking_url === 'string' ? raw.booking_url : '';
+    const booking_url = bookingUrlRaw && verifiedUrls.has(bookingUrlRaw) ? bookingUrlRaw : undefined;
+
+    const suggested_add = buildSuggestedAdd(raw.suggested_add, place, booking_url, arrival, departure);
+
+    const tags = Array.isArray(raw.tags)
+      ? raw.tags.filter((t): t is string => typeof t === 'string').slice(0, 4)
+      : undefined;
+
+    const blurb = typeof raw.blurb === 'string' ? raw.blurb.slice(0, 240) : undefined;
+
+    cards.push({
+      id: `card-${idx}-${Date.now()}`,
+      place_id: place.place_id,
+      name: place.name,
+      address: place.formatted_address,
+      maps_url: place.maps_url,
+      website: place.website,
+      rating: place.rating,
+      price_level: place.price_level,
+      phone: place.phone,
+      photo_url,
+      booking_url,
+      blurb,
+      tags,
+      suggested_add,
+    });
+  });
+  return cards;
 }
 
 function accumulateToolCall(
@@ -324,7 +488,12 @@ async function handleGetMessages(supabase: SupabaseClient, tripId: string, userI
     .order('created_at', { ascending: false })
     .range(offset, offset + limit - 1);
 
-  const orderedMessages = (messages || []).reverse();
+  // Hydrate placeCards from metadata so the client can render them without
+  // re-streaming. Leave metadata in place for other consumers.
+  const orderedMessages = (messages || []).reverse().map((m: any) => ({
+    ...m,
+    placeCards: m.metadata && Array.isArray(m.metadata.placeCards) ? m.metadata.placeCards : undefined,
+  }));
   const hasMore = offset + limit < (totalCount || 0);
 
   return jsonResponse({ messages: orderedMessages, thread_id: thread.id, hasMore, totalCount }, 200, cors);
@@ -426,6 +595,38 @@ function buildSystemPrompt(params: SystemPromptParams): string {
 
   const safeTripName = sanitizeForPrompt(tripName);
 
+  const placeCardsPolicy = hasFindPlace
+    ? `## Rich Place Cards (PREFERRED for recommendations)
+When you recommend one or more restaurants, attractions, bars, landmarks, or activities, output a \`place_cards\` JSON block at the END of your response INSTEAD of listing them in prose. The client renders these as rich cards with photos, ratings, and one-tap "Add to trip" buttons.
+
+Rules:
+- You MUST first call \`find_place\` for each recommendation so we have a verified place_id.
+- Keep your prose to 1–2 sentences of introduction ("Here are three standout dinner spots in Montmartre:"). DO NOT list the places in the prose — the cards ARE the list.
+- Scope for phase 1: restaurants/dining AND attractions/activities only. Do NOT use place_cards for hotels yet.
+- Include a \`suggested_add\` block ONLY when the user gave a specific date (and time, for reservations) that falls between ${arrivalDate} and ${departureDate}. When in doubt, omit it — the user can still tap the card to add it.
+
+Format (one entry per place):
+\`\`\`place_cards
+[
+  {
+    "place_id": "ChIJ...",                           // REQUIRED, from find_place result
+    "blurb": "One sentence on why it's worth going.", // ≤200 chars
+    "tags": ["Italian", "Date night"],                // optional, max 4 short tags
+    "booking_url": "https://resy.com/...",            // optional, only if you have a verified booking URL from search_web
+    "suggested_add": {                                // optional
+      "itemType": "reservation",                      // "reservation" for dining, "activity" for attractions/tours
+      "date": "YYYY-MM-DD",                           // MUST be within ${arrivalDate}..${departureDate}
+      "time": "HH:mm",                                // REQUIRED for reservation, optional for activity
+      "end_time": "HH:mm",                            // optional, activity only
+      "party_size": 2,                                // optional, reservation only
+      "notes": "Short note"                           // optional
+    }
+  }
+]
+\`\`\`
+Do NOT invent place_id, name, address, website, rating, or phone — the server fills these in from Google Places. You only author blurb, tags, booking_url, and the optional suggested_add block.`
+    : '';
+
   return `You are a helpful travel assistant for a trip to ${safeTripName}. ${locationContext}
 Trip dates: ${arrivalDate} to ${departureDate}.${partySizeContext}${itineraryContext}
 
@@ -438,8 +639,10 @@ ${formattedTransportation}
 Guidelines:
 - Be concise and helpful
 - Use markdown formatting for readability. IMPORTANT: When writing numbered lists, put each item on its own line with a blank line between items for proper rendering
-- When listing multiple recommendations, use a numbered markdown list with each item separated by a blank line
-- Format place recommendations as: **[Place Name](verified-url)** — brief description (when you have a verified URL), otherwise **Place Name** — brief description (with no link)
+- When listing multiple recommendations, prefer the \`place_cards\` block (see below) over a markdown list.
+- For places that cannot be shown as cards (e.g. hotels in phase 1, or when find_place is unavailable), format as: **[Place Name](verified-url)** — brief description (when you have a verified URL), otherwise **Place Name** — brief description (with no link)
+
+${placeCardsPolicy}
 
 ${linkPolicy}
 
@@ -482,6 +685,7 @@ type ToolExecutionContext = {
   googlePlacesApiKey: string | undefined;
   message: string;
   verifiedUrls: Set<string>;
+  placesById: Map<string, PlaceResult>;
 };
 
 async function executeSearchWeb(
@@ -512,6 +716,7 @@ async function executeFindPlace(
   tc: ToolCall,
   googlePlacesApiKey: string,
   verifiedUrls: Set<string>,
+  placesById: Map<string, PlaceResult>,
 ): Promise<{ role: 'tool'; tool_call_id: string; content: string }> {
   try {
     const argsStr = (tc.function.arguments || '').trim();
@@ -527,13 +732,17 @@ async function executeFindPlace(
     for (const p of places) {
       verifiedUrls.add(p.maps_url);
       if (p.website) verifiedUrls.add(p.website);
+      placesById.set(p.place_id, p);
     }
     // Give the model a compact, unambiguous structured payload so it can
-    // quote verified URLs instead of authoring new ones.
+    // quote verified URLs instead of authoring new ones. place_id is included
+    // so the model can reference cards in a `place_cards` block.
     const payload = places.map((p) => ({
+      place_id: p.place_id,
       name: p.name,
       address: p.formatted_address,
       rating: p.rating,
+      price_level: p.price_level,
       phone: p.phone,
       website: p.website || null,
       maps_url: p.maps_url,
@@ -554,7 +763,7 @@ async function executeToolCalls(
     if (tc.function.name === 'search_web' && ctx.serperApiKey) {
       toolResults.push(await executeSearchWeb(tc, ctx.serperApiKey, ctx.message, ctx.verifiedUrls));
     } else if (tc.function.name === 'find_place' && ctx.googlePlacesApiKey) {
-      toolResults.push(await executeFindPlace(tc, ctx.googlePlacesApiKey, ctx.verifiedUrls));
+      toolResults.push(await executeFindPlace(tc, ctx.googlePlacesApiKey, ctx.verifiedUrls, ctx.placesById));
     } else {
       toolResults.push({ role: 'tool', tool_call_id: tc.id, content: `Tool "${tc.function.name}" is not available in this environment.` });
     }
@@ -719,20 +928,29 @@ async function handleToolCallFollowUp(
   return fallback;
 }
 
+type FinalEventsParams = {
+  finalContent: string;
+  fallbackMsg: string;
+  placeCards: PlaceCard[];
+  model: string;
+  threadId: string;
+  savedId: string | undefined;
+};
+
 function emitFinalEvents(
   controller: { enqueue: (chunk: Uint8Array) => void; close: () => void },
   encoder: TextEncoder,
-  finalContent: string,
-  fallbackMsg: string,
-  model: string,
-  threadId: string,
-  savedId: string | undefined
+  params: FinalEventsParams,
 ): void {
+  const { finalContent, fallbackMsg, placeCards, model, threadId, savedId } = params;
   const { cleanContent, extractedItems } = parseCreateItemsBlock(finalContent);
   const contentToSave = cleanContent || finalContent;
 
   if (extractedItems.length > 0) {
     controller.enqueue(encoder.encode(`event: extracted_items\ndata: ${JSON.stringify({ items: extractedItems, meta: { model, source: 'conversation' } })}\n\n`));
+  }
+  if (placeCards.length > 0) {
+    controller.enqueue(encoder.encode(`event: place_cards\ndata: ${JSON.stringify({ cards: placeCards })}\n\n`));
   }
   if (fallbackMsg && finalContent === fallbackMsg) {
     controller.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({ content: fallbackMsg })}\n\n`));
@@ -763,6 +981,7 @@ async function handleStreamResponse(
     googlePlacesApiKey: ctx.googlePlacesApiKey,
     message: ctx.message,
     verifiedUrls: ctx.verifiedUrls,
+    placesById: ctx.placesById,
   };
 
   const hasToolSupport = !!ctx.serperApiKey || !!ctx.googlePlacesApiKey;
@@ -777,9 +996,18 @@ async function handleStreamResponse(
   const fallbackMsg = toolCalls?.length ? 'I searched for booking options but couldn\'t format the results. Try searching for the restaurant name plus your city on Resy or OpenTable.' : '';
   const rawFinal = lastResponse.trim() || fallbackMsg;
 
-  // Strip any `create_items` block before URL validation so we don't touch JSON.
-  const { cleanContent, extractedItems } = parseCreateItemsBlock(rawFinal);
-  const prosePart = cleanContent || rawFinal;
+  // Strip structured blocks before URL validation so JSON payloads aren't touched.
+  const { cleanContent: afterCreateItems, extractedItems } = parseCreateItemsBlock(rawFinal);
+  const { cleanContent: prosePart, rawCards } = parsePlaceCardsBlock(afterCreateItems);
+
+  const placeCards = enrichPlaceCards(
+    rawCards,
+    ctx.placesById,
+    ctx.verifiedUrls,
+    ctx.supabaseUrl,
+    ctx.arrivalDate,
+    ctx.departureDate,
+  );
 
   // Replace any AI-authored URLs with Google Search fallbacks unless they
   // were returned by a tool or point to a trusted host (Google, Wikipedia).
@@ -791,8 +1019,20 @@ async function handleStreamResponse(
     : validatedProse;
   const contentToSave = validatedProse;
 
-  const { data: saved } = await ctx.supabase.from('ai_chat_messages').insert({ thread_id: ctx.threadId, role: 'assistant', content: contentToSave || '(No response)' }).select('id').single();
-  emitFinalEvents(controller, encoder, finalContent, fallbackMsg, ctx.openaiOptions.model, ctx.threadId, saved?.id);
+  const metadata = placeCards.length > 0 ? { placeCards } : {};
+  const { data: saved } = await ctx.supabase
+    .from('ai_chat_messages')
+    .insert({ thread_id: ctx.threadId, role: 'assistant', content: contentToSave || '(No response)', metadata })
+    .select('id')
+    .single();
+  emitFinalEvents(controller, encoder, {
+    finalContent,
+    fallbackMsg,
+    placeCards,
+    model: ctx.openaiOptions.model,
+    threadId: ctx.threadId,
+    savedId: saved?.id,
+  });
 }
 
 async function handlePostMessage(
@@ -848,6 +1088,8 @@ async function handlePostMessage(
   const forceToolName = chooseForcedTool(message, !!googlePlacesApiKey, !!serperApiKey);
   const encoder = new TextEncoder();
 
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+
   const ctx: StreamContext = {
     openaiMsgs,
     openaiOptions: { model, openaiApiKey, tools },
@@ -856,6 +1098,10 @@ async function handlePostMessage(
     googlePlacesApiKey,
     searchLocation,
     verifiedUrls: new Set<string>(),
+    placesById: new Map<string, PlaceResult>(),
+    supabaseUrl,
+    arrivalDate,
+    departureDate,
     message,
     supabase,
     threadId

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -23,6 +23,11 @@ function getCorsHeaders(origin: string | null): Record<string, string> {
 
 type SupabaseClient = ReturnType<typeof createClient>;
 
+// Hardcoded model — locked at the function layer so no request path or env
+// override can redirect traffic to a different (potentially unvetted) model.
+const GEMINI_MODEL = 'gemini-2.5-flash';
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
 type ExtractedItem = {
   id: string;
   itemType: string;
@@ -32,31 +37,35 @@ type ExtractedItem = {
   status: 'pending';
 };
 
-type ToolCall = {
-  id: string;
-  type: string;
-  function: { name: string; arguments: string };
-};
+type GeminiFunctionCall = { name: string; args: Record<string, unknown> };
 
-type OpenAIMessage = {
-  role: string;
-  content?: string | null;
-  tool_calls?: any[];
-  tool_call_id?: string;
-  name?: string;
-};
+type GeminiFunctionResponse = { name: string; response: Record<string, unknown> };
 
-type OpenAIOptions = {
-  model: string;
-  openaiApiKey: string;
-  tools?: any[];
-  forceToolName?: string | null;
+type GeminiPart =
+  | { text: string }
+  | { functionCall: GeminiFunctionCall }
+  | { functionResponse: GeminiFunctionResponse };
+
+type GeminiContent = { role: 'user' | 'model'; parts: GeminiPart[] };
+
+type GeminiTool = { functionDeclarations: any[] };
+
+type GeminiToolMode = 'AUTO' | 'ANY' | 'NONE';
+
+type GeminiOptions = {
+  apiKey: string;
+  tools?: GeminiTool[];
+  toolMode?: GeminiToolMode;
+  allowedFunctionNames?: string[];
   skipTools?: boolean;
+  temperature?: number;
+  maxOutputTokens?: number;
 };
 
 type StreamContext = {
-  openaiMsgs: OpenAIMessage[];
-  openaiOptions: OpenAIOptions;
+  systemInstruction: string;
+  contents: GeminiContent[];
+  geminiOptions: GeminiOptions;
   forceToolName: string | null;
   serperApiKey: string | undefined;
   googlePlacesApiKey: string | undefined;
@@ -365,103 +374,109 @@ function enrichPlaceCards(
   return cards;
 }
 
-function accumulateToolCall(
-  toolCallsAcc: Array<ToolCall | undefined>,
-  tcArgs: Record<number, string>,
-  tc: any
-): void {
-  const idx = tc.index ?? 0;
-  if (!toolCallsAcc[idx]) {
-    toolCallsAcc[idx] = {
-      id: tc.id || `call_${idx}`,
-      type: tc.type || 'function',
-      function: { name: tc.function?.name || '', arguments: '' }
-    };
-  }
-  if (tc.id) toolCallsAcc[idx]!.id = tc.id;
-  if (tc.function?.name) toolCallsAcc[idx]!.function.name = tc.function.name;
-  if (tc.function?.arguments) tcArgs[idx] = (tcArgs[idx] || '') + tc.function.arguments;
-}
+type GeminiStreamState = { textContent: string; functionCalls: GeminiFunctionCall[] };
 
-function processStreamLine(
+// Gemini streams SSE messages of the shape
+//   data: {"candidates":[{"content":{"role":"model","parts":[...parts]}, "finishReason":...}]}
+// Parts can be either {text} or {functionCall:{name,args}}. Unlike OpenAI,
+// functionCall arrives as a complete object in a single chunk — not as
+// incremental argument deltas — so no accumulator is needed.
+function processGeminiStreamLine(
   line: string,
-  state: { content: string },
-  toolCallsAcc: Array<ToolCall | undefined>,
-  tcArgs: Record<number, string>,
+  state: GeminiStreamState,
   controller: { enqueue: (chunk: Uint8Array) => void },
   encoder: TextEncoder
 ): void {
-  if (!line.startsWith('data: ') || line.slice(6) === '[DONE]') return;
+  if (!line.startsWith('data: ')) return;
+  const payload = line.slice(6).trim();
+  if (!payload) return;
   try {
-    const data = JSON.parse(line.slice(6));
-    const delta = data.choices?.[0]?.delta;
-    if (delta?.content) {
-      state.content += delta.content;
-      controller.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({ content: delta.content })}\n\n`));
-    }
-    if (delta?.tool_calls) {
-      for (const tc of delta.tool_calls) {
-        accumulateToolCall(toolCallsAcc, tcArgs, tc);
+    const data = JSON.parse(payload);
+    const parts = data.candidates?.[0]?.content?.parts || [];
+    for (const part of parts) {
+      if (typeof part?.text === 'string' && part.text.length > 0) {
+        state.textContent += part.text;
+        controller.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({ content: part.text })}\n\n`));
+      } else if (part?.functionCall && typeof part.functionCall.name === 'string') {
+        state.functionCalls.push({
+          name: part.functionCall.name,
+          args: (part.functionCall.args as Record<string, unknown>) || {},
+        });
       }
     }
   } catch { /* ignore malformed SSE chunks */ }
 }
 
-function finalizeToolCalls(
-  toolCallsAcc: Array<ToolCall | undefined>,
-  tcArgs: Record<number, string>
-): ToolCall[] | null {
-  const withIndex = toolCallsAcc
-    .map((tc, i) => (tc ? { tc, i } : null))
-    .filter(Boolean) as Array<{ tc: ToolCall; i: number }>;
-  if (withIndex.length === 0) return null;
-  return withIndex.map(({ tc, i }) => ({
-    ...tc,
-    function: { ...tc.function, arguments: tcArgs[i] ?? tc.function?.arguments ?? '' }
-  }));
-}
-
-async function processStream(
-  openaiRes: Response,
+async function processGeminiStream(
+  geminiRes: Response,
   controller: { enqueue: (chunk: Uint8Array) => void },
   encoder: TextEncoder
-): Promise<{ fullResponse: string; toolCalls: ToolCall[] | null }> {
-  const reader = openaiRes.body!.getReader();
+): Promise<GeminiStreamState> {
+  const reader = geminiRes.body!.getReader();
   const decoder = new TextDecoder();
-  const state = { content: '' };
-  const toolCallsAcc: Array<ToolCall | undefined> = [];
-  const tcArgs: Record<number, string> = {};
+  const state: GeminiStreamState = { textContent: '', functionCalls: [] };
+  let buffer = '';
 
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    const chunk = decoder.decode(value, { stream: true });
-    for (const line of chunk.split('\n')) {
-      processStreamLine(line, state, toolCallsAcc, tcArgs, controller, encoder);
+    buffer += decoder.decode(value, { stream: true });
+    // SSE messages are \n\n delimited. Each message can contain multiple
+    // lines; we only care about `data:` lines.
+    let boundary: number;
+    while ((boundary = buffer.indexOf('\n\n')) !== -1) {
+      const message = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      for (const line of message.split('\n')) {
+        processGeminiStreamLine(line, state, controller, encoder);
+      }
+    }
+  }
+  if (buffer.trim()) {
+    for (const line of buffer.split('\n')) {
+      processGeminiStreamLine(line, state, controller, encoder);
     }
   }
 
-  return { fullResponse: state.content, toolCalls: finalizeToolCalls(toolCallsAcc, tcArgs) };
+  return state;
 }
 
-async function callOpenAI(messages: OpenAIMessage[], stream: boolean, options: OpenAIOptions): Promise<Response> {
+async function callGemini(
+  systemInstruction: string,
+  contents: GeminiContent[],
+  stream: boolean,
+  options: GeminiOptions,
+): Promise<Response> {
+  const endpoint = stream ? 'streamGenerateContent' : 'generateContent';
+  const url = `${GEMINI_BASE}/models/${GEMINI_MODEL}:${endpoint}${stream ? '?alt=sse' : ''}`;
+
   const body: Record<string, unknown> = {
-    model: options.model,
-    messages,
-    stream,
-    temperature: 0.7,
-    max_completion_tokens: 1500
+    contents,
+    systemInstruction: { parts: [{ text: systemInstruction }] },
+    generationConfig: {
+      temperature: options.temperature ?? 0.7,
+      maxOutputTokens: options.maxOutputTokens ?? 1500,
+    },
   };
+
   if (options.tools && !options.skipTools) {
     body.tools = options.tools;
-    if (options.forceToolName) {
-      body.tool_choice = { type: 'function' as const, function: { name: options.forceToolName } };
+    if (options.toolMode) {
+      body.toolConfig = {
+        functionCallingConfig: {
+          mode: options.toolMode,
+          ...(options.allowedFunctionNames && options.allowedFunctionNames.length > 0
+            ? { allowedFunctionNames: options.allowedFunctionNames }
+            : {}),
+        },
+      };
     }
   }
-  return fetch('https://api.openai.com/v1/chat/completions', {
+
+  return fetch(url, {
     method: 'POST',
-    headers: { 'Authorization': `Bearer ${options.openaiApiKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
+    headers: { 'x-goog-api-key': options.apiKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
   });
 }
 
@@ -689,45 +704,48 @@ type ToolExecutionContext = {
 };
 
 async function executeSearchWeb(
-  tc: ToolCall,
+  call: GeminiFunctionCall,
   serperApiKey: string,
   message: string,
   verifiedUrls: Set<string>,
-): Promise<{ role: 'tool'; tool_call_id: string; content: string }> {
+): Promise<GeminiFunctionResponse> {
   try {
-    const argsStr = (tc.function.arguments || '').trim();
-    const args = argsStr ? JSON.parse(argsStr) : {};
-    const q = extractSearchQuery(args);
+    const q = extractSearchQuery(call.args);
     const searchQuery = q || message || 'restaurant reservations';
     const results = await searchWeb(searchQuery, serperApiKey);
     const organic = (results.organic || []).slice(0, 6);
     for (const r of organic) {
       if (r.link) verifiedUrls.add(r.link);
     }
-    const summary = organic.map((r) => `${r.title}: ${r.link}`).join('\n');
-    return { role: 'tool', tool_call_id: tc.id, content: summary || 'No results found.' };
+    return {
+      name: 'search_web',
+      response: {
+        results: organic.map((r) => ({ title: r.title, link: r.link, snippet: r.snippet || '' })),
+      },
+    };
   } catch (error_) {
     const errorMsg = error_ instanceof Error ? error_.message : 'Unknown';
-    return { role: 'tool', tool_call_id: tc.id, content: `Search error: ${errorMsg}. Do not fabricate a URL; tell the user to search manually.` };
+    return {
+      name: 'search_web',
+      response: { error: `Search error: ${errorMsg}. Do not fabricate a URL; tell the user to search manually.` },
+    };
   }
 }
 
 async function executeFindPlace(
-  tc: ToolCall,
+  call: GeminiFunctionCall,
   googlePlacesApiKey: string,
   verifiedUrls: Set<string>,
   placesById: Map<string, PlaceResult>,
-): Promise<{ role: 'tool'; tool_call_id: string; content: string }> {
+): Promise<GeminiFunctionResponse> {
   try {
-    const argsStr = (tc.function.arguments || '').trim();
-    const args = argsStr ? JSON.parse(argsStr) : {};
-    const query = typeof args.query === 'string' ? args.query : '';
+    const query = typeof call.args.query === 'string' ? call.args.query : '';
     if (!query) {
-      return { role: 'tool', tool_call_id: tc.id, content: 'find_place error: missing "query" argument.' };
+      return { name: 'find_place', response: { error: 'missing "query" argument' } };
     }
     const places = await findPlaces(query, googlePlacesApiKey);
     if (places.length === 0) {
-      return { role: 'tool', tool_call_id: tc.id, content: 'No matching places found.' };
+      return { name: 'find_place', response: { results: [], message: 'No matching places found.' } };
     }
     for (const p of places) {
       verifiedUrls.add(p.maps_url);
@@ -737,7 +755,7 @@ async function executeFindPlace(
     // Give the model a compact, unambiguous structured payload so it can
     // quote verified URLs instead of authoring new ones. place_id is included
     // so the model can reference cards in a `place_cards` block.
-    const payload = places.map((p) => ({
+    const results = places.map((p) => ({
       place_id: p.place_id,
       name: p.name,
       address: p.formatted_address,
@@ -747,69 +765,66 @@ async function executeFindPlace(
       website: p.website || null,
       maps_url: p.maps_url,
     }));
-    return { role: 'tool', tool_call_id: tc.id, content: JSON.stringify(payload) };
+    return { name: 'find_place', response: { results } };
   } catch (error_) {
     const errorMsg = error_ instanceof Error ? error_.message : 'Unknown';
-    return { role: 'tool', tool_call_id: tc.id, content: `find_place error: ${errorMsg}. Do not fabricate a URL.` };
+    return { name: 'find_place', response: { error: `${errorMsg}. Do not fabricate a URL.` } };
   }
 }
 
 async function executeToolCalls(
-  toolCalls: ToolCall[],
+  functionCalls: GeminiFunctionCall[],
   ctx: ToolExecutionContext,
-): Promise<Array<{ role: 'tool'; tool_call_id: string; content: string }>> {
-  const toolResults: Array<{ role: 'tool'; tool_call_id: string; content: string }> = [];
-  for (const tc of toolCalls) {
-    if (tc.function.name === 'search_web' && ctx.serperApiKey) {
-      toolResults.push(await executeSearchWeb(tc, ctx.serperApiKey, ctx.message, ctx.verifiedUrls));
-    } else if (tc.function.name === 'find_place' && ctx.googlePlacesApiKey) {
-      toolResults.push(await executeFindPlace(tc, ctx.googlePlacesApiKey, ctx.verifiedUrls, ctx.placesById));
+): Promise<GeminiFunctionResponse[]> {
+  const results: GeminiFunctionResponse[] = [];
+  for (const call of functionCalls) {
+    if (call.name === 'search_web' && ctx.serperApiKey) {
+      results.push(await executeSearchWeb(call, ctx.serperApiKey, ctx.message, ctx.verifiedUrls));
+    } else if (call.name === 'find_place' && ctx.googlePlacesApiKey) {
+      results.push(await executeFindPlace(call, ctx.googlePlacesApiKey, ctx.verifiedUrls, ctx.placesById));
     } else {
-      toolResults.push({ role: 'tool', tool_call_id: tc.id, content: `Tool "${tc.function.name}" is not available in this environment.` });
+      results.push({ name: call.name, response: { error: `Tool "${call.name}" is not available in this environment.` } });
     }
   }
-  return toolResults;
+  return results;
 }
 
-function buildTools(serperApiKey: string | undefined, googlePlacesApiKey: string | undefined): any[] | undefined {
-  const tools: any[] = [];
+function buildTools(
+  serperApiKey: string | undefined,
+  googlePlacesApiKey: string | undefined,
+): GeminiTool[] | undefined {
+  const decls: any[] = [];
 
   if (googlePlacesApiKey) {
-    tools.push({
-      type: 'function' as const,
-      function: {
-        name: 'find_place',
-        description: 'Look up a specific place (restaurant, hotel, landmark, attraction) on Google Places. Returns verified name, address, website, phone, rating, and a canonical Google Maps URL. Use this whenever you recommend or reference a specific place so that the URL you cite is real.',
-        parameters: {
-          type: 'object',
-          properties: {
-            query: {
-              type: 'string',
-              description: 'Free-text place query, e.g. "Carbone restaurant NYC" or "Hotel Bel-Air Los Angeles".',
-            },
+    decls.push({
+      name: 'find_place',
+      description: 'Look up a specific place (restaurant, hotel, landmark, attraction) on Google Places. Returns verified name, address, website, phone, rating, and a canonical Google Maps URL. Use this whenever you recommend or reference a specific place so that the URL you cite is real.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Free-text place query, e.g. "Carbone restaurant NYC" or "Hotel Bel-Air Los Angeles".',
           },
-          required: ['query'],
         },
+        required: ['query'],
       },
     });
   }
 
   if (serperApiKey) {
-    tools.push({
-      type: 'function' as const,
-      function: {
-        name: 'search_web',
-        description: 'Search the web for up-to-date information. Use only for time-sensitive queries that find_place cannot answer: restaurant booking pages (Resy, OpenTable), weather, current events, opening hours, exchange rates.',
-        parameters: {
-          type: 'object',
-          properties: { query: { type: 'string', description: 'Search query, e.g. "Carbone NYC site:resy.com"' } },
-          required: ['query'],
-        },
+    decls.push({
+      name: 'search_web',
+      description: 'Search the web for up-to-date information. Use only for time-sensitive queries that find_place cannot answer: restaurant booking pages (Resy, OpenTable), weather, current events, opening hours, exchange rates.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'Search query, e.g. "Carbone NYC site:resy.com"' } },
+        required: ['query'],
       },
     });
   }
 
-  return tools.length > 0 ? tools : undefined;
+  return decls.length > 0 ? [{ functionDeclarations: decls }] : undefined;
 }
 
 const DINING_KEYWORDS = /\b(restaurant|restaurants|dining|dinner|lunch|eat|food|reservation|reservations|book a table|opentable|resy|carbone)\b/i;
@@ -898,10 +913,11 @@ function deriveSearchLocation(primaryDestination: string | null, accommodations:
 }
 
 type ToolCallFollowUpParams = {
-  toolCalls: ToolCall[];
-  fullResponse: string;
-  currentMessages: OpenAIMessage[];
-  openaiOptions: OpenAIOptions;
+  functionCalls: GeminiFunctionCall[];
+  textSoFar: string;
+  contents: GeminiContent[];
+  systemInstruction: string;
+  geminiOptions: GeminiOptions;
   toolCtx: ToolExecutionContext;
 };
 
@@ -910,19 +926,33 @@ async function handleToolCallFollowUp(
   controller: { enqueue: (chunk: Uint8Array) => void },
   encoder: TextEncoder
 ): Promise<string> {
-  const { toolCalls, fullResponse, currentMessages, openaiOptions, toolCtx } = params;
-  const assistantMsg = { role: 'assistant' as const, content: fullResponse || null, tool_calls: toolCalls };
-  const toolResults = await executeToolCalls(toolCalls, toolCtx);
-  const updatedMessages = [...currentMessages, assistantMsg, ...toolResults];
-  const followRes = await callOpenAI(updatedMessages, true, { ...openaiOptions, skipTools: true });
+  const { functionCalls, textSoFar, contents, systemInstruction, geminiOptions, toolCtx } = params;
 
-  if (followRes.ok) {
-    const { fullResponse: followContent } = await processStream(followRes, controller, encoder);
-    return followContent;
+  // Re-inject the model's turn (any text it produced + its function calls),
+  // then a user turn containing the matching functionResponse parts. This is
+  // Gemini's equivalent of OpenAI's tool-result messages.
+  const modelParts: GeminiPart[] = [];
+  if (textSoFar) modelParts.push({ text: textSoFar });
+  for (const call of functionCalls) modelParts.push({ functionCall: call });
+
+  const toolResponses = await executeToolCalls(functionCalls, toolCtx);
+  const responseParts: GeminiPart[] = toolResponses.map((r) => ({ functionResponse: r }));
+
+  const updatedContents: GeminiContent[] = [
+    ...contents,
+    { role: 'model', parts: modelParts },
+    { role: 'user', parts: responseParts },
+  ];
+
+  const followRes = await callGemini(systemInstruction, updatedContents, true, { ...geminiOptions, skipTools: true });
+
+  if (followRes.ok && followRes.body) {
+    const followState = await processGeminiStream(followRes, controller, encoder);
+    return followState.textContent;
   }
 
-  const errBody = await followRes.text();
-  console.error('OpenAI follow-up error:', followRes.status, errBody);
+  const errBody = await followRes.text().catch(() => '');
+  console.error('Gemini follow-up error:', followRes.status, errBody);
   const fallback = 'I found some booking options but had trouble formatting them. Try searching for the restaurant name plus your city on Resy or OpenTable.';
   controller.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({ content: fallback })}\n\n`));
   return fallback;
@@ -964,17 +994,22 @@ async function handleStreamResponse(
   encoder: TextEncoder,
   ctx: StreamContext
 ): Promise<void> {
-  const currentMessages = [...ctx.openaiMsgs];
-  const openaiRes = await callOpenAI(currentMessages, true, { ...ctx.openaiOptions, forceToolName: ctx.forceToolName });
+  const geminiRes = await callGemini(ctx.systemInstruction, ctx.contents, true, {
+    ...ctx.geminiOptions,
+    toolMode: ctx.forceToolName ? 'ANY' : 'AUTO',
+    allowedFunctionNames: ctx.forceToolName ? [ctx.forceToolName] : undefined,
+  });
 
-  if (!openaiRes.ok) {
+  if (!geminiRes.ok || !geminiRes.body) {
+    const errBody = await geminiRes.text().catch(() => '');
+    console.error('Gemini error:', geminiRes.status, errBody);
     controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ message: 'AI request failed' })}\n\n`));
     controller.close();
     return;
   }
 
-  const { fullResponse, toolCalls } = await processStream(openaiRes, controller, encoder);
-  let lastResponse = fullResponse;
+  const firstPass = await processGeminiStream(geminiRes, controller, encoder);
+  let lastResponse = firstPass.textContent;
 
   const toolCtx: ToolExecutionContext = {
     serperApiKey: ctx.serperApiKey,
@@ -985,15 +1020,18 @@ async function handleStreamResponse(
   };
 
   const hasToolSupport = !!ctx.serperApiKey || !!ctx.googlePlacesApiKey;
-  if (toolCalls && toolCalls.length > 0 && hasToolSupport) {
+  if (firstPass.functionCalls.length > 0 && hasToolSupport) {
     lastResponse = await handleToolCallFollowUp({
-      toolCalls, fullResponse, currentMessages,
-      openaiOptions: ctx.openaiOptions,
+      functionCalls: firstPass.functionCalls,
+      textSoFar: firstPass.textContent,
+      contents: ctx.contents,
+      systemInstruction: ctx.systemInstruction,
+      geminiOptions: ctx.geminiOptions,
       toolCtx,
     }, controller, encoder);
   }
 
-  const fallbackMsg = toolCalls?.length ? 'I searched for booking options but couldn\'t format the results. Try searching for the restaurant name plus your city on Resy or OpenTable.' : '';
+  const fallbackMsg = firstPass.functionCalls.length > 0 ? 'I searched for booking options but couldn\'t format the results. Try searching for the restaurant name plus your city on Resy or OpenTable.' : '';
   const rawFinal = lastResponse.trim() || fallbackMsg;
 
   // Strip structured blocks before URL validation so JSON payloads aren't touched.
@@ -1029,7 +1067,7 @@ async function handleStreamResponse(
     finalContent,
     fallbackMsg,
     placeCards,
-    model: ctx.openaiOptions.model,
+    model: GEMINI_MODEL,
     threadId: ctx.threadId,
     savedId: saved?.id,
   });
@@ -1040,10 +1078,9 @@ async function handlePostMessage(
   supabase: SupabaseClient,
   tripId: string,
   userId: string,
-  openaiApiKey: string,
+  geminiApiKey: string,
   serperApiKey: string | undefined,
   googlePlacesApiKey: string | undefined,
-  model: string,
   cors: Record<string, string> = {}
 ): Promise<Response> {
   const { message, thread_id } = await req.json();
@@ -1084,15 +1121,27 @@ async function handlePostMessage(
   });
 
   const tools = buildTools(serperApiKey, googlePlacesApiKey);
-  const openaiMsgs: OpenAIMessage[] = [{ role: 'system', content: systemPrompt }, ...(msgs || []).reverse().map((m: any) => ({ role: m.role, content: m.content }))];
+
+  // Convert chat history to Gemini `contents`. Gemini uses 'model' for
+  // assistant turns (not 'assistant') and has no system role — the system
+  // prompt is passed separately via systemInstruction.
+  const contents: GeminiContent[] = (msgs || [])
+    .reverse()
+    .filter((m: any) => m.role === 'user' || m.role === 'assistant')
+    .map((m: any) => ({
+      role: m.role === 'assistant' ? 'model' as const : 'user' as const,
+      parts: [{ text: String(m.content ?? '') }],
+    }));
+
   const forceToolName = chooseForcedTool(message, !!googlePlacesApiKey, !!serperApiKey);
   const encoder = new TextEncoder();
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
 
   const ctx: StreamContext = {
-    openaiMsgs,
-    openaiOptions: { model, openaiApiKey, tools },
+    systemInstruction: systemPrompt,
+    contents,
+    geminiOptions: { apiKey: geminiApiKey, tools },
     forceToolName,
     serperApiKey,
     googlePlacesApiKey,
@@ -1160,10 +1209,9 @@ Deno.serve(async (req: Request) => {
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-  const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
+  const geminiApiKey = Deno.env.get('GEMINI_API_KEY');
   const serperApiKey = Deno.env.get('SERPER_API_KEY');
   const googlePlacesApiKey = Deno.env.get('GOOGLE_PLACES_API_KEY');
-  const model = Deno.env.get('OPENAI_CHAT_MODEL') || 'gpt-5.4-mini';
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
@@ -1186,8 +1234,8 @@ Deno.serve(async (req: Request) => {
   }
 
   if (req.method === 'POST' && !action) {
-    if (!openaiApiKey) return jsonResponse({ code: 'CONFIG_ERROR', message: 'OpenAI not configured' }, 500, corsHeaders);
-    return handlePostMessage(req, supabase, tripId, user.userId, openaiApiKey, serperApiKey, googlePlacesApiKey, model, corsHeaders);
+    if (!geminiApiKey) return jsonResponse({ code: 'CONFIG_ERROR', message: 'Gemini not configured' }, 500, corsHeaders);
+    return handlePostMessage(req, supabase, tripId, user.userId, geminiApiKey, serperApiKey, googlePlacesApiKey, corsHeaders);
   }
 
   return jsonResponse({ error: 'Method not allowed' }, 405, corsHeaders);

--- a/supabase/functions/parse-travel-doc/index.ts
+++ b/supabase/functions/parse-travel-doc/index.ts
@@ -1,5 +1,5 @@
 // supabase/functions/parse-travel-doc/index.ts
-// Deno Edge Function: OCR + structured extraction via OpenAI (gpt-4o-mini by default).
+// Deno Edge Function: OCR + structured extraction via Gemini 2.5 Flash.
 // Returns a canonical response: { itemType, fields, missingRequired, meta } for single-item mode
 // OR { items: [...], meta } for multi-item mode (when itemType is not specified).
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
@@ -21,8 +21,11 @@ function getCorsHeaders(origin: string | null): Record<string, string> {
     'Access-Control-Allow-Methods': 'POST, GET, DELETE, OPTIONS',
   };
 }
-const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY") ?? "";
-const MODEL = Deno.env.get("OPENAI_OCR_MODEL") ?? "gpt-4o-mini";
+const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY") ?? "";
+// Hardcoded model — locked at the function layer so the request path cannot
+// redirect to a different model.
+const MODEL = "gemini-2.5-flash";
+const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
 const MAX_FILE_BYTES = 15 * 1024 * 1024; // 15 MB
@@ -54,9 +57,10 @@ const ok = (json: unknown, status = 200)=>new Response(JSON.stringify(json), {
 const err = (msg: string, status = 400)=>ok({
     error: msg
   }, status);
-// ----------------- File → data URL -----------------
-// SAFE: chunked base64 conversion (prevents call stack overflow)
-const toDataUrl = async (file)=>{
+// ----------------- File → inline base64 -----------------
+// SAFE: chunked base64 conversion (prevents call stack overflow). Returns the
+// raw base64 string + mime, which Gemini consumes via inlineData.
+const toInlineData = async (file)=>{
   const buf = await file.arrayBuffer();
   const bytes = new Uint8Array(buf);
   let binary = "";
@@ -65,9 +69,10 @@ const toDataUrl = async (file)=>{
     const slice = bytes.subarray(i, i + CHUNK);
     binary += String.fromCharCode.apply(null, slice);
   }
-  const base64 = btoa(binary);
-  const mime = file.type || "application/octet-stream";
-  return `data:${mime};base64,${base64}`;
+  return {
+    data: btoa(binary),
+    mimeType: file.type || "application/octet-stream",
+  };
 };
 // ----------------- Prompt builder -----------------
 /**
@@ -563,39 +568,44 @@ const applyDateAssumptions = (itemType, fields)=>{
   return fields;
 };
 // ----------------- Shared helpers -----------------
-const buildVisionPayload = (system, user, dataUrl, maxTokens)=>({
-  model: MODEL,
-  messages: [
-    { role: "system", content: system },
+const buildVisionPayload = (system, user, inlineData, maxTokens)=>({
+  contents: [
     {
       role: "user",
-      content: [
-        { type: "text", text: user },
-        { type: "image_url", image_url: { url: dataUrl } }
+      parts: [
+        { text: user },
+        { inlineData }
       ]
     }
   ],
-  response_format: { type: "json_object" },
-  temperature: 0,
-  max_completion_tokens: maxTokens
+  systemInstruction: { parts: [{ text: system }] },
+  generationConfig: {
+    temperature: 0,
+    maxOutputTokens: maxTokens,
+    responseMimeType: "application/json"
+  }
 });
 
-const callOpenAI = async (payload)=>{
-  const aiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+const callGemini = async (payload)=>{
+  const url = `${GEMINI_BASE}/models/${MODEL}:generateContent`;
+  const aiRes = await fetch(url, {
     method: "POST",
     headers: {
-      authorization: `Bearer ${OPENAI_API_KEY}`,
+      "x-goog-api-key": GEMINI_API_KEY,
       "content-type": "application/json"
     },
     body: JSON.stringify(payload)
   });
   if (!aiRes.ok) {
     const txt = await aiRes.text();
-    console.error("OpenAI error:", aiRes.status, txt);
-    return { error: err("OpenAI request failed", 502) };
+    console.error("Gemini error:", aiRes.status, txt);
+    return { error: err("Gemini request failed", 502) };
   }
   const json = await aiRes.json();
-  const raw = json?.choices?.[0]?.message?.content?.trim();
+  // generateContent returns candidates[0].content.parts[]; with
+  // responseMimeType=application/json the model's JSON is in the text part.
+  const parts = json?.candidates?.[0]?.content?.parts || [];
+  const raw = parts.map((p)=>typeof p?.text === "string" ? p.text : "").join("").trim();
   if (!raw) return { error: err("No content generated", 500) };
   try {
     return { data: JSON.parse(raw) };
@@ -642,10 +652,10 @@ const validateFile = (file)=>{
   return null;
 };
 
-const handleMultiItem = async (dataUrl, file)=>{
+const handleMultiItem = async (inlineData, file)=>{
   const { system, user } = multiItemPrompt();
-  const payload = buildVisionPayload(system, user, dataUrl, 4000);
-  const result = await callOpenAI(payload);
+  const payload = buildVisionPayload(system, user, inlineData, 4000);
+  const result = await callGemini(payload);
   if (result.error) return result.error;
 
   const rawItems = Array.isArray(result.data.items) ? result.data.items : [];
@@ -662,15 +672,15 @@ const handleMultiItem = async (dataUrl, file)=>{
   });
 };
 
-const handleSingleItem = async (itemType, dataUrl, file)=>{
+const handleSingleItem = async (itemType, inlineData, file)=>{
   const validTypes = ["accommodation", "transportation", "activity", "reservation"];
   if (!validTypes.includes(itemType)) {
     return err(`Invalid itemType. Must be one of: ${validTypes.join(", ")} or 'auto' for multi-item mode`);
   }
 
   const { system, user } = promptFor(itemType);
-  const payload = buildVisionPayload(system, user, dataUrl, 1200);
-  const result = await callOpenAI(payload);
+  const payload = buildVisionPayload(system, user, inlineData, 1200);
+  const result = await callGemini(payload);
   if (result.error) return result.error;
 
   const withAssumptions = applyDateAssumptions(itemType, result.data);
@@ -710,10 +720,10 @@ serve(async (req)=>{
 
     const itemType = String(form.get("itemType") ?? "").toLowerCase();
     const isMultiItemMode = !itemType || itemType === "auto";
-    const dataUrl = await toDataUrl(file);
+    const inlineData = await toInlineData(file);
 
-    if (isMultiItemMode) return await handleMultiItem(dataUrl, file);
-    return await handleSingleItem(itemType, dataUrl, file);
+    if (isMultiItemMode) return await handleMultiItem(inlineData, file);
+    return await handleSingleItem(itemType, inlineData, file);
   } catch (e) {
     console.error("parse-travel-doc error", e);
     return err("Server error", 500);


### PR DESCRIPTION
## Summary
This PR migrates the entire AI assistant infrastructure from OpenAI's GPT models to Google's Gemini 2.5 Flash API. The change includes updates to the Deno Edge Functions, Express backend routes, frontend hooks, and UI components to work with Gemini's API format and response structure.

## Key Changes

### Backend & Edge Functions
- **Model hardcoding**: Locked `gemini-2.5-flash` at the function/process layer in `ai-chat/index.ts`, `ai-chat.ts`, `admin-insights.ts`, and `parse-travel-doc/index.ts` to prevent request-path or environment variable overrides to unvetted models
- **API migration**: Replaced OpenAI API calls (`https://api.openai.com/v1/chat/completions`) with Gemini API (`https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:{endpoint}`)
- **Authentication**: Changed from `Authorization: Bearer` headers to `x-goog-api-key` headers
- **Message format**: Converted OpenAI's `messages` array format to Gemini's `contents` array with `role` ('user'|'model') and `parts` structure
- **Streaming**: Updated SSE parsing to handle Gemini's `\n\n`-delimited message format with `candidates[0].content.parts` instead of OpenAI's `choices[0].delta`

### New Place Cards Feature
- **Rich place recommendations**: Added `PlaceCard` type and `PlaceCardCarousel` component to render AI-recommended restaurants/attractions with photos, ratings, and one-tap "Add to trip" functionality
- **Place enrichment**: Implemented `enrichPlaceCards()` function to hydrate raw model output with verified Google Places data (photos, ratings, price levels)
- **Suggested additions**: Added `buildSuggestedAdd()` to validate and structure reservation/activity suggestions with date/time validation against trip windows
- **Place card persistence**: Updated `handleGetMessages()` to hydrate `placeCards` from message metadata so clients can render them without re-streaming
- **Add to trip integration**: Created `placeCardAddService.ts` with `addPlaceCardItem()` and `undoPlaceCardItem()` to insert reservations/activities into the trip database

### Type System Updates
- Replaced `OpenAIMessage`, `OpenAIOptions`, `ToolCall` types with Gemini equivalents: `GeminiContent`, `GeminiOptions`, `GeminiFunctionCall`
- Added `PlaceCard`, `PlaceCardType`, and related types to `src/types/ai-assistant.ts`
- Updated `StreamContext` to track `systemInstruction`, `contents`, `placesById`, and trip date range

### Frontend
- **Chat message rendering**: Updated `ChatMessage` component to accept `onAddPlaceCard` callback and render place card carousels
- **AI assistant panel**: Integrated `addPlaceCardItem()` and `undoPlaceCardItem()` handlers in `AIAssistantPanel`
- **Hooks**: Updated `useAIAssistant` to parse and emit `SSEPlaceCardsEvent` from streaming responses
- **UI components**: Added `PlaceCard.tsx` (individual card with photo, rating, booking button) and `PlaceCardCarousel.tsx` (horizontal scrollable list)

### System Prompt Enhancements
- Added detailed `place_cards` policy section to `buildSystemPrompt()` with rules for when/how to output place card blocks
- Documented format, validation rules, and scope (restaurants/dining and attractions/activities in phase 1)
- Included date validation logic to only suggest additions within the trip's arrival/departure window

### Configuration
- Updated `.env.example`, `README.md`, and documentation to reference `GEMINI_API_KEY` instead of `OPENAI_API_KEY`
- Updated `CLAUDE.md` and privacy/terms pages to reflect Gemini as the AI provider

## Notable Implementation Details
- **SSE buffer handling**: Implemented proper `\n\n` message boundary detection for Gemini's SSE format, with fallback for partial messages
- **Photo attribution**: Added Google

https://claude.ai/code/session_012i9q1TB3natc8mWusCxtWg