### PR TITLE
Add accommodation (hotel) support to place cards

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -77,7 +77,9 @@
       "Bash(git -C /Users/reminiscent/wanderluxe/.claude/worktrees/hardcore-faraday log --oneline -5)",
       "Bash(git -C /Users/reminiscent/wanderluxe/.claude/worktrees/hardcore-faraday diff package.json)",
       "Bash(git -C /Users/reminiscent/wanderluxe/.claude/worktrees/hardcore-faraday add package.json package-lock.json .claude/settings.local.json)",
-      "Bash(git -C /Users/reminiscent/wanderluxe/.claude/worktrees/hardcore-faraday commit -m ':*)"
+      "Bash(git -C /Users/reminiscent/wanderluxe/.claude/worktrees/hardcore-faraday commit -m ':*)",
+      "mcp__5dd3c42b-7439-4695-be3e-bd9b1da8f0bb__get_logs",
+      "mcp__5dd3c42b-7439-4695-be3e-bd9b1da8f0bb__execute_sql"
     ],
     "deny": [],
     "ask": []

--- a/src/services/placeCardAddService.ts
+++ b/src/services/placeCardAddService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
+import { generateDateArray } from '@/utils/dateUtils';
 import type { PlaceCard } from '@/types/ai-assistant';
 
 const toDbTime = (t: unknown): string | null =>
@@ -9,6 +10,9 @@ const strOrNull = (v: unknown): string | null =>
 
 const numOrNull = (v: unknown): number | null =>
   typeof v === 'number' && Number.isFinite(v) ? v : null;
