### PR TITLE
Simplify auth token refresh to rely on Supabase SDK

### DIFF
--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -328,78 +328,12 @@ describe('AuthContext', () => {
     });
   });
 
-  describe('session refresh', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('should refresh session every 20 minutes', async () => {
-      const mockSession = {
-        user: { id: 'user-123' },
-        access_token: 'refreshed-token',
-      };
-
-      mockRefreshSession.mockResolvedValue({
-        data: { session: mockSession },
-        error: null,
-      });
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>
-      );
-
-      // Fast-forward 20 minutes using async timer advancement
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
-      });
-
-      expect(mockRefreshSession).toHaveBeenCalled();
-    });
-
-    it('should handle refresh session errors gracefully', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      mockRefreshSession.mockResolvedValue({
-        data: { session: null },
-        error: { message: 'Refresh failed' },
-      });
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>
-      );
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
-      });
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Session refresh error:',
-        expect.objectContaining({ message: 'Refresh failed' })
-      );
-
-      consoleSpy.mockRestore();
-    });
-  });
-
   describe('visibility change', () => {
-    it('should refresh session when tab becomes visible', async () => {
+    it('should call getSession when tab becomes visible', async () => {
       const mockSession = {
         user: { id: 'user-123' },
         access_token: 'refreshed-token',
       };
-
-      mockRefreshSession.mockResolvedValue({
-        data: { session: mockSession },
-        error: null,
-      });
 
       render(
         <AuthProvider>
@@ -407,8 +341,9 @@ describe('AuthContext', () => {
         </AuthProvider>
       );
 
-      // Clear any calls from mount
-      mockRefreshSession.mockClear();
+      // Clear calls from mount
+      mockGetSession.mockClear();
+      mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
 
       // Simulate tab becoming visible
       Object.defineProperty(document, 'visibilityState', {
@@ -422,19 +357,19 @@ describe('AuthContext', () => {
       });
 
       await waitFor(() => {
-        expect(mockRefreshSession).toHaveBeenCalled();
+        expect(mockGetSession).toHaveBeenCalled();
       });
     });
 
-    it('should not refresh when tab becomes hidden', async () => {
+    it('should not call getSession when tab becomes hidden', async () => {
       render(
         <AuthProvider>
           <TestConsumer />
         </AuthProvider>
       );
 
-      // Clear any calls from mount
-      mockRefreshSession.mockClear();
+      // Clear calls from mount
+      mockGetSession.mockClear();
 
       // Simulate tab becoming hidden
       Object.defineProperty(document, 'visibilityState', {
@@ -452,7 +387,7 @@ describe('AuthContext', () => {
         await Promise.resolve();
       });
 
-      expect(mockRefreshSession).not.toHaveBeenCalled();
+      expect(mockGetSession).not.toHaveBeenCalled();
     });
   });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 
-import { createContext, useContext, useEffect, useState, useMemo } from "react";
+import { createContext, useContext, useEffect, useRef, useState, useMemo } from "react";
 import { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
@@ -35,6 +35,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [fullName, setFullName] = useState<string | null>(null);
   const [lastLoginAt, setLastLoginAt] = useState<string | null>(null);
   const [profileLoaded, setProfileLoaded] = useState(false);
+  // Prevents concurrent visibility-change refreshes from racing the SDK's own
+  // auto-refresh timer (which already handles the common case).
+  const visibilityRefreshInFlight = useRef(false);
 
   // Add cache-busting to avatar URLs to ensure fresh images are loaded
   const addCacheBusting = (url: string | null): string | null => {
@@ -170,69 +173,48 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setUser(session?.user ?? null);
       if (!session?.user) {
         setProfileLoaded(false);
-      } else {
-        // Only update last login on actual sign in events
-        const isNewLogin = event === 'SIGNED_IN';
-        ensureProfile(session.user.id, isNewLogin);
+        return;
       }
+      // TOKEN_REFRESHED fires every time the SDK rotates the access token.
+      // We only need to (re)load the profile on sign-in / user update — not
+      // on every token refresh, which would hit the DB every ~hour.
+      if (event === 'TOKEN_REFRESHED') return;
+      const isNewLogin = event === 'SIGNED_IN';
+      ensureProfile(session.user.id, isNewLogin);
     });
 
-    // Set up a periodic session refresh to keep the token valid
-    // This will run every 20 minutes to refresh the session but without causing full page reloads
-    // Using a longer interval reduces frequency of network requests
-    const refreshInterval = setInterval(async () => {
+    // Token refresh is owned by the Supabase SDK (autoRefreshToken: true).
+    // When it succeeds, onAuthStateChange above fires TOKEN_REFRESHED and our
+    // session/user state stays in sync — no polling interval needed.
+    //
+    // When a tab is hidden the browser throttles timers, so the SDK's refresh
+    // timer can lag. On visibility change we call getSession() once, which the
+    // SDK transparently refreshes if the token is near expiry. We dedupe so
+    // this doesn't race the SDK's own wake-up refresh.
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState !== 'visible') return;
+      if (visibilityRefreshInFlight.current) return;
+      visibilityRefreshInFlight.current = true;
       try {
-        console.log("Refreshing session silently...");
-        // Use a more resilient approach with timeout and error handling
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-        
-        try {
-          const { data, error } = await supabase.auth.refreshSession();
-          clearTimeout(timeoutId);
-
-          if (data.session) {
-            setSession(data.session);
-            setUser(data.session.user ?? null);
-            console.log("Session refreshed successfully");
-          } else if (error) {
-            console.warn("Session refresh error:", error);
-            // Clear session if token is definitively expired/invalid
-            if (error.message?.includes('expired') || error.message?.includes('invalid') || error.status === 401) {
-              console.warn("Session expired during periodic refresh - clearing auth state");
-              setSession(null);
-              setUser(null);
-            }
+        const { data, error } = await supabase.auth.getSession();
+        if (error) {
+          // Transient offline / network blips are expected when a tab wakes up.
+          // The SDK will retry on its own; keep this quiet.
+          if (import.meta.env.DEV) {
+            console.debug('Visibility getSession error (will retry):', error);
           }
-        } catch (fetchErr) {
-          console.warn("Session refresh network error:", fetchErr);
+          return;
+        }
+        if (data.session) {
+          setSession(data.session);
+          setUser(data.session.user ?? null);
         }
       } catch (err) {
-        console.error("Session refresh failed:", err);
-      }
-    }, 20 * 60 * 1000); // 20 minutes (increased from 10)
-    
-    // Handle visibility change to refresh silently when tab becomes visible again
-    const handleVisibilityChange = async () => {
-      if (document.visibilityState === 'visible') {
-        try {
-          console.log("Tab visible - refreshing session silently");
-          const { data, error } = await supabase.auth.refreshSession();
-          if (data.session) {
-            setSession(data.session);
-            setUser(data.session.user ?? null);
-          } else if (error) {
-            console.warn("Session refresh error on visibility change:", error);
-            // If token is expired or invalid, clear session to force re-login
-            if (error.message?.includes('expired') || error.message?.includes('invalid') || error.status === 401) {
-              console.warn("Session expired - clearing auth state");
-              setSession(null);
-              setUser(null);
-            }
-          }
-        } catch (err) {
-          console.error("Session refresh failed on visibility change:", err);
+        if (import.meta.env.DEV) {
+          console.debug('Visibility getSession threw (will retry):', err);
         }
+      } finally {
+        visibilityRefreshInFlight.current = false;
       }
     };
 
@@ -240,7 +222,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
     return () => {
       subscription.unsubscribe();
-      clearInterval(refreshInterval);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -11,5 +11,12 @@ import { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } from '@/config/env';
 // App will fail fast at startup if required variables are missing
 export const supabase = createClient<Database>(
   VITE_SUPABASE_URL,
-  VITE_SUPABASE_ANON_KEY
+  VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
+  }
 );


### PR DESCRIPTION
## Summary
Refactored the authentication token refresh strategy to leverage Supabase's built-in `autoRefreshToken` mechanism instead of implementing custom polling and refresh logic. This reduces complexity, eliminates redundant network requests, and improves reliability.

## Key Changes

- **Removed periodic refresh interval**: Eliminated the 20-minute polling interval that called `refreshSession()`. The Supabase SDK now owns token refresh with `autoRefreshToken: true`.

- **Simplified visibility change handler**: Changed from calling `refreshSession()` to calling `getSession()` when a tab becomes visible. The SDK transparently refreshes the token if needed, avoiding redundant refresh calls.

- **Added deduplication logic**: Introduced `visibilityRefreshInFlight` ref to prevent concurrent visibility-change refreshes from racing the SDK's own auto-refresh timer.

- **Optimized auth state change listener**: Added early return for `TOKEN_REFRESHED` events to avoid unnecessary profile reloads on every token rotation (which happens hourly). Profile is now only reloaded on `SIGNED_IN` and user update events.

- **Enabled Supabase auth options**: Explicitly configured `persistSession`, `autoRefreshToken`, and `detectSessionInUrl` in the Supabase client initialization.

- **Updated tests**: Removed tests for the 20-minute polling interval and updated visibility change tests to verify `getSession()` calls instead of `refreshSession()`.

## Implementation Details

- The SDK's auto-refresh timer may lag when a tab is hidden due to browser throttling. The visibility change handler calls `getSession()` once to catch up, with deduplication to avoid racing the SDK's own wake-up refresh.
- Network errors during visibility-based `getSession()` calls are logged only in development mode, as transient failures are expected when tabs wake up.
- The `TOKEN_REFRESHED` event now serves as a signal that the session is current, rather than a trigger for profile reloads.

https://claude.ai/code/session_01MSigjr4tzVonSSZXUYBBEt