### PR TITLE
Make AI chat place_cards more robust

### DIFF
--- a/src/test/placeCards.test.ts
+++ b/src/test/placeCards.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildSuggestedAdd,
+  enrichPlaceCards,
+  extractBalancedJson,
+  isDateInRange,
+  isValidTime,
+  parsePlaceCardsBlock,
+  type PlaceResult,
+  type RawPlaceCard,
+} from '../../supabase/functions/ai-chat/placeCards';
+
+const ARRIVAL = '2026-05-10';
+const DEPARTURE = '2026-05-15';
+const SUPABASE_URL = 'https://example.supabase.co';
+
+function makePlace(partial: Partial<PlaceResult> & { place_id: string; name: string }): PlaceResult {
+  return {
+    formatted_address: '1 rue Fake, Paris',
+    maps_url: `https://www.google.com/maps/place/?q=place_id:${partial.place_id}`,
+    ...partial,
+  } as PlaceResult;
+}
+
+describe('extractBalancedJson', () => {
+  it('returns the full balanced array when present', () => {
+    expect(extractBalancedJson('[1,2,3] trailing junk')).toBe('[1,2,3]');
+  });
+
+  it('handles nested objects and strings containing brackets', () => {
+    const input = '[{"name":"[bracket] in string","nested":{"k":"v"}}] rest';
+    expect(extractBalancedJson(input)).toBe('[{"name":"[bracket] in string","nested":{"k":"v"}}]');
+  });
+
+  it('returns null when JSON is never balanced', () => {
+    expect(extractBalancedJson('[1,2,3')).toBeNull();
+  });
+
+  it('returns null when input does not start with [ or {', () => {
+    expect(extractBalancedJson('plain text')).toBeNull();
+  });
+});
+
+describe('parsePlaceCardsBlock', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('extracts cards from a well-formed closed fence and strips the block', () => {
+    const input = [
+      'Here are two spots:',
+      '```place_cards',
+      '[{"place_id":"A","blurb":"Great","tags":["x"]}]',
+      '```',
+    ].join('\n');
+    const { cleanContent, rawCards } = parsePlaceCardsBlock(input);
+    expect(rawCards).toHaveLength(1);
+    expect(rawCards[0].place_id).toBe('A');
+    expect(cleanContent).toBe('Here are two spots:');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('recovers cards from an open fence with balanced JSON (stream truncated)', () => {
+    const truncated = 'Intro prose.\n```place_cards\n[{"place_id":"A","blurb":"B"}]';
+    const { cleanContent, rawCards } = parsePlaceCardsBlock(truncated);
+    expect(rawCards).toHaveLength(1);
+    expect(rawCards[0].place_id).toBe('A');
+    expect(cleanContent).toBe('Intro prose.');
+  });
+
+  it('accepts the singular `place_card` alias', () => {
+    const input = '```place_card\n[{"place_id":"A"}]\n```';
+    const { rawCards } = parsePlaceCardsBlock(input);
+    expect(rawCards).toHaveLength(1);
+    expect(rawCards[0].place_id).toBe('A');
+  });
+
+  it('logs a warning and returns no cards on malformed JSON inside a closed fence', () => {
+    const input = '```place_cards\n[{oops}]\n```';
+    const { rawCards, cleanContent } = parsePlaceCardsBlock(input);
+    expect(rawCards).toEqual([]);
+    // Block is still stripped even when parse fails.
+    expect(cleanContent).toBe('');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ai-chat] place_cards parse failed',
+      expect.objectContaining({ jsonPreview: expect.any(String) }),
+    );
+  });
+
+  it('returns content unchanged when no fence is present', () => {
+    const input = 'Just a normal reply with no cards.';
+    const { cleanContent, rawCards } = parsePlaceCardsBlock(input);
+    expect(rawCards).toEqual([]);
+    expect(cleanContent).toBe(input);
+  });
+
+  it('supports multiple cards in one block', () => {
+    const input = '```place_cards\n[{"place_id":"A"},{"place_id":"B"},{"place_id":"C"}]\n```';
+    const { rawCards } = parsePlaceCardsBlock(input);
+    expect(rawCards.map(c => c.place_id)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('wraps a single object payload in an array', () => {
+    const input = '```place_cards\n{"place_id":"A"}\n```';
+    const { rawCards } = parsePlaceCardsBlock(input);
+    expect(rawCards).toHaveLength(1);
+    expect(rawCards[0].place_id).toBe('A');
+  });
+});
+
+describe('isDateInRange', () => {
+  it('accepts dates inside the trip window', () => {
+    expect(isDateInRange('2026-05-12', ARRIVAL, DEPARTURE)).toBe(true);
+    expect(isDateInRange(ARRIVAL, ARRIVAL, DEPARTURE)).toBe(true);
+    expect(isDateInRange(DEPARTURE, ARRIVAL, DEPARTURE)).toBe(true);
+  });
+
+  it('rejects dates outside the window', () => {
+    expect(isDateInRange('2026-05-09', ARRIVAL, DEPARTURE)).toBe(false);
+    expect(isDateInRange('2026-05-16', ARRIVAL, DEPARTURE)).toBe(false);
+  });
+
+  it('rejects malformed date strings', () => {
+    expect(isDateInRange('May 12', ARRIVAL, DEPARTURE)).toBe(false);
+    expect(isDateInRange('2026-5-12', ARRIVAL, DEPARTURE)).toBe(false);
+  });
+
+  it('is lenient when trip dates themselves are missing', () => {
+    expect(isDateInRange('2026-05-12', '', '')).toBe(true);
+  });
+});
+
+describe('isValidTime', () => {
+  it('accepts HH:mm', () => {
+    expect(isValidTime('09:30')).toBe(true);
+    expect(isValidTime('23:59')).toBe(true);
+  });
+
+  it('rejects malformed or wrong-type inputs', () => {
+    expect(isValidTime('9:30')).toBe(false);
+    expect(isValidTime('0930')).toBe(false);
+    expect(isValidTime(undefined)).toBe(false);
+    expect(isValidTime(1230)).toBe(false);
+  });
+});
+
+describe('buildSuggestedAdd', () => {
+  const place = makePlace({ place_id: 'A', name: 'Carbone', phone: '+33 1 23', website: 'https://carbone.example' });
+
+  it('returns undefined when raw is missing or has no date', () => {
+    expect(buildSuggestedAdd(undefined, place, undefined, ARRIVAL, DEPARTURE)).toBeUndefined();
+    expect(buildSuggestedAdd({}, place, undefined, ARRIVAL, DEPARTURE)).toBeUndefined();
+  });
+
+  it('returns undefined when the date is outside the trip window', () => {
+    expect(
+      buildSuggestedAdd({ itemType: 'reservation', date: '2026-05-16', time: '19:00' }, place, undefined, ARRIVAL, DEPARTURE),
+    ).toBeUndefined();
+  });
+
+  it('builds a reservation with time + booking URL fallback to website', () => {
+    const out = buildSuggestedAdd(
+      { itemType: 'reservation', date: '2026-05-12', time: '19:30', party_size: 2, notes: 'Quiet corner' },
+      place,
+      undefined,
+      ARRIVAL,
+      DEPARTURE,
+    );
+    expect(out).toEqual({
+      itemType: 'reservation',
+      fields: expect.objectContaining({
+        restaurant_name: 'Carbone',
+        date: '2026-05-12',
+        time: '19:30',
+        party_size: 2,
+        address: place.formatted_address,
+        phone: place.phone,
+        website: place.website,
+        notes: 'Quiet corner',
+      }),
+    });
+  });
+
+  it('returns undefined for reservation without a valid time', () => {
+    expect(
+      buildSuggestedAdd({ itemType: 'reservation', date: '2026-05-12' }, place, undefined, ARRIVAL, DEPARTURE),
+    ).toBeUndefined();
+  });
+
+  it('builds an activity and preserves end_time when valid', () => {
+    const out = buildSuggestedAdd(
+      { itemType: 'activity', date: '2026-05-12', time: '09:00', end_time: '11:30' },
+      place,
+      undefined,
+      ARRIVAL,
+      DEPARTURE,
+    );
+    expect(out?.itemType).toBe('activity');
+    expect(out?.fields.start_time).toBe('09:00');
+    expect(out?.fields.end_time).toBe('11:30');
+  });
+
+  it('prefers verified booking_url over the place website', () => {
+    const out = buildSuggestedAdd(
+      { itemType: 'reservation', date: '2026-05-12', time: '19:30' },
+      place,
+      'https://resy.com/cities/ny/venues/carbone',
+      ARRIVAL,
+      DEPARTURE,
+    );
+    expect(out?.fields.website).toBe('https://resy.com/cities/ny/venues/carbone');
+  });
+});
+
+describe('enrichPlaceCards', () => {
+  const placeA = makePlace({ place_id: 'A', name: 'Carbone', photo_reference: 'photo-a', rating: 4.7 });
+  const placeB = makePlace({ place_id: 'B', name: 'Le Gigi' });
+
+  function places(): Map<string, PlaceResult> {
+    return new Map<string, PlaceResult>([
+      ['A', placeA],
+      ['B', placeB],
+    ]);
+  }
+
+  it('drops cards missing place_id', () => {
+    const raw: RawPlaceCard[] = [{ blurb: 'oops no id' }];
+    const { cards, drops } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards).toEqual([]);
+    expect(drops).toEqual([{ index: 0, reason: 'missing_place_id' }]);
+  });
+
+  it('drops cards whose place_id is not in the tool-result map', () => {
+    const raw: RawPlaceCard[] = [{ place_id: 'ZZZ', blurb: 'hallucinated' }];
+    const { cards, drops } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards).toEqual([]);
+    expect(drops).toEqual([{ index: 0, reason: 'place_not_in_map' }]);
+  });
+
+  it('keeps the card but flags an unverified booking_url drop', () => {
+    const raw: RawPlaceCard[] = [{ place_id: 'A', booking_url: 'https://fake.example/book' }];
+    const { cards, drops } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].booking_url).toBeUndefined();
+    expect(drops).toEqual([{ index: 0, reason: 'unverified_booking_url_kept_card' }]);
+  });
+
+  it('keeps a verified booking_url on the card', () => {
+    const verified = new Set(['https://resy.com/venue']);
+    const raw: RawPlaceCard[] = [{ place_id: 'A', booking_url: 'https://resy.com/venue' }];
+    const { cards, drops } = enrichPlaceCards(raw, places(), verified, SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards[0].booking_url).toBe('https://resy.com/venue');
+    expect(drops).toEqual([]);
+  });
+
+  it('drops invalid suggested_add (date out of range) but keeps the card', () => {
+    const raw: RawPlaceCard[] = [{
+      place_id: 'A',
+      suggested_add: { itemType: 'reservation', date: '2026-05-20', time: '19:00' },
+    }];
+    const { cards, drops } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].suggested_add).toBeUndefined();
+    expect(drops).toEqual([{ index: 0, reason: 'suggested_add_invalid' }]);
+  });
+
+  it('builds a photo_url from photo_reference via the places proxy', () => {
+    const raw: RawPlaceCard[] = [{ place_id: 'A' }];
+    const { cards } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards[0].photo_url).toContain('google-places-proxy?photo_reference=photo-a');
+  });
+
+  it('truncates blurb to 240 chars and slices tags to 4', () => {
+    const longBlurb = 'x'.repeat(500);
+    const raw: RawPlaceCard[] = [{
+      place_id: 'A',
+      blurb: longBlurb,
+      tags: ['a', 'b', 'c', 'd', 'e', 'f'],
+    }];
+    const { cards } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards[0].blurb).toHaveLength(240);
+    expect(cards[0].tags).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('filters non-string tags out before slicing', () => {
+    const raw: RawPlaceCard[] = [{ place_id: 'A', tags: ['ok', 42, null, 'also-ok'] as unknown[] as string[] }];
+    const { cards } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards[0].tags).toEqual(['ok', 'also-ok']);
+  });
+
+  it('handles a mix of kept and dropped cards in one batch', () => {
+    const raw: RawPlaceCard[] = [
+      { place_id: 'A', blurb: 'kept' },
+      { blurb: 'no id' },
+      { place_id: 'ZZZ', blurb: 'not in map' },
+      { place_id: 'B', blurb: 'also kept' },
+    ];
+    const { cards, drops } = enrichPlaceCards(raw, places(), new Set(), SUPABASE_URL, ARRIVAL, DEPARTURE);
+    expect(cards.map(c => c.place_id)).toEqual(['A', 'B']);
+    expect(drops).toEqual([
+      { index: 1, reason: 'missing_place_id' },
+      { index: 2, reason: 'place_not_in_map' },
+    ]);
+  });
+});