+
+const isYmd = (s: unknown): s is string =>
+  typeof s === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(s);
 
 async function findOrCreateDay(tripId: string, date: string): Promise<string> {
   const { data: existing } = await supabase
@@ -39,7 +43,7 @@ async function nextOrderIndex(table: 'day_activities' | 'reservations', dayId: s
 }
 
 export type AddedPlaceCardItem = {
-  table: 'reservations' | 'day_activities';
+  table: 'reservations' | 'day_activities' | 'accommodations';
   rowId: string;
   label: string;
 };
@@ -50,6 +54,10 @@ export async function addPlaceCardItem(
 ): Promise<AddedPlaceCardItem> {
   const suggestion = card.suggested_add;
   if (!suggestion) throw new Error('This recommendation has no date. Add it manually instead.');
+
+  if (suggestion.itemType === 'accommodation') {
+    return addAccommodationCard(tripId, card, suggestion.fields);
+  }
 
   const date = suggestion.fields.date;
   if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
@@ -106,7 +114,87 @@ export async function addPlaceCardItem(
   return { table: 'day_activities', rowId: data.id, label: card.name };
 }
 
+async function addAccommodationCard(
+  tripId: string,
+  card: PlaceCard,
+  fields: Record<string, unknown>
+): Promise<AddedPlaceCardItem> {
+  const checkIn = fields.check_in_date;
+  const checkOut = fields.check_out_date;
+  if (!isYmd(checkIn) || !isYmd(checkOut)) {
+    throw new Error('Missing check-in or check-out date on this recommendation.');
+  }
+  if (checkOut <= checkIn) {
+    throw new Error('Check-out must be after check-in.');
+  }
+
+  const name = strOrNull(fields.name) || card.name;
+
+  // accommodations.order_index is NOT NULL with no DB default — compute the
+  // next slot for this trip so inserts don't fail on brand-new trips.
+  const { data: maxRow } = await supabase
+    .from('accommodations')
+    .select('order_index')
+    .eq('trip_id', tripId)
+    .order('order_index', { ascending: false })
+    .limit(1);
+  const orderIndex = (maxRow?.[0]?.order_index ?? -1) + 1;
+
+  const { data: stay, error: stayError } = await supabase
+    .from('accommodations')
+    .insert({
+      trip_id: tripId,
+      title: name,
+      hotel: name,
+      hotel_address: strOrNull(fields.address) || card.address || null,
+      hotel_phone: strOrNull(fields.phone) || card.phone || null,
+      hotel_website: strOrNull(fields.website) || card.booking_url || card.website || null,
+      hotel_url: card.booking_url || null,
+      hotel_place_id: strOrNull(fields.place_id) || card.place_id || null,
+      hotel_checkin_date: checkIn,
+      hotel_checkout_date: checkOut,
+      checkin_time: toDbTime(fields.check_in_time),
+      checkout_time: toDbTime(fields.check_out_time),
+      order_index: orderIndex,
+    })
+    .select('stay_id')
+    .single();
+  if (stayError || !stay?.stay_id) {
+    throw new Error(stayError?.message || 'Failed to add accommodation');
+  }
+
+  // Link this stay to every matching trip_day between check-in and check-out
+  // (inclusive), so the timeline picks it up the same way manually-added
+  // hotels do.
+  const dates = generateDateArray(checkIn, checkOut);
+  if (dates.length > 0) {
+    const { data: tripDays } = await supabase
+      .from('trip_days')
+      .select('day_id, date')
+      .eq('trip_id', tripId)
+      .in('date', dates);
+    const dayRows = (tripDays || []).map((d: { day_id: string; date: string }) => ({
+      stay_id: stay.stay_id,
+      day_id: d.day_id,
+      date: d.date,
+    }));
+    if (dayRows.length > 0) {
+      await supabase.from('accommodations_days').insert(dayRows);
+    }
+  }
+
+  return { table: 'accommodations', rowId: stay.stay_id, label: name };
+}
+
 export async function undoPlaceCardItem(item: AddedPlaceCardItem): Promise<void> {
+  if (item.table === 'accommodations') {
+    // Delete the link rows first — accommodations_days has a FK on stay_id
+    // but no cascade, so the parent delete would fail otherwise.
+    await supabase.from('accommodations_days').delete().eq('stay_id', item.rowId);
+    const { error } = await supabase.from('accommodations').delete().eq('stay_id', item.rowId);
+    if (error) throw new Error(error.message);
+    return;
+  }
   const { error } = await supabase.from(item.table).delete().eq('id', item.rowId);
   if (error) throw new Error(error.message);
 }

--- a/src/test/placeCards.test.ts
+++ b/src/test/placeCards.test.ts
@@ -214,6 +214,133 @@ describe('buildSuggestedAdd', () => {
     );
     expect(out?.fields.website).toBe('https://resy.com/cities/ny/venues/carbone');
   });
+
+  describe('accommodation', () => {
+    const hotel = makePlace({
+      place_id: 'H1',
+      name: 'Hotel de Crillon',
+      phone: '+33 1 44',
+      website: 'https://crillon.example',
+    });
+
+    it('builds an accommodation with check-in/out dates inside the trip window', () => {
+      const out = buildSuggestedAdd(
+        {
+          itemType: 'accommodation',
+          check_in_date: '2026-05-11',
+          check_out_date: '2026-05-14',
+          check_in_time: '15:00',
+          check_out_time: '11:00',
+          notes: 'Deluxe suite',
+        },
+        hotel,
+        undefined,
+        ARRIVAL,
+        DEPARTURE,
+      );
+      expect(out?.itemType).toBe('accommodation');
+      expect(out?.fields).toEqual(expect.objectContaining({
+        name: 'Hotel de Crillon',
+        check_in_date: '2026-05-11',
+        check_out_date: '2026-05-14',
+        check_in_time: '15:00',
+        check_out_time: '11:00',
+        address: hotel.formatted_address,
+        phone: hotel.phone,
+        website: hotel.website,
+        place_id: 'H1',
+        notes: 'Deluxe suite',
+      }));
+    });
+
+    it('allows check-in and check-out on the trip boundaries', () => {
+      const out = buildSuggestedAdd(
+        { itemType: 'accommodation', check_in_date: ARRIVAL, check_out_date: DEPARTURE },
+        hotel,
+        undefined,
+        ARRIVAL,
+        DEPARTURE,
+      );
+      expect(out?.itemType).toBe('accommodation');
+      expect(out?.fields.check_in_date).toBe(ARRIVAL);
+      expect(out?.fields.check_out_date).toBe(DEPARTURE);
+    });
+
+    it('returns undefined when a date is outside the trip window', () => {
+      expect(
+        buildSuggestedAdd(
+          { itemType: 'accommodation', check_in_date: '2026-05-09', check_out_date: '2026-05-14' },
+          hotel, undefined, ARRIVAL, DEPARTURE,
+        ),
+      ).toBeUndefined();
+      expect(
+        buildSuggestedAdd(
+          { itemType: 'accommodation', check_in_date: '2026-05-11', check_out_date: '2026-05-16' },
+          hotel, undefined, ARRIVAL, DEPARTURE,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when check-out is not strictly after check-in', () => {
+      expect(
+        buildSuggestedAdd(
+          { itemType: 'accommodation', check_in_date: '2026-05-12', check_out_date: '2026-05-12' },
+          hotel, undefined, ARRIVAL, DEPARTURE,
+        ),
+      ).toBeUndefined();
+      expect(
+        buildSuggestedAdd(
+          { itemType: 'accommodation', check_in_date: '2026-05-13', check_out_date: '2026-05-12' },
+          hotel, undefined, ARRIVAL, DEPARTURE,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when dates are missing or malformed', () => {
+      expect(
+        buildSuggestedAdd(
+          { itemType: 'accommodation', check_in_date: '2026-05-12' },
+          hotel, undefined, ARRIVAL, DEPARTURE,
+        ),
+      ).toBeUndefined();
+      expect(
+        buildSuggestedAdd(
+          { itemType: 'accommodation', check_in_date: 'May 12', check_out_date: '2026-05-14' },
+          hotel, undefined, ARRIVAL, DEPARTURE,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('drops invalid time fields without rejecting the whole card', () => {
+      const out = buildSuggestedAdd(
+        {
+          itemType: 'accommodation',
+          check_in_date: '2026-05-11',
+          check_out_date: '2026-05-14',
+          check_in_time: '3pm',
+          check_out_time: '1100',
+        },
+        hotel, undefined, ARRIVAL, DEPARTURE,
+      );
+      expect(out?.itemType).toBe('accommodation');
+      expect(out?.fields.check_in_time).toBeUndefined();
+      expect(out?.fields.check_out_time).toBeUndefined();
+    });
+
+    it('prefers verified booking_url over the hotel website', () => {
+      const out = buildSuggestedAdd(
+        {
+          itemType: 'accommodation',
+          check_in_date: '2026-05-11',
+          check_out_date: '2026-05-14',
+        },
+        hotel,
+        'https://booking.example/crillon',
+        ARRIVAL, DEPARTURE,
+      );
+      expect(out?.fields.website).toBe('https://booking.example/crillon');
+    });
+  });
 });
 
 describe('enrichPlaceCards', () => {

--- a/src/types/ai-assistant.ts
+++ b/src/types/ai-assistant.ts
@@ -73,7 +73,7 @@ export interface PlaceCard {
   blurb?: string;
   tags?: string[];
   suggested_add?: {
-    itemType: 'reservation' | 'activity';
+    itemType: 'reservation' | 'activity' | 'accommodation';
     fields: Record<string, unknown>;
   };
 }

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -476,13 +476,13 @@ function buildSystemPrompt(params: SystemPromptParams): string {
 
   const placeCardsPolicy = hasFindPlace
     ? `## Rich Place Cards (PREFERRED for recommendations)
-When you recommend one or more restaurants, attractions, bars, landmarks, or activities, output a \`place_cards\` JSON block at the END of your response INSTEAD of listing them in prose. The client renders these as rich cards with photos, ratings, and one-tap "Add to trip" buttons.
+When you recommend one or more restaurants, attractions, bars, landmarks, activities, or hotels, output a \`place_cards\` JSON block at the END of your response INSTEAD of listing them in prose. The client renders these as rich cards with photos, ratings, and one-tap "Add to trip" buttons.
 
 Rules:
 - You MUST call \`find_place\` for each recommendation BEFORE writing your prose response. If you have not already called it in this turn, call it now. Do NOT recommend a place from memory — the place_id you need for the card only exists in a find_place tool result.
 - Keep your prose to 1–2 sentences of introduction ("Here are three standout dinner spots in Montmartre:"). DO NOT list the places in the prose — the cards ARE the list.
-- Scope for phase 1: restaurants/dining AND attractions/activities only. Do NOT use place_cards for hotels yet.
-- Include a \`suggested_add\` block ONLY when the user gave a specific date (and time, for reservations) that falls between ${arrivalDate} and ${departureDate}. When in doubt, omit it — the user can still tap the card to add it.
+- Supported itemTypes for \`suggested_add\`: \`reservation\` (dining), \`activity\` (attractions/tours/landmarks/bars), \`accommodation\` (hotels/stays).
+- Include a \`suggested_add\` block ONLY when the user gave specific dates (and time, for reservations) that fall within ${arrivalDate}..${departureDate}. When in doubt, omit it — the user can still tap the card to see it on the map.
 - If you cannot produce cards (e.g. \`find_place\` returned no results for the user's query), explicitly say so in prose ("I couldn't find verified results for that in ${safeTripName}") rather than silently falling back to a markdown list.
 - Before finishing your response, verify that every place you recommended has a corresponding entry in the \`place_cards\` block.
 
@@ -495,11 +495,17 @@ Format (one entry per place):
     "tags": ["Italian", "Date night"],                // optional, max 4 short tags
     "booking_url": "https://resy.com/...",            // optional, only if you have a verified booking URL from search_web
     "suggested_add": {                                // optional
-      "itemType": "reservation",                      // "reservation" for dining, "activity" for attractions/tours
-      "date": "YYYY-MM-DD",                           // MUST be within ${arrivalDate}..${departureDate}
+      "itemType": "reservation",                      // "reservation" | "activity" | "accommodation"
+      // For reservation / activity:
+      "date": "YYYY-MM-DD",                           // within ${arrivalDate}..${departureDate}
       "time": "HH:mm",                                // REQUIRED for reservation, optional for activity
       "end_time": "HH:mm",                            // optional, activity only
       "party_size": 2,                                // optional, reservation only
+      // For accommodation (hotels):
+      "check_in_date": "YYYY-MM-DD",                  // within trip window
+      "check_out_date": "YYYY-MM-DD",                 // within trip window, after check_in_date
+      "check_in_time": "HH:mm",                       // optional
+      "check_out_time": "HH:mm",                      // optional
       "notes": "Short note"                           // optional
     }
   }

--- a/supabase/functions/ai-chat/placeCards.ts
+++ b/supabase/functions/ai-chat/placeCards.ts
@@ -31,7 +31,7 @@ export type PlaceCard = {
   blurb?: string;
   tags?: string[];
   suggested_add?: {
-    itemType: 'reservation' | 'activity';
+    itemType: 'reservation' | 'activity' | 'accommodation';
     fields: Record<string, unknown>;
   };
 };
@@ -48,6 +48,10 @@ export type RawPlaceCard = {
     end_time?: unknown;
     party_size?: unknown;
     notes?: unknown;
+    check_in_date?: unknown;
+    check_out_date?: unknown;
+    check_in_time?: unknown;
+    check_out_time?: unknown;
   };
 };
 
@@ -172,7 +176,31 @@ export function buildSuggestedAdd(
   arrival: string,
   departure: string,
 ): PlaceCard['suggested_add'] | undefined {
-  if (!raw || typeof raw.date !== 'string') return undefined;
+  if (!raw) return undefined;
+
+  if (raw.itemType === 'accommodation') {
+    if (typeof raw.check_in_date !== 'string' || typeof raw.check_out_date !== 'string') return undefined;
+    if (!isDateInRange(raw.check_in_date, arrival, departure)) return undefined;
+    if (!isDateInRange(raw.check_out_date, arrival, departure)) return undefined;
+    if (raw.check_out_date <= raw.check_in_date) return undefined;
+    return {
+      itemType: 'accommodation',
+      fields: {
+        name: place.name,
+        check_in_date: raw.check_in_date,
+        check_out_date: raw.check_out_date,
+        check_in_time: isValidTime(raw.check_in_time) ? raw.check_in_time : undefined,
+        check_out_time: isValidTime(raw.check_out_time) ? raw.check_out_time : undefined,
+        address: place.formatted_address || undefined,
+        phone: place.phone || undefined,
+        website: bookingUrl || place.website || undefined,
+        place_id: place.place_id,
+        notes: typeof raw.notes === 'string' ? raw.notes : undefined,
+      },
+    };
+  }
+
+  if (typeof raw.date !== 'string') return undefined;
   if (!isDateInRange(raw.date, arrival, departure)) return undefined;
 
   const itemType = raw.itemType === 'activity' ? 'activity' : 'reservation';


### PR DESCRIPTION
## Summary
Extends the place cards system to support hotel/accommodation recommendations with check-in/check-out dates, enabling users to add hotel stays to their trips with one tap.

## Key Changes

- **Type definitions**: Added `'accommodation'` as a supported `itemType` in `PlaceCard` and `RawPlaceCard` types
- **Validation logic**: Implemented date range validation for accommodations in `buildSuggestedAdd()`:
  - Requires both check-in and check-out dates in YYYY-MM-DD format
  - Validates dates fall within trip boundaries (inclusive)
  - Ensures check-out is strictly after check-in
  - Validates and drops malformed time fields without rejecting the card
  - Prefers verified booking URLs over hotel websites
- **Database integration**: Added `addAccommodationCard()` function to persist accommodations:
  - Inserts into `accommodations` table with hotel details (name, address, phone, website, place_id)
  - Automatically computes `order_index` for new trips
  - Links accommodation to all matching `trip_days` via `accommodations_days` junction table
- **Undo support**: Extended `undoPlaceCardItem()` to handle accommodation deletions with proper cascade handling (deletes junction rows first)
- **AI prompt updates**: Updated system prompt to document accommodation support and clarify `suggested_add` requirements for all three item types
- **Comprehensive test coverage**: Added 7 test cases covering valid accommodations, boundary conditions, date validation, malformed inputs, and booking URL preference

## Implementation Details

- Accommodations are linked to trip days using `generateDateArray()` to span the entire stay period
- Time fields use `toDbTime()` for HH:MM format validation and conversion
- The `isYmd()` type guard ensures strict YYYY-MM-DD date format validation
- Accommodation deletion requires manual cascade handling since the database FK has no cascade delete

https://claude.ai/code/session_01KyWmf5mLru2nqgJNpGwhHY