### PR TITLE
chore: release 5.3.1 — SEO slugs, timeline restyle, AI chat polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "5.2.1",
+  "version": "5.3.1",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"NODE_ENV=development npx tsx server/index.ts\"",


### PR DESCRIPTION
## Summary
- Bumps app version to **5.3.1**
- Rolls up accumulated work from `type-check-address` since last merge into `main-agent`:
  - **SEO**: slug URLs for public trips, richer JSON-LD, prerender for showcase trips (PR #223)
  - **AI chat**: mobile-friendly assistant drawer + prompt chips, typeset polish (PRs #222, #224, #225)
  - **Timeline**: warmer day-card chrome, cream paper body for readability, pre-dawn bucketed as early morning
  - Misc: env schema, dev port bump, lockfile drift, bun update

## Test plan
- [ ] App boots and `package.json` shows `5.3.1`
- [ ] `/explore/{slug}` resolves and JSON-LD renders for at least one showcase trip
- [ ] AI assistant drawer opens cleanly on mobile width
- [ ] Timeline day cards render with new warm chrome + cream body
- [ ] No type-check or lint regressions (`npx tsc --noEmit`, `bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)