--- a/src/test/toolForcing.test.ts
+++ b/src/test/toolForcing.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { chooseForcedTool } from '../../supabase/functions/ai-chat/toolForcing';
+
+describe('chooseForcedTool', () => {
+  it('forces find_place for dining queries when both tools are available', () => {
+    expect(chooseForcedTool('Give me dinner recommendations in Montmartre', true, true)).toBe('find_place');
+    expect(chooseForcedTool('Best restaurants near my hotel?', true, true)).toBe('find_place');
+  });
+
+  it('forces search_web for explicit booking-link queries even when find_place is available', () => {
+    expect(chooseForcedTool('Can you give me a booking link for Carbone?', true, true)).toBe('search_web');
+    expect(chooseForcedTool('I need a reservation link for Le Gigi', true, true)).toBe('search_web');
+  });
+
+  it('forces search_web for weather queries', () => {
+    expect(chooseForcedTool("What's the weather tomorrow in Paris?", true, true)).toBe('search_web');
+    expect(chooseForcedTool('forecast for next week', true, true)).toBe('search_web');
+  });
+
+  it('forces search_web for current-info queries (news, events, opening hours)', () => {
+    expect(chooseForcedTool('What events are happening today?', true, true)).toBe('search_web');
+    expect(chooseForcedTool('Are any museums closed today?', true, true)).toBe('search_web');
+    expect(chooseForcedTool('Latest exchange rate EUR to USD', true, true)).toBe('search_web');
+  });
+
+  it('forces find_place for attraction/activity recommendations', () => {
+    expect(chooseForcedTool('Museums to visit in Paris', true, false)).toBe('find_place');
+    expect(chooseForcedTool('Recommend some bars in the 11th', true, false)).toBe('find_place');
+    expect(chooseForcedTool('things to do in Montmartre', true, true)).toBe('find_place');
+  });
+
+  it('falls back to search_web for dining queries when find_place is unavailable', () => {
+    expect(chooseForcedTool('dinner recommendations', false, true)).toBe('search_web');
+  });
+
+  it('returns null when no tool is configured at all', () => {
+    expect(chooseForcedTool('dinner in Paris', false, false)).toBeNull();
+  });
+
+  it('returns null for messages that are neither dining, place, booking, weather nor current-info', () => {
+    // Note: "today" matches CURRENT_INFO_KEYWORDS by design, so keep queries truly neutral.
+    expect(chooseForcedTool('hello there', true, true)).toBeNull();
+    expect(chooseForcedTool('thanks!', true, true)).toBeNull();
+  });
+
+  it('prefers find_place for ambiguous dining+place queries (dining keywords win the structured path)', () => {
+    expect(chooseForcedTool('good food places to visit', true, true)).toBe('find_place');
+  });
+
+  it('respects the find_place fallback when only find_place is available for place queries', () => {
+    // Use exact keywords — the keyword regex is word-bounded so "landmarks"
+    // won't match "landmark". That's intentional; this test documents it.
+    expect(chooseForcedTool('any museum you recommend?', true, false)).toBe('find_place');
+  });
+
+  it('returns null when only search_web is configured and the message has no keywords', () => {
+    expect(chooseForcedTool('hi there', false, true)).toBeNull();
+  });
+});

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,6 +1,14 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { validateAndRewriteLinks } from './linkValidator.ts';
+import {
+  enrichPlaceCards,
+  extractBalancedJson,
+  parsePlaceCardsBlock,
+  type PlaceCard,
+  type PlaceResult,
+} from './placeCards.ts';
+import { chooseForcedTool } from './toolForcing.ts';
 
 // Inlined from _shared/cors.ts to support single-function deployment
 const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') ?? 'https://wanderluxe.io';
