### PR TITLE
feat(analytics): PostHog Tier 1 — identify, key events, session replay

### DIFF
--- a/src/components/PostHogConsentSync.tsx
+++ b/src/components/PostHogConsentSync.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import posthog from 'posthog-js';
 import { useConsent } from '@/contexts/ConsentContext';
+import { supabase } from '@/integrations/supabase/client';
+import { identifyUser } from '@/lib/analytics';
 
 /**
  * Syncs PostHog capturing state with the user's cookie consent preferences.
@@ -15,6 +17,17 @@ export default function PostHogConsentSync() {
 
     if (hasConsented && preferences.analytics) {
       posthog.opt_in_capturing();
+      // If the user signed in before granting consent, AuthContext's identify()
+      // call was dropped while capturing was opted-out. Re-identify here.
+      supabase.auth.getUser().then(({ data: { user } }) => {
+        if (user) {
+          identifyUser(user.id, {
+            email: user.email,
+            provider: user.app_metadata?.provider,
+            created_at: user.created_at,
+          });
+        }
+      });
       posthog.capture('$pageview');
     } else {
       posthog.opt_out_capturing();

--- a/src/components/trip/create/CreateTripForm.tsx
+++ b/src/components/trip/create/CreateTripForm.tsx
@@ -8,6 +8,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { generateDateArray } from '../../../utils/dateUtils';
 import { createTripDays } from '@/services/tripDaysService';
 import { addOwnerToTripShares } from '@/services/travelers';
+import { track } from '@/lib/analytics';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, ArrowRight, MapPin, Pen, CalendarDays, Camera, Loader2 } from 'lucide-react';
@@ -120,6 +121,12 @@ const CreateTripForm: React.FC<CreateTripFormProps> = ({ onSubmit, onCancel }) =
         await addOwnerToTripShares(trip.trip_id, user.id);
         const days = generateDateArray(startDate, endDate);
         await createTripDays(trip.trip_id, days);
+        track('trip_created', {
+          trip_id: trip.trip_id,
+          destination: primaryDestination || null,
+          duration_days: days.length,
+          has_cover_image: Boolean(coverImageUrl),
+        });
         onSubmit(trip.trip_id);
       }
     } catch (error) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@
 import { createContext, useContext, useEffect, useRef, useState, useMemo } from "react";
 import { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { identifyUser, resetAnalytics } from "@/lib/analytics";
 
 interface AuthContextType {
   session: Session | null;
@@ -180,6 +181,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       // on every token refresh, which would hit the DB every ~hour.
       if (event === 'TOKEN_REFRESHED') return;
       const isNewLogin = event === 'SIGNED_IN';
+      identifyUser(session.user.id, {
+        email: session.user.email,
+        provider: session.user.app_metadata?.provider,
+        created_at: session.user.created_at,
+      });
       ensureProfile(session.user.id, isNewLogin);
     });
 
@@ -228,6 +234,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const signOut = async () => {
     await supabase.auth.signOut();
+    resetAnalytics();
   };
 
   const refreshProfile = async () => {

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { supabase } from '@/integrations/supabase/client';
 import { useBufferedStreaming } from '@/hooks/useBufferedStreaming';
+import { track } from '@/lib/analytics';
 import type {
   AIChatMessage,
   AIUsageInfo,
@@ -615,11 +616,16 @@ export function useAIAssistant({ tripId, onLimitReached, onItemsExtracted }: Use
 
   // Route sendMessage to the appropriate handler
   const sendMessage = useCallback(async (content: string): Promise<void> => {
+    track('ai_chat_message_sent', {
+      trip_id: tripId,
+      anonymous: isAnonymous,
+      message_length: content.length,
+    });
     if (isAnonymous) {
       return sendMessageAnon(content);
     }
     return sendMessageAuth(content);
-  }, [isAnonymous, sendMessageAnon, sendMessageAuth]);
+  }, [isAnonymous, sendMessageAnon, sendMessageAuth, tripId]);
 
   // Clear thread/conversation
   const clearThread = useCallback(async (): Promise<void> => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,21 @@
+import posthog from 'posthog-js';
+
+type EventProps = Record<string, string | number | boolean | null | undefined>;
+
+export const track = (event: string, props?: EventProps): void => {
+  if (import.meta.env.DEV) {
+    console.debug('[analytics]', event, props ?? {});
+  }
+  posthog.capture(event, props);
+};
+
+export const identifyUser = (
+  userId: string,
+  props?: EventProps,
+): void => {
+  posthog.identify(userId, props);
+};
+
+export const resetAnalytics = (): void => {
+  posthog.reset();
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,11 @@ if (posthogKey) {
     capture_pageleave: false,
     autocapture: false,
     opt_out_capturing_by_default: true,
+    disable_session_recording: false,
+    session_recording: {
+      maskAllInputs: true,
+      maskInputOptions: { password: true, email: false },
+    },
   });
 }
 

--- a/src/services/pdfmake-export.ts
+++ b/src/services/pdfmake-export.ts
@@ -16,6 +16,7 @@ import pdfMake from 'pdfmake/build/pdfmake';
 import { loadPdfFonts } from './pdf-fonts';
 
 import { supabase } from '@/integrations/supabase/client';
+import { track } from '@/lib/analytics';
 import { parseISO, format as fnsFormat, isSameDay } from 'date-fns';
 import type { PdfExportOptions } from '@/components/trip/PdfExportDialog';
 import type { Content, TableCell, TDocumentDefinitions } from 'pdfmake/interfaces';
@@ -1179,6 +1180,10 @@ export async function exportItineraryPdf(tripId: string, o: PdfExportOptions): P
     await loadPdfFonts();
     console.log('[PDF Export] Starting export for trip:', tripId);
     console.log('[PDF Export] Options:', o);
+    track('pdf_exported', {
+      trip_id: tripId,
+      page_preset: (o as PdfExportOptions & { pagePreset?: string })?.pagePreset ?? 'auto',
+    });
 
     const preset: PagePreset = ((o as PdfExportOptions & { pagePreset?: PagePreset })?.pagePreset) || 'auto';
     const {


### PR DESCRIPTION
## Summary

Tier 1 PostHog activation. The integration was wired up but inactive in product terms — no `identify()` calls and no custom events meant DAU/WAU/Retention defaults stayed empty.

- **Identify on auth state change** (`AuthContext`) with `email`, `provider`, `created_at`; reset on sign-out
- **Re-identify in `PostHogConsentSync`** when a user grants consent *after* signing in (the AuthContext identify is otherwise dropped while capturing is opted-out)
- **Capture three product events**: `trip_created` (destination, duration, has cover), `pdf_exported` (preset), `ai_chat_message_sent` (trip id, anonymous flag, message length — no content)
- **Enable session recording in SDK init** with `maskAllInputs: true` and explicit `password: true` masking. Email is intentionally left visible for person-page debugging
- **New `src/lib/analytics.ts`** wrapper: `track / identifyUser / resetAnalytics`, with a dev-mode console.debug

Pairs with project settings flipped via MCP: `session_recording_opt_in=true` at `0.10` sample rate (30d retention).

## Test plan

- [ ] Sign in → confirm a person profile appears in PostHog with the user's email
- [ ] Sign out → confirm `posthog.reset()` fires (no further events tied to that distinct_id)
- [ ] Create a trip → `trip_created` event lands with correct `destination`/`duration_days`
- [ ] Export a PDF → `pdf_exported` lands with `page_preset`
- [ ] Send an AI chat message → `ai_chat_message_sent` lands; verify message body is **not** captured
- [ ] Grant cookie consent after signing in → identify is called and the person appears (not anonymous)
- [ ] After ~10 sessions, confirm a replay shows up in [/replay/home](https://us.posthog.com/project/363169/replay/home) and that password fields are masked

## Notes

- Local `.env` now has `VITE_POSTHOG_KEY` set, so dev traffic will hit production. Consider filtering yourself via the existing test-account cohort, or wrapping `track()` to no-op in `import.meta.env.DEV`
- No new feature flags, dashboards, or insights — those come in Tier 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)