### PR TITLE
Add automatic order_index assignment for accommodations

### DIFF
--- a/src/services/accommodation/accommodationService.ts
+++ b/src/services/accommodation/accommodationService.ts
@@ -21,6 +21,21 @@ export interface AccommodationFormData {
   clear_image_url?: boolean;
 }
 
+// Compute the next order_index for accommodations within a trip
+const getNextAccommodationOrderIndex = async (tripId: string): Promise<number> => {
+  const { data, error } = await supabase
+    .from("accommodations")
+    .select("order_index")
+    .eq("trip_id", tripId)
+    .order("order_index", { ascending: false })
+    .limit(1);
+  if (error) {
+    console.error("Error fetching max accommodation order_index:", error);
+    throw error;
+  }
+  return (data?.[0]?.order_index ?? -1) + 1;
+};
+
 // Helper function to generate and insert accommodation days
 const insertAccommodationDays = async (
   stayId: string,
@@ -87,6 +102,7 @@ export const addAccommodation = async (
 ) => {
   try {
     console.log("Adding accommodation with data:", formData);
+    const orderIndex = await getNextAccommodationOrderIndex(tripId);
     // Insert the accommodation record
     const { data: accommodationData, error: accommodationError } = await supabase
       .from("accommodations")
@@ -106,6 +122,7 @@ export const addAccommodation = async (
         cost: formData.cost ? parseFloat(formData.cost) : null,
         currency: formData.currency || null,
         hotel_place_id: formData.hotel_place_id || null,
+        order_index: orderIndex,
       })
       .select("*")
       .single();


### PR DESCRIPTION
## Summary
This PR adds automatic ordering functionality for accommodations within a trip by computing and assigning the next available `order_index` when a new accommodation is created.

## Key Changes
- Added `getNextAccommodationOrderIndex()` helper function that queries the database to find the highest existing `order_index` for a trip and returns the next sequential value
- Updated `addAccommodation()` to compute the order index before inserting a new accommodation record
- The order index is now automatically assigned and persisted in the database when creating accommodations

## Implementation Details
- The `getNextAccommodationOrderIndex()` function queries accommodations for a specific trip, orders by `order_index` in descending order, and takes the maximum value
- If no accommodations exist for the trip, it defaults to starting at index 0 (by using -1 as the fallback and adding 1)
- Error handling is included to log and throw any database query errors
- The computed `order_index` is included in the accommodation insert payload

https://claude.ai/code/session_016u9qpNDYd3aUNQWy2Fo3WA