### PR TITLE
AI chat typesetting, SEO slugs, Expedia CTAs, timeline + misc fixes

### DIFF
--- a/src/components/trip/day/components/timeline-utils.ts
+++ b/src/components/trip/day/components/timeline-utils.ts
@@ -141,11 +141,11 @@ export const getTimePeriod = (time?: string): TimePeriod => {
   const hm = parseTimeToHM(time);
   if (!hm) return 'no-time';
   const hour = hm.h;
-  
-  if (hour >= 5 && hour < 9) return 'early-morning';
-  if (hour >= 9 && hour < 12) return 'morning';
-  if (hour >= 12 && hour < 17) return 'afternoon';
-  if (hour >= 17 && hour < 21) return 'evening';
+
+  if (hour < 9) return 'early-morning';
+  if (hour < 12) return 'morning';
+  if (hour < 17) return 'afternoon';
+  if (hour < 21) return 'evening';
   return 'night';
 };
 


### PR DESCRIPTION
## Summary

Multi-concern branch covering recent product work:

- **fix(timeline)**: pre-dawn hours (0–4 AM) were bucketed as "night" and sorted to the end of the day. A 1 AM flight now correctly appears at the top of the day under Early Morning instead of below the afternoon events.
- **style(ai-chat)**: typeset chat bubbles, header, empty state, and adapted the assistant drawer + prompt chips for mobile.
- **feat(seo)**: slug URLs, richer JSON-LD, prerender of showcase trips, sitemap and robots updates.
- **feat(expedia)**: surface "Book on Expedia" on hotel cards even when dates are missing.
- **chore**: dev port bump, env schema, lockfile drift.

## Test plan

- [ ] Open a trip with a flight scheduled between midnight and 5 AM — confirm it renders under **Early Morning** at the top of the day, not under **Night**.
- [ ] Confirm a trip day with both an early-AM flight and a PM event renders them in chronological order.
- [ ] Open the AI assistant drawer on mobile — verify chips and bubbles are legible and properly sized.
- [ ] Visit `/explore` and a showcase trip — confirm slug URL works and prerendered JSON-LD is present.
- [ ] On a hotel card with no dates, verify the **Book on Expedia** CTA still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)