@@ -116,40 +124,6 @@ async function searchWeb(query: string, apiKey: string): Promise<{ organic: Arra
   return res.json();
 }
 
-type PlaceResult = {
-  name: string;
-  place_id: string;
-  formatted_address: string;
-  maps_url: string;
-  website?: string;
-  rating?: number;
-  phone?: string;
-  price_level?: number;
-  photo_reference?: string;
-};
-
-// Enriched place card shipped to the client. All URLs are either derived from
-// Google Places (verified) or booking_url that survived the verifiedUrls gate.
-type PlaceCard = {
-  id: string;
-  place_id: string;
-  name: string;
-  address: string;
-  maps_url: string;
-  website?: string;
-  rating?: number;
-  price_level?: number;
-  phone?: string;
-  photo_url?: string;
-  booking_url?: string;
-  blurb?: string;
-  tags?: string[];
-  suggested_add?: {
-    itemType: 'reservation' | 'activity';
-    fields: Record<string, unknown>;
-  };
-};
-
 // Hardcoded Google Places API base. All findPlaces() fetches target this host
 // and nothing else — the `query` and `place_id` values are only ever appended
 // as query-string parameters via URL.searchParams, never as path segments or
@@ -215,51 +189,6 @@ async function findPlaces(query: string, apiKey: string): Promise<PlaceResult[]>
 const CREATE_ITEMS_REGEX = /```create_items\s*([\s\S]*?)```/;
 const CREATE_ITEMS_OPEN_REGEX = /```create_items\s*([\s\S]*)$/;
 
-// Extract the longest balanced JSON array/object starting at index 0 of `src`.
-// Used to recover items when the model's response was truncated before the
-// closing ``` fence was emitted — see parseCreateItemsBlock.
-function extractBalancedJson(src: string): string | null {
-  const trimmed = src.trimStart();
-  if (!trimmed) return null;
-  const first = trimmed[0];
-  if (first !== '[' && first !== '{') return null;
-  const open = first;
-  const close = open === '[' ? ']' : '}';
-
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-  let lastBalanced = -1;
-
-  for (let i = 0; i < trimmed.length; i++) {
-    const ch = trimmed[i];
-    if (inString) {
-      if (escape) {
-        escape = false;
-      } else if (ch === '\\') {
-        escape = true;
-      } else if (ch === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-    } else if (ch === open) {
-      depth++;
-    } else if (ch === close) {
-      depth--;
-      if (depth === 0) {
-        lastBalanced = i;
-        break;
-      }
-    }
-  }
-
-  if (lastBalanced === -1) return null;
-  return trimmed.slice(0, lastBalanced + 1);
-}
-
 function parseCreateItemsBlock(response: string): { cleanContent: string; extractedItems: ExtractedItem[] } {
   // Try the strict closed-fence match first. Fall back to balanced-JSON
   // recovery when only the opening fence is present (model was truncated
@@ -307,139 +236,6 @@ function parseCreateItemsBlock(response: string): { cleanContent: string; extrac
 
   const cleanContent = response.replace(matchedRange, '').trim();
   return { cleanContent, extractedItems: items };
-}
-
-type RawPlaceCard = {
-  place_id?: unknown;
-  blurb?: unknown;
-  tags?: unknown;
-  booking_url?: unknown;
-  suggested_add?: {
-    itemType?: unknown;
-    date?: unknown;
-    time?: unknown;
-    end_time?: unknown;
-    party_size?: unknown;
-    notes?: unknown;
-  };
-};
-
-function parsePlaceCardsBlock(response: string): { cleanContent: string; rawCards: RawPlaceCard[] } {
-  const regex = /```place_cards\s*([\s\S]*?)```/;
-  const match = response.match(regex);
-  if (!match) return { cleanContent: response, rawCards: [] };
-  const jsonStr = match[1].trim();
-  let rawCards: RawPlaceCard[] = [];
-  try {
-    const parsed = JSON.parse(jsonStr);
-    rawCards = (Array.isArray(parsed) ? parsed : [parsed]) as RawPlaceCard[];
-  } catch { /* ignore parse errors */ }
-  const cleanContent = response.replace(regex, '').trim();
-  return { cleanContent, rawCards };
-}
-
-function isDateInRange(date: string, arrival: string, departure: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(arrival) || !/^\d{4}-\d{2}-\d{2}$/.test(departure)) {
-    return true; // Trip has no fixed dates — trust the model's date.
-  }
-  return date >= arrival && date <= departure;
-}
-
-function isValidTime(time: unknown): time is string {
-  return typeof time === 'string' && /^\d{2}:\d{2}$/.test(time);
-}
-
-function buildSuggestedAdd(
-  raw: RawPlaceCard['suggested_add'],
-  place: PlaceResult,
-  bookingUrl: string | undefined,
-  arrival: string,
-  departure: string,
-): PlaceCard['suggested_add'] | undefined {
-  if (!raw || typeof raw.date !== 'string') return undefined;
-  if (!isDateInRange(raw.date, arrival, departure)) return undefined;
-
-  const itemType = raw.itemType === 'activity' ? 'activity' : 'reservation';
-
-  if (itemType === 'reservation') {
-    if (!isValidTime(raw.time)) return undefined;
-    return {
-      itemType: 'reservation',
-      fields: {
-        restaurant_name: place.name,
-        date: raw.date,
-        time: raw.time,
-        party_size: typeof raw.party_size === 'number' ? raw.party_size : undefined,
-        address: place.formatted_address || undefined,
-        phone: place.phone || undefined,
-        website: bookingUrl || place.website || undefined,
-        notes: typeof raw.notes === 'string' ? raw.notes : undefined,
-      },
-    };
-  }
-
-  // activity
-  return {
-    itemType: 'activity',
-    fields: {
-      name: place.name,
-      date: raw.date,
-      start_time: isValidTime(raw.time) ? raw.time : undefined,
-      end_time: isValidTime(raw.end_time) ? raw.end_time : undefined,
-      location: place.formatted_address || undefined,
-      notes: typeof raw.notes === 'string' ? raw.notes : undefined,
-    },
-  };
-}
-
-function enrichPlaceCards(
-  rawCards: RawPlaceCard[],
-  placesById: Map<string, PlaceResult>,
-  verifiedUrls: Set<string>,
-  supabaseUrl: string,
-  arrival: string,
-  departure: string,
-): PlaceCard[] {
-  const cards: PlaceCard[] = [];
-  rawCards.forEach((raw, idx) => {
-    if (typeof raw.place_id !== 'string') return;
-    const place = placesById.get(raw.place_id);
-    if (!place) return;
-
-    const photo_url = place.photo_reference
-      ? `${supabaseUrl}/functions/v1/google-places-proxy?photo_reference=${encodeURIComponent(place.photo_reference)}&maxwidth=800`
-      : undefined;
-
-    const bookingUrlRaw = typeof raw.booking_url === 'string' ? raw.booking_url : '';
-    const booking_url = bookingUrlRaw && verifiedUrls.has(bookingUrlRaw) ? bookingUrlRaw : undefined;
-
-    const suggested_add = buildSuggestedAdd(raw.suggested_add, place, booking_url, arrival, departure);
-
-    const tags = Array.isArray(raw.tags)
-      ? raw.tags.filter((t): t is string => typeof t === 'string').slice(0, 4)
-      : undefined;
-
-    const blurb = typeof raw.blurb === 'string' ? raw.blurb.slice(0, 240) : undefined;
-
-    cards.push({
-      id: `card-${idx}-${Date.now()}`,
-      place_id: place.place_id,
-      name: place.name,
-      address: place.formatted_address,
-      maps_url: place.maps_url,
-      website: place.website,
-      rating: place.rating,
-      price_level: place.price_level,
-      phone: place.phone,
-      photo_url,
-      booking_url,
-      blurb,
-      tags,
-      suggested_add,
-    });
-  });
-  return cards;
 }
 
 type GeminiStreamState = { textContent: string; functionCalls: GeminiFunctionCall[] };
@@ -683,10 +479,12 @@ function buildSystemPrompt(params: SystemPromptParams): string {
 When you recommend one or more restaurants, attractions, bars, landmarks, or activities, output a \`place_cards\` JSON block at the END of your response INSTEAD of listing them in prose. The client renders these as rich cards with photos, ratings, and one-tap "Add to trip" buttons.
 
 Rules:
-- You MUST first call \`find_place\` for each recommendation so we have a verified place_id.
+- You MUST call \`find_place\` for each recommendation BEFORE writing your prose response. If you have not already called it in this turn, call it now. Do NOT recommend a place from memory — the place_id you need for the card only exists in a find_place tool result.
 - Keep your prose to 1–2 sentences of introduction ("Here are three standout dinner spots in Montmartre:"). DO NOT list the places in the prose — the cards ARE the list.
 - Scope for phase 1: restaurants/dining AND attractions/activities only. Do NOT use place_cards for hotels yet.
 - Include a \`suggested_add\` block ONLY when the user gave a specific date (and time, for reservations) that falls between ${arrivalDate} and ${departureDate}. When in doubt, omit it — the user can still tap the card to add it.
+- If you cannot produce cards (e.g. \`find_place\` returned no results for the user's query), explicitly say so in prose ("I couldn't find verified results for that in ${safeTripName}") rather than silently falling back to a markdown list.
+- Before finishing your response, verify that every place you recommended has a corresponding entry in the \`place_cards\` block.
 
 Format (one entry per place):
 \`\`\`place_cards
@@ -895,36 +693,6 @@ function buildTools(
   return decls.length > 0 ? [{ functionDeclarations: decls }] : undefined;
 }
 
-const DINING_KEYWORDS = /\b(restaurant|restaurants|dining|dinner|lunch|eat|food|reservation|reservations|book a table|opentable|resy|carbone)\b/i;
-const PLACE_KEYWORDS = /\b(hotel|hotels|attraction|attractions|landmark|museum|park|bar|bars|cafe|neighborhood|things to do|visit|sightseeing|activity|activities|recommend)\b/i;
-const BOOKING_KEYWORDS = /\b(booking link|reservation link|book a table)\b/i;
-const WEATHER_KEYWORDS = /\b(weather|temperature|forecast|rainy|sunny|snow|humidity)\b/i;
-const CURRENT_INFO_KEYWORDS = /\b(news|latest|current|today|happening|events|concerts|opening hours|closed today|exchange rate|currency)\b/i;
-
-function chooseForcedTool(
-  message: string,
-  hasFindPlace: boolean,
-  hasSearchWeb: boolean,
-): string | null {
-  // When the message is explicitly about live/web info, prefer web search.
-  if (hasSearchWeb && (
-    BOOKING_KEYWORDS.test(message)
-    || WEATHER_KEYWORDS.test(message)
-    || CURRENT_INFO_KEYWORDS.test(message)
-  )) {
-    return 'search_web';
-  }
-  // Otherwise for dining / place recommendations, prefer structured Google Places.
-  if (hasFindPlace && (DINING_KEYWORDS.test(message) || PLACE_KEYWORDS.test(message))) {
-    return 'find_place';
-  }
-  // Dining without find_place → fall back to search_web if available.
-  if (hasSearchWeb && DINING_KEYWORDS.test(message)) {
-    return 'search_web';
-  }
-  return null;
-}
-
 async function fetchTripContext(supabase: SupabaseClient, tripId: string) {
   const { data: trip } = await supabase.from('trips').select('destination, arrival_date, departure_date, primary_destination, primary_destination_place_id').eq('trip_id', tripId).single();
   const { data: days } = await supabase.from('trip_days').select('date, title, day_activities(title, start_time)').eq('trip_id', tripId).order('date');
@@ -1112,7 +880,7 @@ async function handleStreamResponse(
   }
   const { cleanContent: prosePart, rawCards } = parsePlaceCardsBlock(afterCreateItems);
 
-  const placeCards = enrichPlaceCards(
+  const { cards: placeCards, drops: placeCardDrops } = enrichPlaceCards(
     rawCards,
     ctx.placesById,
     ctx.verifiedUrls,
@@ -1120,6 +888,14 @@ async function handleStreamResponse(
     ctx.arrivalDate,
     ctx.departureDate,
   );
+
+  if (rawCards.length > 0 || placeCardDrops.length > 0) {
+    console.log('[ai-chat] place_cards summary', {
+      total: rawCards.length,
+      kept: placeCards.length,
+      drops: placeCardDrops,
+    });
+  }
 
   // Replace any AI-authored URLs with Google Search fallbacks unless they
   // were returned by a tool or point to a trusted host (Google, Wikipedia).

--- a/supabase/functions/ai-chat/placeCards.ts
+++ b/supabase/functions/ai-chat/placeCards.ts
@@ -1,0 +1,275 @@
+// Pure helpers for parsing the model's `place_cards` JSON block out of its
+// response and enriching the raw cards with verified Google Places data.
+//
+// Kept free of Deno / Node globals (beyond `console.warn`) so vitest can
+// import this module directly from the src/ test suite.
+
+export type PlaceResult = {
+  name: string;
+  place_id: string;
+  formatted_address: string;
+  maps_url: string;
+  website?: string;
+  rating?: number;
+  phone?: string;
+  price_level?: number;
+  photo_reference?: string;
+};
+
+export type PlaceCard = {
+  id: string;
+  place_id: string;
+  name: string;
+  address: string;
+  maps_url: string;
+  website?: string;
+  rating?: number;
+  price_level?: number;
+  phone?: string;
+  photo_url?: string;
+  booking_url?: string;
+  blurb?: string;
+  tags?: string[];
+  suggested_add?: {
+    itemType: 'reservation' | 'activity';
+    fields: Record<string, unknown>;
+  };
+};
+
+export type RawPlaceCard = {
+  place_id?: unknown;
+  blurb?: unknown;
+  tags?: unknown;
+  booking_url?: unknown;
+  suggested_add?: {
+    itemType?: unknown;
+    date?: unknown;
+    time?: unknown;
+    end_time?: unknown;
+    party_size?: unknown;
+    notes?: unknown;
+  };
+};
+
+export type EnrichDropReason =
+  | 'missing_place_id'
+  | 'place_not_in_map'
+  | 'unverified_booking_url_kept_card'
+  | 'suggested_add_invalid';
+
+export type EnrichDrop = { index: number; reason: EnrichDropReason };
+
+export type EnrichResult = { cards: PlaceCard[]; drops: EnrichDrop[] };
+
+// Accept `place_cards` (canonical) and `place_card` (singular, observed model
+// drift). The `s?` is a mild leniency: any other suffix (e.g. `place_cardxx`)
+// will still fall through to the no-match branch.
+const PLACE_CARDS_CLOSED_REGEX = /```place_cards?\s*([\s\S]*?)```/;
+const PLACE_CARDS_OPEN_REGEX = /```place_cards?\s*([\s\S]*)$/;
+
+// Extract the longest balanced JSON array/object starting at index 0 of `src`.
+// Used to recover items when the model's response was truncated before the
+// closing ``` fence could be emitted (happens near maxOutputTokens).
+export function extractBalancedJson(src: string): string | null {
+  const trimmed = src.trimStart();
+  if (!trimmed) return null;
+  const first = trimmed[0];
+  if (first !== '[' && first !== '{') return null;
+  const open = first;
+  const close = open === '[' ? ']' : '}';
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let lastBalanced = -1;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === open) {
+      depth++;
+    } else if (ch === close) {
+      depth--;
+      if (depth === 0) {
+        lastBalanced = i;
+        break;
+      }
+    }
+  }
+
+  if (lastBalanced === -1) return null;
+  return trimmed.slice(0, lastBalanced + 1);
+}
+
+export function parsePlaceCardsBlock(response: string): {
+  cleanContent: string;
+  rawCards: RawPlaceCard[];
+} {
+  let jsonStr: string | null = null;
+  let matchedRange: RegExp | null = null;
+
+  const closed = response.match(PLACE_CARDS_CLOSED_REGEX);
+  if (closed) {
+    jsonStr = closed[1].trim();
+    matchedRange = PLACE_CARDS_CLOSED_REGEX;
+  } else {
+    const open = response.match(PLACE_CARDS_OPEN_REGEX);
+    if (open) {
+      const balanced = extractBalancedJson(open[1]);
+      if (balanced) {
+        jsonStr = balanced;
+        matchedRange = PLACE_CARDS_OPEN_REGEX;
+      }
+    }
+  }
+
+  if (!jsonStr || !matchedRange) {
+    return { cleanContent: response, rawCards: [] };
+  }
+
+  let rawCards: RawPlaceCard[] = [];
+  try {
+    const parsed = JSON.parse(jsonStr);
+    rawCards = (Array.isArray(parsed) ? parsed : [parsed]) as RawPlaceCard[];
+  } catch (e) {
+    console.warn('[ai-chat] place_cards parse failed', {
+      jsonPreview: jsonStr.slice(0, 300),
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  const cleanContent = response.replace(matchedRange, '').trim();
+  return { cleanContent, rawCards };
+}
+
+export function isDateInRange(date: string, arrival: string, departure: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(arrival) || !/^\d{4}-\d{2}-\d{2}$/.test(departure)) {
+    return true; // Trip has no fixed dates — trust the model's date.
+  }
+  return date >= arrival && date <= departure;
+}
+
+export function isValidTime(time: unknown): time is string {
+  return typeof time === 'string' && /^\d{2}:\d{2}$/.test(time);
+}
+
+export function buildSuggestedAdd(
+  raw: RawPlaceCard['suggested_add'],
+  place: PlaceResult,
+  bookingUrl: string | undefined,
+  arrival: string,
+  departure: string,
+): PlaceCard['suggested_add'] | undefined {
+  if (!raw || typeof raw.date !== 'string') return undefined;
+  if (!isDateInRange(raw.date, arrival, departure)) return undefined;
+
+  const itemType = raw.itemType === 'activity' ? 'activity' : 'reservation';
+
+  if (itemType === 'reservation') {
+    if (!isValidTime(raw.time)) return undefined;
+    return {
+      itemType: 'reservation',
+      fields: {
+        restaurant_name: place.name,
+        date: raw.date,
+        time: raw.time,
+        party_size: typeof raw.party_size === 'number' ? raw.party_size : undefined,
+        address: place.formatted_address || undefined,
+        phone: place.phone || undefined,
+        website: bookingUrl || place.website || undefined,
+        notes: typeof raw.notes === 'string' ? raw.notes : undefined,
+      },
+    };
+  }
+
+  return {
+    itemType: 'activity',
+    fields: {
+      name: place.name,
+      date: raw.date,
+      start_time: isValidTime(raw.time) ? raw.time : undefined,
+      end_time: isValidTime(raw.end_time) ? raw.end_time : undefined,
+      location: place.formatted_address || undefined,
+      notes: typeof raw.notes === 'string' ? raw.notes : undefined,
+    },
+  };
+}
+
+export function enrichPlaceCards(
+  rawCards: RawPlaceCard[],
+  placesById: Map<string, PlaceResult>,
+  verifiedUrls: Set<string>,
+  supabaseUrl: string,
+  arrival: string,
+  departure: string,
+): EnrichResult {
+  const cards: PlaceCard[] = [];
+  const drops: EnrichDrop[] = [];
+
+  rawCards.forEach((raw, idx) => {
+    if (typeof raw.place_id !== 'string' || !raw.place_id) {
+      drops.push({ index: idx, reason: 'missing_place_id' });
+      return;
+    }
+    const place = placesById.get(raw.place_id);
+    if (!place) {
+      drops.push({ index: idx, reason: 'place_not_in_map' });
+      return;
+    }
+
+    const photo_url = place.photo_reference
+      ? `${supabaseUrl}/functions/v1/google-places-proxy?photo_reference=${encodeURIComponent(place.photo_reference)}&maxwidth=800`
+      : undefined;
+
+    const bookingUrlRaw = typeof raw.booking_url === 'string' ? raw.booking_url : '';
+    const bookingUrlVerified = bookingUrlRaw.length > 0 && verifiedUrls.has(bookingUrlRaw);
+    const booking_url = bookingUrlVerified ? bookingUrlRaw : undefined;
+    if (bookingUrlRaw.length > 0 && !bookingUrlVerified) {
+      // Card is kept (the place is still useful) but we surface the drop so
+      // operators can tell how often the model is hallucinating booking URLs.
+      drops.push({ index: idx, reason: 'unverified_booking_url_kept_card' });
+    }
+
+    const suggested_add = buildSuggestedAdd(raw.suggested_add, place, booking_url, arrival, departure);
+    if (raw.suggested_add && !suggested_add) {
+      drops.push({ index: idx, reason: 'suggested_add_invalid' });
+    }
+
+    const tags = Array.isArray(raw.tags)
+      ? raw.tags.filter((t): t is string => typeof t === 'string').slice(0, 4)
+      : undefined;
+
+    const blurb = typeof raw.blurb === 'string' ? raw.blurb.slice(0, 240) : undefined;
+
+    cards.push({
+      id: `card-${idx}-${Date.now()}`,
+      place_id: place.place_id,
+      name: place.name,
+      address: place.formatted_address,
+      maps_url: place.maps_url,
+      website: place.website,
+      rating: place.rating,
+      price_level: place.price_level,
+      phone: place.phone,
+      photo_url,
+      booking_url,
+      blurb,
+      tags,
+      suggested_add,
+    });
+  });
+
+  return { cards, drops };
+}

--- a/supabase/functions/ai-chat/toolForcing.ts
+++ b/supabase/functions/ai-chat/toolForcing.ts
@@ -1,0 +1,34 @@
+// Pure tool-forcing heuristics for the AI chat. Given a user message, decide
+// whether to force the model to call one of the available tools (`find_place`
+// or `search_web`) on its first turn, rather than letting it answer from
+// memory. Kept free of Deno globals so vitest can import directly.
+
+export const DINING_KEYWORDS = /\b(restaurant|restaurants|dining|dinner|lunch|eat|food|reservation|reservations|book a table|opentable|resy|carbone)\b/i;
+export const PLACE_KEYWORDS = /\b(hotel|hotels|attraction|attractions|landmark|museum|park|bar|bars|cafe|neighborhood|things to do|visit|sightseeing|activity|activities|recommend)\b/i;
+export const BOOKING_KEYWORDS = /\b(booking link|reservation link|book a table)\b/i;
+export const WEATHER_KEYWORDS = /\b(weather|temperature|forecast|rainy|sunny|snow|humidity)\b/i;
+export const CURRENT_INFO_KEYWORDS = /\b(news|latest|current|today|happening|events|concerts|opening hours|closed today|exchange rate|currency)\b/i;
+
+export function chooseForcedTool(
+  message: string,
+  hasFindPlace: boolean,
+  hasSearchWeb: boolean,
+): string | null {
+  // Explicit live/web info → prefer web search.
+  if (hasSearchWeb && (
+    BOOKING_KEYWORDS.test(message)
+    || WEATHER_KEYWORDS.test(message)
+    || CURRENT_INFO_KEYWORDS.test(message)
+  )) {
+    return 'search_web';
+  }
+  // Dining / place recommendations → prefer structured Google Places.
+  if (hasFindPlace && (DINING_KEYWORDS.test(message) || PLACE_KEYWORDS.test(message))) {
+    return 'find_place';
+  }
+  // Dining fallback when only search_web is configured.
+  if (hasSearchWeb && DINING_KEYWORDS.test(message)) {
+    return 'search_web';
+  }
+  return null;
+}


### PR DESCRIPTION
Recommendation cards from Gemini were inconsistent: sometimes a dinner query
returned rich place cards, sometimes the same query returned prose. Root
causes in the parsing pipeline are now addressed:

- parsePlaceCardsBlock gains balanced-JSON recovery (matching
  parseCreateItemsBlock) so stream truncation before the closing fence no
  longer drops every card, accepts the `place_card` singular alias, and
  warns instead of silently swallowing JSON parse errors.
- enrichPlaceCards returns drop reasons alongside cards; handleStreamResponse
  logs a one-line summary per response (total / kept / drops) so operators
  can see which failure mode is biting in production.
- System prompt now requires find_place before the prose response and tells
  the model to say so explicitly when it cannot produce cards, instead of
  silently falling back to a markdown list.

Place-card parsing, enrichment, suggested_add validation, and tool-forcing
heuristics are extracted into standalone modules and covered by two new
Vitest suites (43 new tests; full suite 202 passing).