### PR TITLE
Show pending badge for email-invited travelers without accounts

### DIFF
--- a/src/components/trip/travelers/TravelerRow.tsx
+++ b/src/components/trip/travelers/TravelerRow.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Share2, Shield } from "lucide-react";
+import { Clock, Share2, Shield } from "lucide-react";
 import { Traveler } from "@/hooks/useTravelers";
 import { cn } from "@/lib/utils";
 
@@ -26,6 +26,7 @@ export default function TravelerRow({ traveler, onEdit }: TravelerRowProps) {
 
   const hasEmail = !!traveler.shared_with_email;
   const isOwner = !!(traveler as any).is_owner;
+  const isPending = hasEmail && !isOwner && !traveler.shared_with_user_id;
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -73,7 +74,22 @@ export default function TravelerRow({ traveler, onEdit }: TravelerRowProps) {
                 </span>
               )}
 
-              {hasEmail && (
+              {isPending ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger
+                      onClick={(e) => e.stopPropagation()}
+                      className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-sunset-100 text-sunset-600"
+                    >
+                      <Clock className="h-3 w-3" />
+                      Pending
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Invited by email — hasn't signed up yet</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : hasEmail ? (
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger
@@ -87,7 +103,7 @@ export default function TravelerRow({ traveler, onEdit }: TravelerRowProps) {
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
-              )}
+              ) : null}
             </div>
 
             {traveler.shared_with_email && (


### PR DESCRIPTION
Adds a visual "Pending" badge to TravelerRow when a traveler was added
via email but hasn't yet signed up for WanderLuxe (i.e. shared_with_user_id
is NULL). Owners can now tell at a glance whether an invited traveler
has actually joined or if the invitation is still sitting unclaimed.

https://claude.ai/code/session_01NkHX9Yc4yrAs6j4MMN9XVf