### PR TITLE
style(timeline): distill day cards, warm chrome, lighten body

### DIFF
--- a/src/components/trip/day/CompactDayCard.tsx
+++ b/src/components/trip/day/CompactDayCard.tsx
@@ -450,7 +450,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                     </h3>
                     <p className="text-sm text-muted-foreground mb-6 max-w-xs mx-auto leading-relaxed">
                       {canEdit
-                        ? 'Add a hotel, an activity, a reservation — the day takes shape from here.'
+                        ? 'Add a hotel, an activity, a reservation, and the day takes shape from here.'
                         : 'This day is unplanned.'}
                     </p>
                     {canEdit && (

--- a/src/components/trip/day/CompactDayCard.tsx
+++ b/src/components/trip/day/CompactDayCard.tsx
@@ -294,7 +294,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
               transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
               className="border-t border-border overflow-hidden"
             >
-              <div className="bg-muted/60 px-3 py-4 sm:px-4 sm:py-5 md:px-6 md:py-6">
+              <div className="bg-background px-3 py-4 sm:px-4 sm:py-5 md:px-6 md:py-6">
                 {hasContent ? (
                   <DndContext
                     sensors={sensors}

--- a/src/components/trip/day/DayImage.tsx
+++ b/src/components/trip/day/DayImage.tsx
@@ -69,7 +69,7 @@ const DayImage: React.FC<DayImageProps> = ({
         <div className="relative overflow-hidden rounded-lg w-full h-full">
           {title && (
             <div className="absolute top-0 left-0 z-10 p-2">
-              <h2 className="text-white text-xl font-bold drop-shadow-lg">
+              <h2 className="text-white text-xl font-bold [filter:drop-shadow(0_1px_3px_rgba(33,31,27,0.55))]">
                 {title}
               </h2>
             </div>
@@ -86,15 +86,6 @@ const DayImage: React.FC<DayImageProps> = ({
                 width: '100%',
                 height: '100%',
                 transition: 'object-position 0.2s ease-out' /* Add smooth transition */
-              }}
-              onLoad={(e) => {
-                // Force the browser to recognize the image position by briefly changing a property
-                const img = e.currentTarget;
-                const originalOpacity = img.style.opacity;
-                img.style.opacity = '0.99';
-                setTimeout(() => {
-                  img.style.opacity = originalOpacity;
-                }, 50);
               }}
               onError={(e) => {
                 console.error('Image failed to load:', displayImageUrl);

--- a/src/components/trip/day/components/AllDayHotelsSection.tsx
+++ b/src/components/trip/day/components/AllDayHotelsSection.tsx
@@ -12,15 +12,16 @@ type Props = {
 const AllDayHotelsSection: React.FC<Props> = ({ stays, onHotelClick, tripId }) => {
   if (stays.length === 0) return null;
   return (
-    <div className="bg-secondary/60 rounded-card border border-border p-3 sm:p-4">
-      <div className="flex items-center gap-2 mb-2">
+    <div className="pb-2 sm:pb-3">
+      <div className="flex items-center gap-2 mb-1.5">
         <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.16em]">All day</span>
+        <div className="flex-1 h-px bg-border" />
       </div>
       <div className="space-y-1">
         {stays.map(stay => (
           <div
             key={`allday-${stay.stay_id}`}
-            className="flex items-center gap-3 cursor-pointer hover:bg-card rounded-md p-2 -mx-2 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            className="flex items-center gap-3 cursor-pointer hover:bg-secondary/40 rounded-md p-2 -mx-2 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             role="button"
             tabIndex={0}
             onClick={() => onHotelClick?.(stay)}

--- a/src/components/trip/day/components/DayHeader.tsx
+++ b/src/components/trip/day/components/DayHeader.tsx
@@ -87,10 +87,10 @@ const DayHeader: React.FC<Props> = ({
                 <Badge className="bg-primary text-primary-foreground text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-primary">Today</Badge>
               )}
               {isCheckInDay && (
-                <Badge className="bg-emerald-600/90 text-white text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-emerald-600/90">Check-in</Badge>
+                <Badge className="bg-primary/15 text-primary border-transparent text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-primary/15">Check-in</Badge>
               )}
               {isCheckOutDay && (
-                <Badge className="bg-amber-700/90 text-white text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-amber-700/90">Check-out</Badge>
+                <Badge className="bg-muted text-muted-foreground border-transparent text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-muted">Check-out</Badge>
               )}
               {summary && (
                 <span className="text-[10px] sm:text-xs text-muted-foreground font-medium">{summary}</span>

--- a/src/components/trip/day/components/DaySummaryCard.tsx
+++ b/src/components/trip/day/components/DaySummaryCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
 import { formatCurrencyWithSymbol } from '../../budget/utils/budgetCalculations';
 import { convertCurrency } from '../../budget/utils/currencyConverter';
-import { TrendingUp, Wallet } from 'lucide-react';
+import { Hotel, Plane, Star, TrendingUp, Utensils, Wallet } from 'lucide-react';
 
 type Props = {
   activities: DayActivity[];
@@ -17,8 +17,7 @@ interface CategoryCost {
   category: string;
   amount: number;
   currency: string;
-  icon: string;
-  color: string;
+  Icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
 }
 
 const DaySummaryCard: React.FC<Props> = ({
@@ -38,8 +37,7 @@ const DaySummaryCard: React.FC<Props> = ({
       category: 'Activities',
       amount: activitiesCost,
       currency: activities[0]?.currency || 'USD',
-      icon: '🎯',
-      color: 'text-purple-600',
+      Icon: Star,
     });
   }
 
@@ -50,8 +48,7 @@ const DaySummaryCard: React.FC<Props> = ({
       category: 'Accommodations',
       amount: accCost,
       currency: hotelStays[0]?.currency || 'USD',
-      icon: '🏨',
-      color: 'text-green-600',
+      Icon: Hotel,
     });
   }
 
@@ -62,8 +59,7 @@ const DaySummaryCard: React.FC<Props> = ({
       category: 'Transportation',
       amount: transCost,
       currency: transportations[0]?.currency || 'USD',
-      icon: '✈️',
-      color: 'text-blue-600',
+      Icon: Plane,
     });
   }
 
@@ -74,8 +70,7 @@ const DaySummaryCard: React.FC<Props> = ({
       category: 'Dining',
       amount: diningCost,
       currency: reservations[0]?.currency || 'USD',
-      icon: '🍽️',
-      color: 'text-orange-600',
+      Icon: Utensils,
     });
   }
 
@@ -104,7 +99,7 @@ const DaySummaryCard: React.FC<Props> = ({
   }
 
   return (
-    <div className="bg-gradient-to-br from-sand-50 to-sand-100 rounded-lg p-4 border border-sand-200 mb-4">
+    <div className="bg-card rounded-card p-4 border border-border mb-4">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <Wallet className="h-5 w-5 text-earth-600" />
@@ -126,10 +121,10 @@ const DaySummaryCard: React.FC<Props> = ({
         {categoryData.map((cat) => (
           <div key={cat.category} className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <span className="text-lg">{cat.icon}</span>
+              <cat.Icon className="h-3.5 w-3.5 text-earth-500" strokeWidth={1.5} />
               <span className="text-xs text-earth-700">{cat.category}</span>
             </div>
-            <span className={`text-xs font-semibold ${cat.color}`}>
+            <span className="text-xs font-medium text-foreground tabular-nums">
               {formatCurrencyWithSymbol(cat.amount, cat.currency)}
             </span>
           </div>
@@ -137,7 +132,7 @@ const DaySummaryCard: React.FC<Props> = ({
       </div>
 
       {total > 0 && (
-        <div className="flex items-center gap-1 mt-3 pt-3 border-t border-sand-200 text-xs text-earth-600">
+        <div className="flex items-center gap-1 mt-3 pt-3 border-t border-border text-xs text-earth-600">
           <TrendingUp className="h-3 w-3" />
           <span>Track your spending in the Budget tab</span>
         </div>

--- a/src/components/trip/day/components/GroupedEventCard.tsx
+++ b/src/components/trip/day/components/GroupedEventCard.tsx
@@ -53,7 +53,7 @@ const GroupedEventCard: React.FC<Props> = ({
       <div className="grid grid-cols-[24px_1fr] sm:grid-cols-[40px_1fr] gap-2 sm:gap-3">
         {/* Column 1: Timeline Rail - Node */}
         <div className="relative flex flex-col items-center">
-          <div className="relative w-2.5 h-2.5 rounded-full flex-shrink-0 mt-1 bg-card border-2 border-sand-500/60 z-10" />
+          <div className="relative w-3 h-3 rounded-full flex-shrink-0 mt-1 bg-card border-2 border-sand-500 z-10" />
         </div>
 
         {/* Column 2: Time Label + Grouped Card */}
@@ -65,10 +65,10 @@ const GroupedEventCard: React.FC<Props> = ({
             </span>
           )}
 
-          {/* Grouped Event Card */}
+          {/* Grouped Event Row */}
           <div className="relative flex-1 min-w-0">
             <div
-              className="bg-card rounded-card shadow-warm-sm hover:shadow-warm p-3 sm:p-4 cursor-pointer transition-shadow duration-200 border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+              className="-mx-2 px-2 py-1.5 sm:py-2 cursor-pointer rounded-md hover:bg-secondary/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
               role="button"
               tabIndex={0}
               onClick={() => setIsExpanded(!isExpanded)}
@@ -115,12 +115,12 @@ const GroupedEventCard: React.FC<Props> = ({
                   transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
                   className="overflow-hidden mt-2"
                 >
-                  <div className="space-y-2 pl-4 border-l border-border">
+                  <div className="space-y-1 pl-4 border-l border-border">
                     {items.map((item) => (
                       <div key={item.id} className="relative">
-                        {/* Individual event card - simplified version */}
+                        {/* Individual event row - typographic */}
                         <div
-                          className="bg-secondary/50 rounded-md shadow-warm-sm hover:shadow-warm p-3 cursor-pointer transition-shadow duration-200 border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                          className="-mx-2 px-2 py-1.5 cursor-pointer rounded-md hover:bg-secondary/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                           role="button"
                           tabIndex={0}
                           onClick={(e) => { e.stopPropagation(); handleEventClick(item); }}

--- a/src/components/trip/day/components/LayoverHintRow.tsx
+++ b/src/components/trip/day/components/LayoverHintRow.tsx
@@ -44,7 +44,7 @@ const LayoverHintRow: React.FC<Props> = ({ text, hintType = 'layover' }) => {
         <div className="relative flex flex-col items-center">
           <div className={cn("w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full flex-shrink-0 mt-2.5 z-10", config.dotColor)} />
         </div>
-        <div className={cn("flex items-center gap-2 px-3 py-2 rounded-md border border-dashed", config.bg, config.border)}>
+        <div className={cn("flex items-center gap-2 px-3 py-2 rounded-md border", config.bg, config.border)}>
           <Icon className={cn("h-3.5 w-3.5 flex-shrink-0", config.iconColor)} strokeWidth={1.5} />
           <span className={cn("text-xs", config.textColor)}>{text}</span>
         </div>

--- a/src/components/trip/day/components/TimelineRow.tsx
+++ b/src/components/trip/day/components/TimelineRow.tsx
@@ -156,16 +156,16 @@ const TimelineRow: React.FC<Props> = ({
             </span>
           )}
 
-          {/* Event Card */}
+          {/* Event Row */}
           <div
-            className="relative flex-1 min-w-0 bg-card rounded-card shadow-warm-sm hover:shadow-warm p-3 sm:p-4 cursor-pointer transition-shadow duration-200 border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            className="group/row relative flex-1 min-w-0 -mx-2 px-2 py-1.5 sm:py-2 cursor-pointer rounded-md hover:bg-secondary/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             role="button"
             tabIndex={0}
             onClick={handleItemClick}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleItemClick(); } }}
           >
             {/* Top-right: Avatar Stack */}
-            <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
+            <div className="absolute top-1.5 right-2 sm:top-2 sm:right-2">
               <TravelerAvatars
                 tripId={tripId}
                 eventType={item.type === 'hotel' ? 'accommodation' : item.type}
@@ -218,7 +218,7 @@ const TimelineRow: React.FC<Props> = ({
 
             {/* Footer Section */}
             {hasFooter && (
-              <div className="mt-3 pt-3 border-t border-border flex items-center justify-between">
+              <div className="mt-2 pt-2 flex items-center justify-between">
                 {item.data?.cost ? (
                   <span className="text-xs font-medium text-earth-600 tabular-nums">
                     {formatCurrencyWithSymbol(item.data.cost, item.data.currency || 'USD')}

--- a/src/components/trip/day/components/timeline-utils.ts
+++ b/src/components/trip/day/components/timeline-utils.ts
@@ -151,11 +151,11 @@ export const getTimePeriod = (time?: string): TimePeriod => {
 
 export const getPeriodLabel = (period: TimePeriod): string => {
   const labels: Record<TimePeriod, string> = {
-    'early-morning': '🌅 Early Morning',
-    'morning': '☀️ Morning',
-    'afternoon': '🌤️ Afternoon',
-    'evening': '🌆 Evening',
-    'night': '🌙 Night',
+    'early-morning': 'Early Morning',
+    'morning': 'Morning',
+    'afternoon': 'Afternoon',
+    'evening': 'Evening',
+    'night': 'Night',
     'no-time': 'Unscheduled',
   };
   return labels[period];
@@ -296,13 +296,13 @@ const generateTransportGroupTitle = (items: TimelineItem[]): string => {
   const allSameArrival = firstArrival && items.every(item =>
     extractIata(item.data?.arrival_location) === firstArrival
   );
-  if (allSameArrival) return `Group Arrivals: ${firstArrival}`;
+  if (allSameArrival) return `${items.length} ${typeLabel.toLowerCase()} into ${firstArrival}`;
 
   const firstDeparture = extractIata(items[0].data?.departure_location);
   const allSameDeparture = firstDeparture && items.every(item =>
     extractIata(item.data?.departure_location) === firstDeparture
   );
-  if (allSameDeparture) return `Group Departures: ${firstDeparture}`;
+  if (allSameDeparture) return `${items.length} ${typeLabel.toLowerCase()} out of ${firstDeparture}`;
 
   return `${items.length} ${typeLabel}`;
 };

--- a/src/components/trip/day/components/useDayTimeline.ts
+++ b/src/components/trip/day/components/useDayTimeline.ts
@@ -478,9 +478,9 @@ export function useDayTimeline({
   const summary = useMemo(() => {
     const parts: string[] = [];
     if (activityCount > 0) parts.push(`${activityCount} ${activityCount === 1 ? 'activity' : 'activities'}`);
-    if (hotelCount > 0) parts.push(`${hotelCount} hotel`);
-    if (transportCount > 0) parts.push(`${transportCount} transport`);
-    if (diningCount > 0) parts.push(`${diningCount} dining`);
+    if (hotelCount > 0) parts.push(`${hotelCount} ${hotelCount === 1 ? 'hotel' : 'hotels'}`);
+    if (transportCount > 0) parts.push(`${transportCount} ${transportCount === 1 ? 'flight' : 'flights'}`);
+    if (diningCount > 0) parts.push(`${diningCount} ${diningCount === 1 ? 'reservation' : 'reservations'}`);
     return parts.length > 0 ? parts.join(' • ') : 'No plans yet';
   }, [activityCount, hotelCount, transportCount, diningCount]);
 

--- a/src/components/trip/timeline/DayNavigator.tsx
+++ b/src/components/trip/timeline/DayNavigator.tsx
@@ -80,9 +80,9 @@ const DayNavigator: React.FC<DayNavigatorProps> = ({ days, className }) => {
   return (
     <>
       {/* Desktop sticky top navigation */}
-      <div 
+      <div
         className={cn(
-          "hidden md:block sticky top-16 z-40 bg-white/95 backdrop-blur-sm border-b transition-all duration-200",
+          "hidden md:block sticky top-16 z-40 bg-card/95 border-b border-border transition-all duration-200",
           isCompact ? "py-2" : "py-3",
           className
         )}
@@ -114,7 +114,7 @@ const DayNavigator: React.FC<DayNavigatorProps> = ({ days, className }) => {
                     onClick={() => scrollToDay(index)}
                     className={cn(
                       "min-w-[80px] text-xs transition-all",
-                      isTodayFlag && !isActive && "ring-1 ring-blue-500"
+                      isTodayFlag && !isActive && "ring-1 ring-primary"
                     )}
                   >
                     <div className="flex flex-col items-center">
@@ -168,7 +168,7 @@ const DayNavigator: React.FC<DayNavigatorProps> = ({ days, className }) => {
       </div>
       
       {/* Mobile View - Floating Bottom Navigation */}
-      <div className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-white/95 backdrop-blur-sm border-t shadow-warm-lg pb-safe">
+      <div className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-card/95 border-t border-border shadow-warm-lg pb-safe">
         <div className="flex items-center justify-between gap-2 px-2 py-3">
           <Button
             variant="ghost"
@@ -194,8 +194,8 @@ const DayNavigator: React.FC<DayNavigatorProps> = ({ days, className }) => {
                   onClick={() => scrollToDay(index)}
                   className={cn(
                     "h-12 px-3 min-w-[60px] flex-shrink-0 flex flex-col items-center justify-center gap-0.5 py-1.5 rounded-lg",
-                    isActive && "bg-earth-600 hover:bg-earth-700 shadow-md",
-                    isTodayFlag && !isActive && "ring-2 ring-emerald-500"
+                    isActive && "bg-earth-600 hover:bg-earth-700 shadow-warm",
+                    isTodayFlag && !isActive && "ring-2 ring-primary"
                   )}
                 >
                   <span className="text-[10px] leading-none opacity-90">{format(parseISO(day.date), 'MMM')}</span>

--- a/src/components/trip/timeline/DayWeatherBadge.tsx
+++ b/src/components/trip/timeline/DayWeatherBadge.tsx
@@ -153,7 +153,7 @@ export function DayWeatherBadge({ forecast, currentWeather, isToday, className, 
                 "inline-flex items-center gap-1.5 px-2 py-1 rounded-full",
                 "text-xs font-medium cursor-pointer transition-all",
                 isToday
-                  ? "bg-emerald-100/80 text-emerald-700 border border-emerald-200/50 hover:bg-emerald-200/80"
+                  ? "bg-primary/15 text-primary border border-primary/20 hover:bg-primary/20"
                   : "bg-sand-100/80 text-earth-600 border border-sand-200/50 hover:bg-sand-200/80",
                 className
               )}

--- a/src/components/trip/timeline/TimelineContent.tsx
+++ b/src/components/trip/timeline/TimelineContent.tsx
@@ -105,7 +105,7 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
 
   if (!days.length) {
     return (
-      <div className="text-center py-12 border border-dashed rounded-lg">
+      <div className="text-center py-12 border border-border rounded-card bg-card">
         <p className="text-muted-foreground">No days added yet. Start by setting your trip dates above.</p>
       </div>
     );

--- a/src/components/trip/timeline/TripDates.tsx
+++ b/src/components/trip/timeline/TripDates.tsx
@@ -178,7 +178,7 @@ const TripDates: React.FC<TripDatesProps> = ({
   const toggleCollapse = () => setIsCollapsed(prev => !prev);
 
   return (
-    <div className="bg-sand-50 rounded-lg shadow-md overflow-hidden w-full">
+    <div className="bg-card rounded-card shadow-warm-sm border border-border overflow-hidden w-full">
       {/* HEADER */}
       <Button
         variant="ghost"

--- a/src/components/trip/timeline/ViewingStatusAvatars.tsx
+++ b/src/components/trip/timeline/ViewingStatusAvatars.tsx
@@ -85,11 +85,11 @@ const ViewingStatusAvatars: React.FC<ViewingStatusAvatarsProps> = ({
   const getBorderColor = (category: ViewingCategory): string => {
     switch (category) {
       case "active":
-        return "ring-green-500"; // Green for actively viewing
+        return "ring-primary"; // Strongest contrast: actively viewing
       case "viewed":
-        return "ring-sand-400"; // Grey for has viewed
+        return "ring-sand-400"; // Mid: has viewed previously
       case "never":
-        return "ring-earth-800"; // Black/dark for never viewed
+        return "ring-border"; // Faintest: not yet opened
     }
   };
 
@@ -161,11 +161,7 @@ const ViewingStatusAvatars: React.FC<ViewingStatusAvatarsProps> = ({
                       {t.is_owner ? " (Owner)" : ""}
                     </p>
                     <p className={`text-xs ${
-                      t.viewingCategory === "active"
-                        ? "text-green-600"
-                        : t.viewingCategory === "viewed"
-                        ? "text-muted-foreground"
-                        : "text-muted-foreground"
+                      t.viewingCategory === "active" ? "text-primary" : "text-muted-foreground"
                     }`}>
                       {statusText}
                     </p>
@@ -178,7 +174,7 @@ const ViewingStatusAvatars: React.FC<ViewingStatusAvatarsProps> = ({
           {overflowCount > 0 && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-sand-400 text-xs font-medium text-white ring-2 ring-white hover:z-10">
+                <div className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-sand-400 text-xs font-medium text-white ring-2 ring-card hover:z-10">
                   +{overflowCount}
                 </div>
               </TooltipTrigger>


### PR DESCRIPTION
## Summary
- **Distill nested cards.** Inner timeline rows (`TimelineRow`, `GroupedEventCard`, `AllDayHotelsSection`, expanded grouped items) drop their card chrome and sit as typographic rows on the rail; the day's outer `<Card>` is the only container left. Day body now uses cream paper (`bg-background`, 99% L) instead of `bg-muted/60` for legibility.
- **Warm the chrome.** `DayNavigator` drops `bg-white/95 backdrop-blur-sm` for `bg-card/95` (no glassmorphism); "today" unified to a single `ring-primary` across breakpoints. `DayImage` swaps `drop-shadow-lg` for an espresso-ink-tinted shadow and loses a superstitious `onLoad` opacity flash. `TripDates` and the empty-days state move off plain `shadow-md` / `border-dashed`.
- **On-brand status colors.** Check-in/Check-out badges (emerald/amber), the today weather pill, and the viewing-status avatar rings all route through warm semantic tokens (`primary`, `muted`, `sand-400`, `border`). Presence semantics inverted: active = loudest (`ring-primary`), never-viewed = quietest (`ring-border`).
- **Typeset.** Period labels lose 🌅 ☀️ 🌤️ 🌆 🌙 emoji prefixes. `"2 transport"` → `"2 flights"`; `"Group Arrivals: JFK"` → `"2 flights into JFK"`. Em dash in empty-state copy → comma.

## Test plan
- [ ] Open a populated trip; confirm each day card reads as a single warm sheet with no nested-card borders inside.
- [ ] Confirm "today" highlight is consistent across the desktop sticky nav, mobile floating nav, and the weather pill (all `ring-primary` / `bg-primary/15`).
- [ ] Confirm period labels render as tracked caps (no emoji); summary pluralization reads naturally (`1 flight`, `2 flights`, `1 reservation`, `2 reservations`).
- [ ] Confirm Check-in / Check-out badges are bronze-tint and muted (no emerald/amber).
- [ ] Confirm the day image overlay title still has legible contrast over photos.
- [ ] `npx tsc --noEmit` passes (already green locally).

## Out of scope (follow-ups)
- Mobile inline add affordance per period band (needs UX design).
- Undo toasts on drag-reorder / delete and debounced `DayNavigator` scroll listener (needs mutation-flow testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)