### PR TITLE
feat(seo): slug URLs + richer JSON-LD + prerender showcase trips

### DIFF
--- a/.claude/skills/create-showcase-trip/SKILL.md
+++ b/.claude/skills/create-showcase-trip/SKILL.md
@@ -67,9 +67,15 @@ Generate a single `DO $$` PL/pgSQL block that inserts everything in one transact
 **Database schema reference:**
 
 ```sql
--- trips (required: user_id, destination, arrival_date, departure_date, is_public, hidden)
-INSERT INTO trips (user_id, destination, arrival_date, departure_date, is_public, hidden)
-VALUES (v_user_id, 'Destination Name', 'YYYY-MM-DD', 'YYYY-MM-DD', true, false)
+-- trips (required: user_id, destination, arrival_date, departure_date, is_public, hidden, slug, summary)
+-- slug: kebab-case URL identifier, format `{destination}-{nights}-nights` (e.g. 'tokyo-japan-6-nights')
+--   - A BEFORE-INSERT trigger auto-appends `-2`, `-3`, … if the slug collides with another public trip.
+--   - After insert, SELECT slug FROM trips WHERE trip_id = v_trip_id and surface the final value.
+-- summary: 140-160 char meta description, keyword-rich, no boilerplate. Powers /explore/{slug} SEO and JSON-LD.
+INSERT INTO trips (user_id, destination, arrival_date, departure_date, is_public, hidden, slug, summary)
+VALUES (v_user_id, 'Destination Name', 'YYYY-MM-DD', 'YYYY-MM-DD', true, false,
+  'destination-N-nights',
+  'A keyword-rich 140-160 character description of the trip, leading with the destination and one unique angle.')
 RETURNING trip_id INTO v_trip_id;
 
 -- trip_days (required: trip_id, date, title)
@@ -144,6 +150,8 @@ END $$;
 - All times use `'HH:MM'` format
 - Costs should be in the local currency for the destination (EUR, JPY, ZAR, MAD, etc.) except international flights which use USD
 - The `is_public = true` flag is what makes trips visible on the Explore page
+- `slug` powers the SEO-friendly URL `/explore/{slug}`. The BEFORE-INSERT trigger `ensure_unique_public_slug` will auto-disambiguate collisions by appending `-2`, `-3`, … — after INSERT, read the trip back to surface the final slug to the user.
+- `summary` is the authored meta description used in `<meta name="description">`, OG/Twitter, and JSON-LD. Keep it 140–160 characters, lead with the destination and one specific angle (hotel, season, defining experience).
 
 ### Step 4: Execute
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /explore/
 Disallow: /auth
 Disallow: /auth/
 Disallow: /my-trips

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -33,20 +33,25 @@ async function fetchPublicTrips(): Promise<SitemapEntry[]> {
   const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
   const { data, error } = await supabase
     .from('trips')
-    .select('trip_id, updated_at')
-    .eq('is_public', true);
+    .select('slug, updated_at')
+    .eq('is_public', true)
+    .not('slug', 'is', null);
 
   if (error) {
     console.warn('[sitemap] Could not fetch public trips:', error.message);
     return [];
   }
 
-  return (data ?? []).map((row: { trip_id: string; updated_at?: string | null }) => ({
-    loc: `/trip/${row.trip_id}`,
-    lastmod: row.updated_at?.split('T')[0],
-    changefreq: 'weekly' as const,
-    priority: '0.8',
-  }));
+  return (data ?? [])
+    .filter((row: { slug: string | null }): row is { slug: string; updated_at?: string | null } =>
+      typeof row.slug === 'string' && row.slug.length > 0,
+    )
+    .map((row) => ({
+      loc: `/explore/${row.slug}`,
+      lastmod: row.updated_at?.split('T')[0],
+      changefreq: 'weekly' as const,
+      priority: '0.9',
+    }));
 }
 
 function renderXml(entries: SitemapEntry[]): string {

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -1,13 +1,53 @@
+import 'dotenv/config';
 import puppeteer, { type Browser } from 'puppeteer';
 import fs from 'node:fs';
 import path from 'node:path';
 import { preview } from 'vite';
+import { createClient } from '@supabase/supabase-js';
 
-const ROUTES_TO_PRERENDER = ['/', '/explore', '/about', '/terms', '/privacy'];
+const STATIC_ROUTES = ['/', '/explore', '/about', '/terms', '/privacy'];
 const DIST_DIR = path.resolve(process.cwd(), 'dist');
 const PORT = Number(process.env.PRERENDER_PORT || 4173);
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+async function fetchPublicTrips(): Promise<Array<{ trip_id: string; slug: string }>> {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    console.warn('[prerender] VITE_SUPABASE_URL/ANON_KEY missing — skipping per-trip prerender.');
+    return [];
+  }
+  const supabase = createClient(url, key);
+  const { data, error } = await supabase
+    .from('trips')
+    .select('trip_id, slug')
+    .eq('is_public', true)
+    .not('slug', 'is', null);
+  if (error) {
+    console.warn('[prerender] Could not fetch public trips:', error.message);
+    return [];
+  }
+  return (data ?? [])
+    .filter((r): r is { trip_id: string; slug: string } =>
+      typeof r.slug === 'string' && SLUG_PATTERN.test(r.slug)
+    );
+}
+
+// Strict route guard: static routes are hardcoded, and dynamic /explore/{slug}
+// routes only reach here after the slug has matched SLUG_PATTERN. Anything else
+// is refused so no untrusted string can shape a filesystem write.
+const STATIC_ROUTE_SET = new Set(STATIC_ROUTES);
+const EXPLORE_SLUG_ROUTE = /^\/explore\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function isSafeRoute(route: string): boolean {
+  return STATIC_ROUTE_SET.has(route) || EXPLORE_SLUG_ROUTE.test(route);
+}
 
 async function prerenderRoute(browser: Browser, origin: string, route: string) {
+  if (!isSafeRoute(route)) {
+    throw new Error(`[prerender] Refusing to render unsafe route: ${route}`);
+  }
+
   const page = await browser.newPage();
   await page.setViewport({ width: 1280, height: 800 });
 
@@ -22,7 +62,6 @@ async function prerenderRoute(browser: Browser, origin: string, route: string) {
   const html = await page.content();
   await page.close();
 
-  // Derived path is built from the hardcoded ROUTES_TO_PRERENDER list only.
   const outDir =
     route === '/' ? DIST_DIR : path.join(DIST_DIR, route.replace(/^\//, ''));
   fs.mkdirSync(outDir, { recursive: true });
@@ -36,6 +75,22 @@ async function main() {
     console.error('[prerender] dist/index.html not found — run `vite build` first.');
     process.exit(1);
   }
+
+  const publicTrips = await fetchPublicTrips();
+  const tripRoutes = publicTrips.map((t) => `/explore/${t.slug}`);
+  const routesToPrerender = [...STATIC_ROUTES, ...tripRoutes];
+
+  // Emit UUID → slug redirects map for the Express server's 301 handler.
+  const redirects: Record<string, string> = {};
+  for (const trip of publicTrips) {
+    redirects[trip.trip_id.toLowerCase()] = trip.slug;
+  }
+  fs.writeFileSync(
+    path.join(DIST_DIR, 'redirects.json'),
+    JSON.stringify(redirects, null, 2),
+    'utf8',
+  );
+  console.log(`[prerender] Wrote redirects.json with ${Object.keys(redirects).length} entries.`);
 
   // Use Vite's programmatic preview server to serve dist/ — safer than a
   // hand-rolled static server and avoids user-input-to-path expressions.
@@ -51,7 +106,7 @@ async function main() {
   });
 
   try {
-    for (const route of ROUTES_TO_PRERENDER) {
+    for (const route of routesToPrerender) {
       try {
         await prerenderRoute(browser, origin, route);
       } catch (err) {
@@ -63,7 +118,7 @@ async function main() {
     await new Promise<void>((resolve) => server.httpServer.close(() => resolve()));
   }
 
-  console.log('[prerender] Done.');
+  console.log(`[prerender] Done. Rendered ${routesToPrerender.length} routes.`);
 }
 
 main().catch((err) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -87,19 +87,71 @@ const prerenderedAbout = path.join(distPath, 'about', 'index.html');
 const prerenderedTerms = path.join(distPath, 'terms', 'index.html');
 const prerenderedPrivacy = path.join(distPath, 'privacy', 'index.html');
 
+// Build the allow-list of /explore/{slug} prerendered slugs by scanning dist/explore/*/index.html.
+// Membership check + strict slug regex means no user-controlled path can ever escape this set.
+const exploreSlugs = new Set<string>();
+try {
+  const exploreDir = path.join(distPath, 'explore');
+  if (fs.existsSync(exploreDir) && fs.statSync(exploreDir).isDirectory()) {
+    for (const entry of fs.readdirSync(exploreDir, { withFileTypes: true })) {
+      if (
+        entry.isDirectory() &&
+        /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entry.name) &&
+        fs.existsSync(path.join(exploreDir, entry.name, 'index.html'))
+      ) {
+        exploreSlugs.add(entry.name);
+      }
+    }
+  }
+} catch (err) {
+  console.warn('[server] Failed to scan prerendered /explore slugs:', err);
+}
+
+// UUID → slug redirect map, emitted by scripts/prerender.ts at build time.
+// Used to issue 301 redirects from legacy /trip/{uuid} URLs to /explore/{slug}.
+let uuidToSlug: Record<string, string> = {};
+try {
+  const redirectsPath = path.join(distPath, 'redirects.json');
+  if (fs.existsSync(redirectsPath)) {
+    const parsed = JSON.parse(fs.readFileSync(redirectsPath, 'utf8'));
+    if (parsed && typeof parsed === 'object') {
+      uuidToSlug = parsed as Record<string, string>;
+    }
+  }
+} catch (err) {
+  console.warn('[server] Failed to load redirects.json:', err);
+}
+
+const UUID_TRIP_PATH = /^\/trip\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/.*)?$/i;
+const EXPLORE_SLUG_PATH = /^\/explore\/([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+
 function prerenderedFileFor(normalizedPath: string): string | null {
   switch (normalizedPath) {
     case '/explore': return prerenderedExplore;
     case '/about': return prerenderedAbout;
     case '/terms': return prerenderedTerms;
     case '/privacy': return prerenderedPrivacy;
-    default: return null;
   }
+  const exploreMatch = EXPLORE_SLUG_PATH.exec(normalizedPath);
+  if (exploreMatch && exploreSlugs.has(exploreMatch[1])) {
+    return path.join(distPath, 'explore', exploreMatch[1], 'index.html');
+  }
+  return null;
 }
 
 // Check if dist folder exists and serve static files
 if (fs.existsSync(distPath)) {
   app.use(express.static(distPath));
+
+  // 301-redirect legacy /trip/{uuid} URLs for public trips to their /explore/{slug} canonical.
+  app.get(/^\/trip\/[0-9a-fA-F-]+(?:\/.*)?$/, (req, res, next) => {
+    const match = UUID_TRIP_PATH.exec(req.path);
+    if (!match) return next();
+    const slug = uuidToSlug[match[1].toLowerCase()];
+    if (!slug) return next();
+    const suffix = match[2] ?? '';
+    return res.redirect(301, `/explore/${slug}${suffix}`);
+  });
 
   // Handle SPA routing - prefer prerendered HTML for known public routes,
   // fall back to index.html for everything else (client-side routing).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ const App = () => {
                   <Route path="/auth/forgot-password" element={<ForgotPassword />} />
                   <Route path="/auth/update-password" element={<UpdatePassword />} />
                   <Route path="/explore" element={<Explore />} />
+                  <Route path="/explore/:slug/*" element={<TripDetails />} />
                   <Route path="/terms" element={<TermsOfService />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />
                   <Route path="/about" element={<LLMTraining />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -16,7 +16,7 @@ interface NavigationProps {
 const Navigation = ({ mobileMenuTrigger }: NavigationProps) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const isTripPage = location.pathname.startsWith('/trip/');
+  const isTripPage = location.pathname.startsWith('/trip/') || /^\/explore\/[^/]+/.test(location.pathname);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const handleMobileNavigation = (path: string) => {

--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -5,22 +5,25 @@ import { Button } from "@/components/ui/button";
 
 interface BottomNavigationProps {
   tripId: string | undefined;
+  tripPath?: string;
   onQuickAddClick: () => void;
   onPeopleClick: () => void;
   onAIClick: () => void;
 }
 
-const BottomNavigation = ({ tripId, onQuickAddClick, onPeopleClick, onAIClick }: BottomNavigationProps) => {
+const BottomNavigation = ({ tripId, tripPath, onQuickAddClick, onPeopleClick, onAIClick }: BottomNavigationProps) => {
+  const base = tripPath ?? (tripId ? `/trip/${tripId}` : undefined);
+
   const timelineItem = {
     title: "Timeline",
     icon: Calendar,
-    href: tripId ? `/trip/${tripId}/timeline` : "/trips",
+    href: base ? `${base}/timeline` : "/trips",
   };
 
   const budgetItem = {
     title: "Budget",
     icon: BarChart2,
-    href: tripId ? `/trip/${tripId}/budget` : "/trips",
+    href: base ? `${base}/budget` : "/trips",
   };
 
   return (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -66,11 +66,13 @@ const timelineManagementItems = {
 
 interface SidebarProps {
   tripId: string | undefined;
+  tripPath?: string;
   activeTab: string;
   onTabChange: (tab: string) => void;
 }
 
-const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) => {
+const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId, tripPath }, ref) => {
+  const tabBase = tripPath ?? (tripId ? `/trip/${tripId}` : undefined);
   const { user, subscriptionTier, avatarUrl, fullName } = useAuth();
   const queryClient = useQueryClient();
   const sidebar = useSidebarState(tripId);
@@ -184,7 +186,7 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId }, ref) 
           {tripNavItems.map(item => (
             <div key={item.title}>
               <NavLink
-                to={`/trip/${tripId}/${item.href}`}
+                to={tabBase ? `${tabBase}/${item.href}` : `/trip/${tripId}/${item.href}`}
                 onClick={() => {
                   if (window.innerWidth < 768) setIsOpen(false);
                 }}

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -14,7 +14,7 @@ import NavigationAuth from "./NavigationAuth";
 const Navigation: React.FC = () => {
   const headerRef = useRef<HTMLElement | null>(null);
   const location = useLocation();
-  const isTripPage = location.pathname.startsWith('/trip/');
+  const isTripPage = location.pathname.startsWith('/trip/') || /^\/explore\/[^/]+/.test(location.pathname);
 
   const handleOpenSidebar = () => {
     // Dispatch custom event that Sidebar listens for

--- a/src/components/trip/TripCard.tsx
+++ b/src/components/trip/TripCard.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { supabase } from '@/integrations/supabase/client';
 import { useWeather, getWeatherForDate, getWeatherEmoji } from '@/hooks/useWeather';
 import WeatherDetailModal from '@/components/trip/weather/WeatherDetailModal';
+import { buildTripPath } from '@/utils/tripUrl';
 
 async function resolveSupabaseSignedUrl(src: string): Promise<string | null> {
   const pathMatch = src.match(/\/storage\/v1\/object\/(?:public|sign)\/trip-images\/(.+?)(?:\?|$)/);
@@ -179,7 +180,7 @@ const TripCard = ({
           if (weatherModalOpen || weatherModalJustClosed.current) return;
           // For pending invites, require Accept/Decline first
           if (isPendingInvite) return;
-          navigate(`/trip/${trip.trip_id}`);
+          navigate(buildTripPath(trip));
         }}
       >
         <div className="relative h-56 overflow-hidden">

--- a/src/hooks/useTripQuery.tsx
+++ b/src/hooks/useTripQuery.tsx
@@ -4,6 +4,31 @@ import { toast } from 'sonner';
 import { Trip } from '@/types/trip';
 import { useNavigate } from 'react-router-dom';
 
+export const useTripIdBySlug = (slug: string | undefined) => {
+  const { data, isLoading, error } = useQuery<string | null>({
+    queryKey: ['trip-id-by-slug', slug],
+    queryFn: async () => {
+      if (!slug) return null;
+      const { data, error } = await supabase
+        .from('trips')
+        .select('trip_id')
+        .eq('slug', slug)
+        .eq('is_public', true)
+        .maybeSingle();
+      if (error) {
+        console.error('Error resolving slug to trip_id:', error);
+        return null;
+      }
+      return data?.trip_id ?? null;
+    },
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60 * 24,
+    enabled: !!slug,
+    retry: 1,
+  });
+  return { tripId: data ?? undefined, isLoading, error };
+};
+
 export const useTripQuery = (tripId: string | undefined) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();

--- a/src/integrations/supabase/types/database.ts
+++ b/src/integrations/supabase/types/database.ts
@@ -1164,6 +1164,8 @@ export type Database = {
           is_public: boolean
           primary_destination: string | null
           primary_destination_place_id: string | null
+          slug: string | null
+          summary: string | null
           trip_id: string
           user_id: string
         }
@@ -1182,6 +1184,8 @@ export type Database = {
           is_public?: boolean
           primary_destination?: string | null
           primary_destination_place_id?: string | null
+          slug?: string | null
+          summary?: string | null
           trip_id?: string
           user_id: string
         }
@@ -1200,6 +1204,8 @@ export type Database = {
           is_public?: boolean
           primary_destination?: string | null
           primary_destination_place_id?: string | null
+          slug?: string | null
+          summary?: string | null
           trip_id?: string
           user_id?: string
         }
@@ -1595,3 +1601,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -11,6 +11,7 @@ import { Plus } from 'lucide-react';
 import { Trip } from '@/types/trip';
 import { useAuth } from "@/contexts/AuthContext";
 import SEO, { SITE_URL } from '@/components/SEO';
+import { buildTripPath } from '@/utils/tripUrl';
 
 import { NextTripBoardingPass, DefaultHeroCard } from '@/components/trip/hero';
 import { useTravelStats } from '@/hooks/useTravelStats';
@@ -188,7 +189,7 @@ const Explore = () => {
         itemListElement: publicTrips.slice(0, 20).map((trip, idx) => ({
           "@type": "ListItem",
           position: idx + 1,
-          url: `${SITE_URL}/trip/${trip.trip_id}`,
+          url: `${SITE_URL}${buildTripPath(trip)}`,
           name: trip.destination,
         })),
       }
@@ -221,7 +222,7 @@ const Explore = () => {
               daysUntil={daysUntilNextTrip!}
               onViewTrip={() => {
                 handleTripClick(nextTrip, 'Hero');
-                navigate(`/trip/${nextTrip.trip_id}`);
+                navigate(buildTripPath(nextTrip));
               }}
               className="-mx-4 rounded-none md:mx-0 md:rounded-2xl"
             />

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -4,7 +4,8 @@ import HeroSection from "../components/trip/HeroSection";
 import Sidebar, { SidebarHandle } from "@/components/layout/Sidebar";
 import BottomNavigation from "@/components/layout/BottomNavigation";
 import QuickAddSheet from "@/components/layout/QuickAddSheet";
-import { useTripQuery } from '@/hooks/useTripQuery';
+import { useTripQuery, useTripIdBySlug } from '@/hooks/useTripQuery';
+import { buildOgImageUrl } from '@/utils/tripUrl';
 import { useTripSubscription } from '@/components/trip/details/useTripSubscription';
 import TripDetailsSkeleton from '@/components/trip/details/TripDetailsSkeleton';
 import TripDetailsError from '@/components/trip/details/TripDetailsError';
@@ -23,10 +24,15 @@ import { DEFAULT_TRIP_IMAGE } from '@/constants/unsplash';
 import SEO, { SITE_URL } from '@/components/SEO';
 
 const TripDetails = () => {
-  const { tripId } = useParams<{ tripId: string }>();
+  const { tripId: paramsTripId, slug } = useParams<{ tripId?: string; slug?: string }>();
   const location = useLocation();
   const navigate = useNavigate();
   const { session } = useAuth();
+
+  const { tripId: tripIdFromSlug, isLoading: slugLookupLoading } = useTripIdBySlug(slug);
+  const tripId = paramsTripId ?? tripIdFromSlug ?? undefined;
+  const onExploreRoute = slug !== undefined;
+
   const { canView, canEdit, isLoading: permissionsLoading } = useTripPermissions(tripId);
 
   const activeTab = useMemo(() => {
@@ -39,13 +45,22 @@ const TripDetails = () => {
   }, [location.pathname]);
 
   useEffect(() => {
-    if (tripId && location.pathname === `/trip/${tripId}`) {
-      navigate(`/trip/${tripId}/timeline`, { replace: true });
+    if (!onExploreRoute && paramsTripId && location.pathname === `/trip/${paramsTripId}`) {
+      navigate(`/trip/${paramsTripId}/timeline`, { replace: true });
     }
-  }, [tripId, location.pathname, navigate]);
+  }, [onExploreRoute, paramsTripId, location.pathname, navigate]);
 
   const { trip, tripLoading, tripError, previousTrip } = useTripQuery(tripId);
   useTripSubscription(tripId);
+
+  useEffect(() => {
+    const tripSlug = (trip as { slug?: string | null })?.slug;
+    const tripIsPublic = (trip as { is_public?: boolean | null })?.is_public;
+    if (paramsTripId && tripIsPublic && tripSlug && location.pathname.startsWith(`/trip/${paramsTripId}`)) {
+      const rest = location.pathname.slice(`/trip/${paramsTripId}`.length) || '';
+      navigate(`/explore/${tripSlug}${rest}`, { replace: true });
+    }
+  }, [paramsTripId, trip, location.pathname, navigate]);
 
   // Quick add sheet state
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -103,6 +118,10 @@ const TripDetails = () => {
     }
   };
 
+  if (slug && slugLookupLoading) return <TripDetailsSkeleton />;
+  if (slug && !slugLookupLoading && !tripIdFromSlug) {
+    return <TripDetailsError message="The requested trip could not be found." />;
+  }
   if (tripLoading && !previousTrip) return <TripDetailsSkeleton />;
   if (permissionsLoading) return <TripDetailsSkeleton />;
   if (tripError) return <TripDetailsError />;
@@ -143,33 +162,101 @@ const TripDetails = () => {
   }
 
   const handleTabChange = (tab: string) => {
-    navigate(`/trip/${tripId}/${tab}`);
+    if (onExploreRoute && slug) {
+      navigate(`/explore/${slug}/${tab}`);
+    } else if (tripId) {
+      navigate(`/trip/${tripId}/${tab}`);
+    }
   };
 
-  const sidebar = <Sidebar ref={sidebarRef} tripId={tripId} activeTab={activeTab} onTabChange={handleTabChange} />;
-
   const isPublicTrip = Boolean((displayData as { is_public?: boolean })?.is_public);
+  const displaySlug = (displayData as { slug?: string | null })?.slug ?? undefined;
+  const displaySummary = (displayData as { summary?: string | null })?.summary ?? undefined;
+  const publicSlug = isPublicTrip ? displaySlug : undefined;
+
+  let tripPath: string | undefined;
+  if (onExploreRoute && slug) {
+    tripPath = `/explore/${slug}`;
+  } else if (publicSlug) {
+    tripPath = `/explore/${publicSlug}`;
+  } else if (tripId) {
+    tripPath = `/trip/${tripId}`;
+  }
+
+  const canonicalPath = publicSlug ? `/explore/${publicSlug}` : `/trip/${tripId}`;
+
+  const sidebar = <Sidebar ref={sidebarRef} tripId={tripId} tripPath={tripPath} activeTab={activeTab} onTabChange={handleTabChange} />;
+  const canonicalUrl = `${SITE_URL}${canonicalPath}`;
+  const nights = displayData.arrival_date && displayData.departure_date
+    ? Math.max(
+        1,
+        Math.round(
+          (new Date(displayData.departure_date).getTime() - new Date(displayData.arrival_date).getTime()) /
+            (1000 * 60 * 60 * 24)
+        )
+      )
+    : null;
+
+  const seoTitle = isPublicTrip && nights
+    ? `${displayData.destination} — ${nights}-Night Luxury Itinerary`
+    : `${displayData.destination} itinerary`;
+  const seoDescription = displaySummary
+    || `Explore a curated luxury itinerary for ${displayData.destination} on WanderLuxe — accommodations, activities, dining, and transportation in one place.`;
+
   const tripJsonLd = isPublicTrip
-    ? {
-        "@context": "https://schema.org",
-        "@type": "TouristTrip",
-        name: `${displayData.destination} itinerary`,
-        description: `A curated luxury travel itinerary for ${displayData.destination} on WanderLuxe.`,
-        touristType: "Luxury traveler",
-        url: `${SITE_URL}/trip/${tripId}`,
-        ...(displayData.arrival_date && { startDate: displayData.arrival_date }),
-        ...(displayData.departure_date && { endDate: displayData.departure_date }),
-        ...(displayData.cover_image_url && { image: displayData.cover_image_url }),
-      }
+    ? [
+        {
+          "@context": "https://schema.org",
+          "@type": "TouristTrip",
+          name: seoTitle,
+          description: seoDescription,
+          touristType: "Luxury traveler",
+          url: canonicalUrl,
+          provider: {
+            "@type": "Organization",
+            name: "WanderLuxe",
+            url: SITE_URL,
+          },
+          ...(displayData.arrival_date && { startDate: displayData.arrival_date }),
+          ...(displayData.departure_date && { endDate: displayData.departure_date }),
+          ...(displayData.cover_image_url && { image: displayData.cover_image_url }),
+          ...(displayData.primary_destination && {
+            itinerary: {
+              "@type": "ItemList",
+              name: `${displayData.destination} itinerary`,
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  item: {
+                    "@type": "TouristDestination",
+                    name: displayData.primary_destination,
+                  },
+                },
+              ],
+            },
+          }),
+        },
+        {
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            { "@type": "ListItem", position: 1, name: "Home", item: SITE_URL },
+            { "@type": "ListItem", position: 2, name: "Explore", item: `${SITE_URL}/explore` },
+            { "@type": "ListItem", position: 3, name: displayData.destination, item: canonicalUrl },
+          ],
+        },
+      ]
     : undefined;
 
   return (
     <div className="flex min-h-screen w-full overflow-x-clip">
       <SEO
-        title={`${displayData.destination} itinerary`}
-        description={`Explore a curated luxury itinerary for ${displayData.destination} on WanderLuxe — accommodations, activities, dining, and transportation in one place.`}
-        canonicalPath={`/trip/${tripId}`}
-        ogImage={displayData.cover_image_url || undefined}
+        title={seoTitle}
+        description={seoDescription}
+        canonicalPath={canonicalPath}
+        ogImage={buildOgImageUrl(displayData.cover_image_url)}
+        ogType={isPublicTrip ? "article" : "website"}
         noIndex={!isPublicTrip}
         jsonLd={tripJsonLd}
       />
@@ -204,6 +291,23 @@ const TripDetails = () => {
           >
 
             <div className="max-w-none mx-auto px-4 pt-6 pb-24 md:pb-8">
+              {isPublicTrip && (
+                <nav aria-label="Breadcrumb" className="mb-4 text-sm">
+                  <ol className="flex items-center gap-1.5 text-earth-500">
+                    <li>
+                      <a href="/" className="hover:text-earth-700 transition-colors">Home</a>
+                    </li>
+                    <li aria-hidden="true">/</li>
+                    <li>
+                      <a href="/explore" className="hover:text-earth-700 transition-colors">Explore</a>
+                    </li>
+                    <li aria-hidden="true">/</li>
+                    <li className="text-earth-700 font-medium" aria-current="page">
+                      {displayData.destination}
+                    </li>
+                  </ol>
+                </nav>
+              )}
               {!canEdit && (
                 <div className="mb-6 bg-blue-50 border-l-4 border-blue-500 p-4 rounded-r-lg">
                   <div className="flex items-center">
@@ -260,6 +364,7 @@ const TripDetails = () => {
       {/* Mobile Bottom Navigation */}
       <BottomNavigation
         tripId={tripId}
+        tripPath={tripPath}
         onQuickAddClick={() => setQuickAddOpen(true)}
         onPeopleClick={() => sidebarRef.current?.openTravelersPanel()}
         onAIClick={() => setAiDrawerOpen(true)}

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -194,6 +194,8 @@ export interface Trip {
   departure_date: string;
   budget: number | null;
   is_public?: boolean;
+  slug?: string | null;
+  summary?: string | null;
   primary_destination?: string | null;
   primary_destination_place_id?: string | null;
   cover_image_position?: string | null;

--- a/src/utils/tripUrl.ts
+++ b/src/utils/tripUrl.ts
@@ -1,0 +1,46 @@
+interface TripLinkFields {
+  trip_id: string;
+  slug?: string | null;
+  is_public?: boolean | null;
+}
+
+export function buildTripPath(trip: TripLinkFields): string {
+  if (trip.is_public && trip.slug) {
+    return `/explore/${trip.slug}`;
+  }
+  return `/trip/${trip.trip_id}`;
+}
+
+export function slugify(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidSlug(value: string): boolean {
+  return SLUG_PATTERN.test(value);
+}
+
+const UNSPLASH_HOST = 'images.unsplash.com';
+
+export function buildOgImageUrl(coverImageUrl: string | null | undefined): string | undefined {
+  if (!coverImageUrl) return undefined;
+  try {
+    const url = new URL(coverImageUrl);
+    if (url.hostname !== UNSPLASH_HOST) return coverImageUrl;
+    url.searchParams.set('fit', 'crop');
+    url.searchParams.set('crop', 'entropy');
+    url.searchParams.set('w', '1200');
+    url.searchParams.set('h', '630');
+    url.searchParams.set('q', '80');
+    url.searchParams.set('fm', 'jpg');
+    return url.toString();
+  } catch {
+    return coverImageUrl;
+  }
+}

--- a/supabase/migrations/20260515000000_add_trip_slug_summary.sql
+++ b/supabase/migrations/20260515000000_add_trip_slug_summary.sql
@@ -1,0 +1,74 @@
+-- Slug + summary columns for public trips, with auto-disambiguation trigger.
+-- Slugs power SEO-friendly URLs at /explore/{slug}; summary provides authored
+-- meta descriptions and JSON-LD descriptions for showcase content.
+
+alter table public.trips
+  add column if not exists slug text,
+  add column if not exists summary text;
+
+create unique index if not exists trips_slug_unique
+  on public.trips (slug)
+  where is_public = true and slug is not null;
+
+create or replace function public.ensure_unique_public_slug() returns trigger
+language plpgsql
+as $$
+declare
+  base text;
+  candidate text;
+  n int := 1;
+begin
+  if new.is_public is true and new.slug is not null then
+    base := new.slug;
+    candidate := base;
+    while exists (
+      select 1 from public.trips
+      where is_public = true
+        and slug = candidate
+        and trip_id <> new.trip_id
+    ) loop
+      n := n + 1;
+      candidate := base || '-' || n;
+    end loop;
+    new.slug := candidate;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_ensure_unique_public_slug on public.trips;
+create trigger trg_ensure_unique_public_slug
+  before insert or update of slug, is_public on public.trips
+  for each row execute function public.ensure_unique_public_slug();
+
+-- Backfill curated showcase trips by exact destination match (idempotent via slug-is-null guard).
+
+update public.trips set
+  slug = 'porto-cervo-italy-5-nights',
+  summary = 'A five-night Sardinian escape in Porto Cervo: Costa Smeralda yachts, Hotel Cala di Volpe, and Michelin dining curated for slow Mediterranean summers.'
+where is_public = true and slug is null and destination = 'Porto Cervo, Italy';
+
+update public.trips set
+  slug = 'mykonos-greece-5-nights',
+  summary = 'Five nights of curated Mykonos luxury: Belvedere Hotel suites, Nammos beach club afternoons, Scorpios sunsets, and private catamaran days in the Cyclades.'
+where is_public = true and slug is null and destination = 'Mykonos, Greece';
+
+update public.trips set
+  slug = 'tokyo-japan-6-nights',
+  summary = 'A six-night luxury Tokyo itinerary: Aman Tokyo, sushi temples in Ginza, teamLab Planets, and the quietest corners of the city after dark.'
+where is_public = true and slug is null and destination = 'Tokyo, Japan';
+
+update public.trips set
+  slug = 'sabi-sands-cape-town-8-nights',
+  summary = 'An eight-night South African journey: Singita Sabi Sand Big Five safari, then Cape Town wine country, Table Mountain, and the V&A Waterfront in style.'
+where is_public = true and slug is null and destination = 'Sabi Sands & Cape Town, South Africa';
+
+update public.trips set
+  slug = 'marrakech-morocco-5-nights',
+  summary = 'A five-night Marrakech escape: Royal Mansour riads, Jemaa el-Fnaa souks at dusk, an Atlas Mountain day trip, and modernist desert dining at La Mamounia.'
+where is_public = true and slug is null and destination = 'Marrakech, Morocco';
+
+update public.trips set
+  slug = 'st-barths-french-west-indies-6-nights',
+  summary = 'Six nights on St. Barthélemy: Eden Rock beach suites, Le Toiny dinners, Colombier hikes, and Gustavia harbor afternoons in pure West Indies luxury.'
+where is_public = true and slug is null and destination = 'St. Barthélemy, French West Indies';


### PR DESCRIPTION
## Summary
- Public showcase trips move from `/trip/{uuid}` to `/explore/{slug}` — keyword-rich, shareable URLs.
- Express now serves prerendered HTML per slug (from a strict allow-list scan of `dist/explore/*/`) and 301-redirects legacy UUID URLs from a build-time `dist/redirects.json` map, so Googlebot sees real content instead of the SPA shell.
- Trip pages gain authored summaries (new `summary` column), `TouristTrip` + `BreadcrumbList` JSON-LD, slug-aware canonical URLs, 1200×630 Unsplash-derived OG images, and a visible breadcrumb.
- A `BEFORE INSERT` trigger auto-disambiguates slug collisions (`tokyo-7-nights` → `tokyo-7-nights-2`) so future non-admin publish flows can't break.
- Sitemap emits `/explore/{slug}` (priority 0.9); robots.txt explicitly allows `/explore/`.

## What changed
- DB: `supabase/migrations/20260515000000_add_trip_slug_summary.sql` — adds `slug`, `summary`, partial unique index, dedup trigger, and backfills the 6 curated showcase trips.
- Routing: new `/explore/:slug/*` route, `useTripIdBySlug` hook, slug-aware tab paths in `Sidebar` + `BottomNavigation`, client-side replace from legacy `/trip/{uuid}`.
- SEO: enriched `TripDetails` `<SEO>` payload (title, summary, JSON-LD pair, OG image transform).
- Build: `scripts/prerender.ts` queries public trips, renders each `/explore/{slug}`, and emits `dist/redirects.json`. `scripts/generate-sitemap.ts` emits slug URLs.
- Docs: `create-showcase-trip` skill updated to set `slug`/`summary` and read back the final slug after the trigger runs.

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean
- [ ] `npx vitest run` — 217/217 passing
- [ ] `npm run build` — `dist/explore/{slug}/index.html` exists for each of the 6 showcase trips; `dist/redirects.json` populated
- [ ] `curl -A "Googlebot" .../explore/tokyo-japan-6-nights | grep -E "<title>|application/ld"` — prerendered content visible
- [ ] `curl -I .../trip/{old-uuid}` returns `301 Location: /explore/{slug}`
- [ ] `/sitemap.xml` lists `/explore/{slug}` entries; no `/trip/{uuid}` URLs leaked
- [ ] Google Rich Results Test on a deployed `/explore/{slug}` URL — `TouristTrip` and `BreadcrumbList` validate
- [ ] Twitter Card Validator / LinkedIn Post Inspector — OG image renders at 1200×630
- [ ] Lighthouse SEO on `/`, `/explore`, `/explore/{slug}` — 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)