### PR TITLE
Update sitemap generation to use created_at and add 6 new luxury trip listings

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,4 +25,40 @@
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>https://wanderluxe.io/explore/st-barths-french-west-indies-6-nights</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://wanderluxe.io/explore/marrakech-morocco-5-nights</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://wanderluxe.io/explore/sabi-sands-cape-town-8-nights</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://wanderluxe.io/explore/tokyo-japan-6-nights</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://wanderluxe.io/explore/mykonos-greece-5-nights</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://wanderluxe.io/explore/porto-cervo-italy-5-nights</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -33,7 +33,7 @@ async function fetchPublicTrips(): Promise<SitemapEntry[]> {
   const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
   const { data, error } = await supabase
     .from('trips')
-    .select('slug, updated_at')
+    .select('slug, created_at')
     .eq('is_public', true)
     .not('slug', 'is', null);
 
@@ -43,12 +43,12 @@ async function fetchPublicTrips(): Promise<SitemapEntry[]> {
   }
 
   return (data ?? [])
-    .filter((row: { slug: string | null }): row is { slug: string; updated_at?: string | null } =>
+    .filter((row: { slug: string | null }): row is { slug: string; created_at?: string | null } =>
       typeof row.slug === 'string' && row.slug.length > 0,
     )
     .map((row) => ({
       loc: `/explore/${row.slug}`,
-      lastmod: row.updated_at?.split('T')[0],
+      lastmod: row.created_at?.split('T')[0],
       changefreq: 'weekly' as const,
       priority: '0.9',
     }));

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -6,7 +6,7 @@ export const DEFAULT_OG_IMAGE =
 const DEFAULT_DESCRIPTION =
   "WanderLuxe is an AI-assisted luxury travel planning platform with real-time collaboration, curated itineraries, and professional PDF export.";
 
-interface SEOProps {ß
+interface SEOProps {
   title?: string;
   description?: string;
   canonicalPath?: string;

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -211,6 +211,7 @@ const TripDetails = () => {
           name: seoTitle,
           description: seoDescription,
           touristType: "Luxury traveler",
+          inLanguage: "en",
           url: canonicalUrl,
           provider: {
             "@type": "Organization",


### PR DESCRIPTION
## Summary
This PR updates the sitemap generation logic to use `created_at` instead of `updated_at` for trip lastmod dates, adds 6 new luxury destination trip listings to the sitemap, and fixes a minor typo in the SEO component. It also enhances trip schema markup with language metadata.

## Key Changes

- **Sitemap Generation Script** (`scripts/generate-sitemap.ts`):
  - Changed trip data selection from `updated_at` to `created_at` field
  - Updated type filtering and mapping to reflect the new field
  - This ensures sitemap lastmod dates reflect when trips were created rather than last modified

- **Sitemap Content** (`public/sitemap.xml`):
  - Added 6 new luxury travel destination entries with high priority (0.9):
    - St. Barths, French West Indies (6 nights)
    - Marrakech, Morocco (5 nights)
    - Sabi Sands & Cape Town, South Africa (8 nights)
    - Tokyo, Japan (6 nights)
    - Mykonos, Greece (5 nights)
    - Porto Cervo, Italy (5 nights)
  - All new entries dated 2026-03-31 with weekly change frequency

- **SEO Component** (`src/components/SEO.tsx`):
  - Fixed typo in interface definition (removed stray `ß` character)

- **Trip Details Schema** (`src/pages/TripDetails.tsx`):
  - Added `inLanguage: "en"` to JSON-LD schema markup for better SEO and accessibility

## Implementation Details

The change from `updated_at` to `created_at` aligns with the principle that trip creation date is more relevant for search engine crawling frequency than modification date, as luxury trip itineraries are typically curated once and remain relatively stable.

https://claude.ai/code/session_019wphxKnDsEnmXAXtL5Cmx1