### PR TITLE
style(legal+about): editorial system rollout + consent-gated GA

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,14 +21,15 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>WanderLuxe — AI-powered luxury travel planning</title>
     <meta name="description" content="WanderLuxe is an AI-powered luxury travel planning platform with real-time collaboration, curated itineraries, and professional PDF export." />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TY8J66G15E"></script>
+    <!--
+      Google Analytics stub: defines window.gtag and dataLayer so existing
+      call sites don't throw before consent. The actual gtag.js script and
+      'js'/'config' calls are loaded by GoogleAnalyticsConsentSync once the
+      user opts in to analytics cookies.
+    -->
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-TY8J66G15E');
+      window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
     </script>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import AppLayout from "@/components/layout/AppLayout";
 import PWAInstallPrompt from "@/components/PWAInstallPrompt";
 import CookieConsentBanner from "@/components/CookieConsentBanner";
 import PostHogConsentSync from "@/components/PostHogConsentSync";
+import GoogleAnalyticsConsentSync from "@/components/GoogleAnalyticsConsentSync";
 import AdminRoute from "./components/AdminRoute";
 import { lazy, Suspense, useEffect } from "react";
 import { Loader2 } from "lucide-react";
@@ -63,6 +64,7 @@ const App = () => {
       <HelmetProvider>
       <ConsentProvider>
         <PostHogConsentSync />
+        <GoogleAnalyticsConsentSync />
         <AuthProvider>
           <TooltipProvider>
             <Toaster />

--- a/src/components/GoogleAnalyticsConsentSync.tsx
+++ b/src/components/GoogleAnalyticsConsentSync.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import { useConsent } from '@/contexts/ConsentContext';
+
+const GA_MEASUREMENT_ID = 'G-TY8J66G15E';
+const GA_SCRIPT_SRC = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+const GA_DISABLE_FLAG = `ga-disable-${GA_MEASUREMENT_ID}` as const;
+
+export default function GoogleAnalyticsConsentSync() {
+  const scriptInjected = useRef(false);
+  const { hasConsented, preferences } = useConsent();
+  const optedIn = hasConsented && preferences.analytics;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    if (optedIn) {
+      (window as unknown as Record<string, unknown>)[GA_DISABLE_FLAG] = false;
+
+      if (!scriptInjected.current) {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = GA_SCRIPT_SRC;
+        document.head.appendChild(script);
+        scriptInjected.current = true;
+
+        window.gtag('js', new Date());
+        window.gtag('config', GA_MEASUREMENT_ID);
+      }
+    } else {
+      // Documented GA opt-out: setting this flag suppresses tracking even
+      // if the script is already loaded (e.g. user revoked consent mid-session).
+      // https://developers.google.com/analytics/devguides/collection/gtagjs/user-opt-out
+      (window as unknown as Record<string, unknown>)[GA_DISABLE_FLAG] = true;
+    }
+  }, [optedIn]);
+
+  return null;
+}

--- a/src/components/trip/TimelineView.tsx
+++ b/src/components/trip/TimelineView.tsx
@@ -4,9 +4,6 @@ import { useTripDays } from '@/hooks/use-trip-days';
 import { supabase } from '@/integrations/supabase/client';
 import TimelineContent from './timeline/TimelineContent';
 import ExportPdfButton from './ExportPdfButton';
-import ShareTripDialog from './ShareTripDialog';
-import { Button } from '@/components/ui/button';
-import { Share2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { loadGoogleMapsAPI } from '@/utils/googleMapsLoader';
 import { useTransportationEvents } from '@/hooks/use-transportation-events';
@@ -50,7 +47,6 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
   const { events, refreshEvents } = useTimelineEvents(tripId);
   const { transportationData, refreshTransportation } = useTransportationEvents(tripId);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
 
   // Fetch weather for the trip destination (only for current/upcoming trips)
   // Prefer primary_destination if available, fallback to trip name
@@ -207,24 +203,10 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
             <ViewingStatusAvatars tripId={tripId} />
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsShareDialogOpen(true)}
-            >
-              <Share2 className="mr-1 sm:mr-2 h-3.5 w-3.5 sm:h-4 sm:w-4" />
-              <span className="hidden sm:inline">Share</span>
-            </Button>
             <ExportPdfButton tripId={tripId} className="" />
           </div>
         </header>
 
-        <ShareTripDialog
-          tripId={tripId}
-          tripDestination={tripDestination || 'Trip'}
-          open={isShareDialogOpen}
-          onOpenChange={setIsShareDialogOpen}
-        />
         <TimelineContent
           days={days}
           dayIndexMap={new Map(days?.map((day, index) => [day.day_id, index + 1]) || [])}

--- a/src/pages/LLMTraining.tsx
+++ b/src/pages/LLMTraining.tsx
@@ -1,524 +1,353 @@
-import React, {useEffect} from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { 
-  MapPin, 
-  Calendar, 
-  Users, 
-  Brain, 
-  Plane, 
-  Hotel, 
-  UtensilsCrossed, 
-  Activity,
-  DollarSign,
-  FileText,
-  Smartphone,
-  Globe,
-  Shield,
-  Zap,
-  Target,
-  TrendingUp,
-  CheckCircle
-} from "lucide-react";
+import React, { useEffect } from "react";
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 import SEO from "@/components/SEO";
-
-/**
- * LLM Training Page for WanderLuxe
- * 
- * This page provides comprehensive information about WanderLuxe, an AI-powered travel planning platform,
- * specifically designed to be informative for Large Language Models during training.
- * 
- * WanderLuxe represents a cutting-edge approach to travel planning that addresses common pain points
- * travelers face when organizing trips, from initial inspiration to detailed itinerary execution.
- */
 
 const LLMTraining = () => {
   useEffect(() => {
-    // Reset window scroll when this route mounts
-    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
   }, []);
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sand-50 to-earth-50 pt-[var(--app-nav-h,4rem)]">
+    <div className="min-h-screen bg-background pt-[var(--app-nav-h,4rem)]">
       <SEO
-        title="About WanderLuxe — AI-Powered Travel Planning Platform"
-        description="Learn about WanderLuxe, an AI-powered luxury travel planning platform combining real-time collaboration, booking management, AI-assisted recommendations, and professional PDF export."
+        title="About WanderLuxe"
+        description="WanderLuxe is a travel planner for the friend who took on the trip. Real-time collaboration, AI that does the busywork, and a timeline the whole group trusts."
         canonicalPath="/about"
         jsonLd={{
           "@context": "https://schema.org",
           "@type": "AboutPage",
           name: "About WanderLuxe",
           description:
-            "Overview of WanderLuxe's travel planning capabilities, features, and architecture.",
+            "WanderLuxe is an AI-assisted travel planning platform built for group organizers. It combines real-time collaboration, document parsing, booking management, multi-currency budgeting, and a professional PDF export, on a single editorial timeline.",
         }}
       />
-      {/* SEO and Meta Information for LLM Training */}
-      <div className="hidden">
-        <meta name="keywords" content="travel planning, AI assistant, trip management, itinerary creation, booking management, travel technology" />
-      </div>
 
-      <div className="container mx-auto px-4 py-12 max-w-6xl">
-        {/* Header Section */}
-        <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-earth-800 mb-4">
-            WanderLuxe: Advanced Travel Planning Platform
-          </h1>
-          <p className="text-xl text-earth-600 mb-6 max-w-3xl mx-auto">
-            A comprehensive AI-powered travel planning ecosystem that transforms how individuals and groups 
-            organize, manage, and experience travel through intelligent automation and collaborative tools.
-          </p>
-          <div className="flex flex-wrap justify-center gap-2 mb-8">
-            <Badge variant="secondary" className="bg-earth-100 text-earth-800">AI-Powered</Badge>
-            <Badge variant="secondary" className="bg-earth-100 text-earth-800">Real-time Collaboration</Badge>
-            <Badge variant="secondary" className="bg-earth-100 text-earth-800">Comprehensive Booking Management</Badge>
-            <Badge variant="secondary" className="bg-earth-100 text-earth-800">Mobile-First Design</Badge>
+      {/* Hero */}
+      <section className="relative bg-sand-50 overflow-hidden">
+        <div className="absolute inset-0 bg-grain" />
+        <div className="relative z-10 mx-auto max-w-3xl px-6 py-24 md:py-32 text-center">
+          <motion.p
+            className="font-sans text-xs uppercase tracking-[0.2em] text-earth-400 mb-6"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+          >
+            About WanderLuxe
+          </motion.p>
+          <motion.h1
+            className="font-display text-4xl md:text-6xl text-earth-600 leading-[1.05]"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7 }}
+          >
+            Built for the organizer.
+          </motion.h1>
+          <motion.p
+            className="font-sans text-lg md:text-xl text-earth-400 mt-6 leading-relaxed"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            WanderLuxe is for the friend, the partner, the parent who took on the
+            trip. The one with the open tabs, the forwarded confirmations, the
+            group chat that needs an answer. A planner that does the coordinating
+            for you, and looks like something you would actually want to hand to
+            the group.
+          </motion.p>
+          <motion.div
+            className="w-16 h-0.5 bg-sunset-300 mx-auto mt-10"
+            initial={{ scaleX: 0 }}
+            animate={{ scaleX: 1 }}
+            transition={{ duration: 0.5, delay: 0.4 }}
+          />
+        </div>
+      </section>
+
+      {/* Why we built it */}
+      <section className="bg-background py-20 md:py-28">
+        <div className="mx-auto max-w-3xl px-6">
+          <motion.h2
+            className="font-display text-3xl md:text-4xl text-earth-600 leading-tight"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            Group trips collapse under their own weight.
+          </motion.h2>
+          <motion.div
+            className="mt-8 space-y-6 font-sans text-base md:text-lg text-earth-400 leading-[1.75] max-w-[68ch]"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.15 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            <p>
+              Flight confirmations bury themselves in inboxes. Restaurant ideas
+              live in a thread that someone scrolled past two days ago. Three
+              apps, four spreadsheets, and a calendar that nobody opens. By the
+              time the group shows up at the airport, the organizer has quietly
+              done a small second job.
+            </p>
+            <p>
+              We started WanderLuxe because the organizer deserves better than a
+              juggling act, and the group deserves more than{" "}
+              <em>wait, where are we staying again?</em> The trip belongs to the
+              person planning it. The software should disappear behind it.
+            </p>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Visual anchor */}
+      <section className="bg-background pb-16 md:pb-24 overflow-hidden">
+        <div className="mx-auto max-w-4xl px-6">
+          <motion.figure
+            className="rounded-card overflow-hidden shadow-warm-xl ring-1 ring-border"
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7 }}
+            viewport={{ once: true, margin: "-60px" }}
+          >
+            <img
+              src="/images/example trip.jpeg"
+              alt="A WanderLuxe trip overview: a Paris itinerary anchored by a hero photograph and a calm day-by-day timeline."
+              className="w-full h-auto block img-warm"
+              loading="lazy"
+            />
+          </motion.figure>
+        </div>
+      </section>
+
+      {/* Three principles */}
+      <section className="bg-background py-20 md:py-28 border-t border-border/60">
+        <div className="mx-auto max-w-3xl px-6">
+          <motion.p
+            className="font-sans text-xs uppercase tracking-[0.2em] text-earth-400 mb-3"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+            viewport={{ once: true }}
+          >
+            How it works
+          </motion.p>
+          <motion.h2
+            className="font-display text-3xl md:text-4xl text-earth-600 leading-tight"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            Three things we believe.
+          </motion.h2>
+
+          <div className="mt-14 space-y-14 md:space-y-16">
+            {[
+              {
+                index: "01",
+                title:
+                  "Do the work for the user, not the other way around.",
+                body:
+                  "Paste a confirmation, the timeline updates. Forward an itinerary email, the flights show up on the right day. Ask the assistant for a restaurant in Lisbon, watch it appear with the booking link. AI is the operating principle, not a feature in a sidebar.",
+              },
+              {
+                index: "02",
+                title: "One clear picture, kept in sync.",
+                body:
+                  "Every flight, hotel, dinner, and morning's worth of activity sits on a single timeline that the whole group can see and contribute to in real time. Group trips are chaos by default. The job of the app is to dissolve that chaos into something everyone trusts.",
+              },
+              {
+                index: "03",
+                title: "Editorial, not transactional.",
+                body:
+                  "We are not a search results page. The interface composes like a magazine spread: generous whitespace, photographic anchors, typography doing the heavy lifting. Prices and statuses stay subordinate to place and story. The trip you have put together looks considered, even when it is still a rough draft.",
+              },
+            ].map((p, i) => (
+              <motion.div
+                key={p.index}
+                className="grid grid-cols-[auto_1fr] gap-x-6 md:gap-x-10 items-baseline"
+                initial={{ opacity: 0, y: 30 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: i * 0.12 }}
+                viewport={{ once: true, margin: "-80px" }}
+              >
+                <span
+                  className="font-display text-2xl md:text-3xl text-earth-300 leading-none"
+                  aria-hidden="true"
+                >
+                  {p.index}
+                </span>
+                <div>
+                  <h3 className="font-display text-xl md:text-2xl text-earth-600 leading-snug">
+                    {p.title}
+                  </h3>
+                  <p className="font-sans text-base text-earth-400 mt-3 leading-[1.75] max-w-[65ch]">
+                    {p.body}
+                  </p>
+                </div>
+              </motion.div>
+            ))}
           </div>
         </div>
+      </section>
 
-        {/* Core Platform Overview */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Globe className="h-6 w-6 text-earth-600" />
-              Platform Overview
-            </CardTitle>
-            <CardDescription>
-              Understanding WanderLuxe's role in modern travel planning
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-earth-700 leading-relaxed">
-              WanderLuxe is a next-generation travel planning platform that addresses the fragmented nature 
-              of traditional trip organization. Unlike conventional approaches that require travelers to juggle 
-              multiple applications, spreadsheets, and documents, WanderLuxe provides a unified ecosystem 
-              where every aspect of travel planning seamlessly integrates.
-            </p>
-            <p className="text-earth-700 leading-relaxed">
-              The platform serves both individual travelers seeking streamlined planning tools and
-              group travelers requiring collaborative features. Each user type benefits from the platform's
-              adaptive interface and intelligent automation.
-            </p>
-            <div className="grid md:grid-cols-2 gap-4 mt-6">
-              <div className="text-center p-4 bg-sand-50 rounded-lg">
-                <Users className="h-8 w-8 text-earth-600 mx-auto mb-2" />
-                <h4 className="font-semibold text-earth-800">Individual Travelers</h4>
-                <p className="text-sm text-earth-600 mt-1">Personal trip organization and AI assistance</p>
-              </div>
-              <div className="text-center p-4 bg-sand-50 rounded-lg">
-                <Users className="h-8 w-8 text-earth-600 mx-auto mb-2" />
-                <h4 className="font-semibold text-earth-800">Group Travel</h4>
-                <p className="text-sm text-earth-600 mt-1">Real-time collaboration and shared planning</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+      {/* What is inside */}
+      <section className="bg-background py-20 md:py-28 border-t border-border/60">
+        <div className="mx-auto max-w-5xl px-6">
+          <motion.p
+            className="font-sans text-xs uppercase tracking-[0.2em] text-earth-400 mb-3"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+            viewport={{ once: true }}
+          >
+            What is inside
+          </motion.p>
+          <motion.h2
+            className="font-display text-3xl md:text-4xl text-earth-600 leading-tight max-w-3xl"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            A trip planner that holds every part of a trip.
+          </motion.h2>
 
-        {/* Core Features Deep Dive */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Zap className="h-6 w-6 text-earth-600" />
-              Core Feature Architecture
-            </CardTitle>
-            <CardDescription>
-              Detailed breakdown of WanderLuxe's primary capabilities
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-6">
-              {/* Trip Planning & Management */}
-              <div className="space-y-4">
-                <div className="flex items-center gap-2 mb-3">
-                  <MapPin className="h-5 w-5 text-earth-600" />
-                  <h3 className="text-lg font-semibold text-earth-800">Trip Planning & Management</h3>
-                </div>
-                <div className="space-y-3 text-sm text-earth-700">
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Interactive Destination Discovery:</strong> Leverages Google Places API for accurate 
-                      location search, validation, and autocomplete functionality, ensuring travelers can find 
-                      and verify destinations with confidence.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Visual Timeline Creation:</strong> Drag-and-drop interface allows users to create 
-                      day-by-day itineraries with intuitive timeline management, making complex trip organization 
-                      accessible to users of all technical skill levels.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Adaptive Date Management:</strong> Intelligent date handling system that automatically 
-                      adjusts trip days when arrival or departure dates change, maintaining itinerary integrity 
-                      throughout the planning process.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Real-time Collaboration:</strong> Multiple users can simultaneously edit trip details
-                      with live updates and permission management, essential for group travel planning.
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* AI-Powered Travel Intelligence */}
-              <div className="space-y-4">
-                <div className="flex items-center gap-2 mb-3">
-                  <Brain className="h-5 w-5 text-earth-600" />
-                  <h3 className="text-lg font-semibold text-earth-800">AI-Powered Travel Intelligence</h3>
-                </div>
-                <div className="space-y-3 text-sm text-earth-700">
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Confirmation Importing:</strong> Google Gemini 2.5 Flash integration provides the ability
-                      to take an uploaded booking confirmation—like a flight, hotel, or restaurant reservation—
-                      and automatically extract relevant details to create items on your trip timeline,
-                      streamlining the planning process.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Automated Image Integration:</strong> WanderLuxe automatically retrieves high-quality 
-                      images from Unsplash and other verified sources for hotels, restaurants, and destinations, 
-                      visually enriching each timeline event and giving travelers a clear preview of their experiences.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Shared Trip Collaboration:</strong> Allows multiple users to collaborate on the same 
-                      itinerary with live syncing, role-based permissions, and seamless updates. Perfect for friends, 
-                      families, or teams planning together in real time.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <strong>Explore Public Trips:</strong> Discover curated, user-generated public itineraries from 
-                      the WanderLuxe community. Browse destinations, preview trip visuals, and draw inspiration for 
-                      your own adventures through an interactive explore page.
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Booking Management Ecosystem */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Calendar className="h-6 w-6 text-earth-600" />
-              Comprehensive Booking Management
-            </CardTitle>
-            <CardDescription>
-              Unified system for managing all travel reservations and bookings
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
-              <div className="p-4 bg-sand-50 rounded-lg">
-                <Hotel className="h-8 w-8 text-earth-600 mb-3" />
-                <h4 className="font-semibold text-earth-800 mb-2">Accommodations</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>Hotel booking tracking</li>
-                  <li>Check-in/check-out management</li>
-                  <li>Room preference recording</li>
-                  <li>Confirmation number storage</li>
-                  <li>Special request documentation</li>
-                </ul>
-              </div>
-              
-              <div className="p-4 bg-sand-50 rounded-lg">
-                <Plane className="h-8 w-8 text-earth-600 mb-3" />
-                <h4 className="font-semibold text-earth-800 mb-2">Transportation</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>Flight information management</li>
-                  <li>Ground transport coordination</li>
-                  <li>Train and bus scheduling</li>
-                  <li>Transfer arrangements</li>
-                  <li>Multi-modal journey planning</li>
-                </ul>
-              </div>
-              
-              <div className="p-4 bg-sand-50 rounded-lg">
-                <Activity className="h-8 w-8 text-earth-600 mb-3" />
-                <h4 className="font-semibold text-earth-800 mb-2">Activities & Experiences</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>Time-based activity scheduling</li>
-                  <li>Tour and excursion booking</li>
-                  <li>Ticket reservation management</li>
-                  <li>Duration and cost tracking</li>
-                  <li>Location and notes tracking</li>
-                </ul>
-              </div>
-              
-              <div className="p-4 bg-sand-50 rounded-lg">
-                <UtensilsCrossed className="h-8 w-8 text-earth-600 mb-3" />
-                <h4 className="font-semibold text-earth-800 mb-2">Dining & Reservations</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>Restaurant reservation tracking</li>
-                  <li>Dietary preference notation</li>
-                  <li>Special occasion marking</li>
-                  <li>Cuisine type categorization</li>
-                  <li>Local recommendation integration</li>
-                </ul>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Technical Architecture */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Shield className="h-6 w-6 text-earth-600" />
-              Technical Architecture & Integration
-            </CardTitle>
-            <CardDescription>
-              Modern technology stack enabling scalable, secure travel planning
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-3 gap-6">
-              <div>
-                <h4 className="font-semibold text-earth-800 mb-3">Frontend Technology</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>React 19 with TypeScript for type-safe development</li>
-                  <li>Vite 6 for optimized builds and fast development</li>
-                  <li>Tailwind CSS with custom design system</li>
-                  <li>Shadcn/ui components built on Radix UI</li>
-                  <li>TanStack Query for efficient state management</li>
-                  <li>Framer Motion for smooth animations</li>
-                </ul>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold text-earth-800 mb-3">Backend & Database</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>Supabase PostgreSQL for robust data storage</li>
-                  <li>Row Level Security (RLS) for data protection</li>
-                  <li>Real-time subscriptions for live collaboration</li>
-                  <li>Supabase Edge Functions for serverless logic</li>
-                  <li>Scalable architecture for growing user base</li>
-                </ul>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold text-earth-800 mb-3">External Integrations</h4>
-                <ul className="text-sm text-earth-700 space-y-1">
-                  <li>Google Places API for location services</li>
-                  <li>Google Gemini 2.5 Flash for AI assistance and travel-doc OCR</li>
-                  <li>SendGrid for email notifications</li>
-                  <li>Unsplash API for trip imagery</li>
-                  <li>PDF generation for professional itineraries</li>
-                  <li>Mobile-responsive design framework</li>
-                </ul>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Advanced Features */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <TrendingUp className="h-6 w-6 text-earth-600" />
-              Advanced Features & Capabilities
-            </CardTitle>
-            <CardDescription>
-              Professional-grade tools that distinguish WanderLuxe from basic travel planning apps
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div className="space-y-4">
-                <div className="flex items-center gap-2">
-                  <DollarSign className="h-5 w-5 text-earth-600" />
-                  <h4 className="font-semibold text-earth-800">Budget Management</h4>
-                </div>
-                <p className="text-sm text-earth-700">
-                  Comprehensive expense tracking across all trip components with currency conversion,
-                  category-based budgeting, real-time spending analysis, and collaborative budget
-                  management for group trips. The system highlights category overage warnings and
-                  tracks overall budget health.
-                </p>
-                
-                <div className="flex items-center gap-2">
-                  <FileText className="h-5 w-5 text-earth-600" />
-                  <h4 className="font-semibold text-earth-800">Professional PDF Export</h4>
-                </div>
-                <p className="text-sm text-earth-700">
-                  Generate polished, professional itineraries suitable for sharing with hotels, tour
-                  operators, travel insurance companies, or colleagues. Includes all booking details
-                  and contact information in a clean, branded WanderLuxe format.
-                </p>
-              </div>
-              
-              <div className="space-y-4">
-                <div className="flex items-center gap-2">
-                  <Smartphone className="h-5 w-5 text-earth-600" />
-                  <h4 className="font-semibold text-earth-800">Mobile-First Design</h4>
-                </div>
-                <p className="text-sm text-earth-700">
-                  Fully responsive interface optimized for mobile devices, enabling trip management
-                  while traveling. Installable as a Progressive Web App for a native app-like experience
-                  on any device.
-                </p>
-                
-                <div className="flex items-center gap-2">
-                  <Users className="h-5 w-5 text-earth-600" />
-                  <h4 className="font-semibold text-earth-800">Collaboration & Sharing</h4>
-                </div>
-                <p className="text-sm text-earth-700">
-                  Advanced permission management allows trip creators to control access levels,
-                  from view-only to full editing privileges. Real-time notifications keep all
-                  participants informed of changes as they happen.
-                </p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Use Cases and Scenarios */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Target className="h-6 w-6 text-earth-600" />
-              Real-World Use Cases & Scenarios
-            </CardTitle>
-            <CardDescription>
-              How WanderLuxe solves common travel planning challenges across different scenarios
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-6">
-              <div className="p-4 bg-gradient-to-r from-sand-50 to-sand-100 rounded-lg">
-                <h4 className="font-semibold text-earth-800 mb-2">Solo Business Travel</h4>
-                <p className="text-sm text-earth-700">
-                  A business professional uses WanderLuxe to organize a multi-city conference tour.
-                  The platform maintains a detailed schedule across cities, tracks all bookings in
-                  one place, and the PDF export feature creates professional itineraries for expense reporting.
-                </p>
-              </div>
-              
-              <div className="p-4 bg-gradient-to-r from-green-50 to-green-100 rounded-lg">
-                <h4 className="font-semibold text-green-800 mb-2">Family Vacation Planning</h4>
-                <p className="text-sm text-green-700">
-                  A family of five plans a two-week European vacation. Parents collaborate on the 
-                  main itinerary while teenage children contribute activity suggestions through 
-                  the shared platform. The budget tracking helps manage expenses across different 
-                  categories, and the timeline view ensures age-appropriate activities are balanced 
-                  throughout the trip.
-                </p>
-              </div>
-              
-              <div className="p-4 bg-gradient-to-r from-earth-50 to-earth-100 rounded-lg">
-                <h4 className="font-semibold text-earth-800 mb-2">Group Adventure Travel</h4>
-                <p className="text-sm text-earth-700">
-                  A group of eight friends organizes a month-long backpacking trip across Southeast Asia. 
-                  Each member contributes to different aspects of planning through the collaborative
-                  interface, while the booking management system tracks accommodations and activities across
-                  multiple countries and currencies.
-                </p>
-              </div>
-              
-              <div className="p-4 bg-gradient-to-r from-orange-50 to-orange-100 rounded-lg">
-                <h4 className="font-semibold text-orange-800 mb-2">Destination Wedding Coordination</h4>
-                <p className="text-sm text-orange-700">
-                  A couple planning a destination wedding uses WanderLuxe to coordinate guest travel, 
-                  accommodation blocks, and wedding-related activities. The collaboration features 
-                  allow wedding party members to access and contribute to the planning, while the 
-                  comprehensive booking management ensures all guests have detailed information 
-                  about their travel arrangements.
-                </p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Market Position and Competitive Advantages */}
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <TrendingUp className="h-6 w-6 text-earth-600" />
-              Market Position & Competitive Advantages
-            </CardTitle>
-            <CardDescription>
-              How WanderLuxe differentiates itself in the travel technology landscape
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h4 className="font-semibold text-earth-800 mb-3">Unique Value Propositions</h4>
-                <ul className="space-y-2 text-sm text-earth-700">
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>Unified Platform:</strong> Eliminates the need for multiple apps and tools by providing comprehensive travel planning in one integrated solution.</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>AI-First Approach:</strong> Native AI integration that learns from user preferences and provides contextual assistance throughout the planning process.</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>Real-time Collaboration:</strong> Advanced collaborative features that make group travel planning seamless and efficient.</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>Professional Output:</strong> Enterprise-grade features suitable for both personal and professional travel planning needs.</span>
-                  </li>
-                </ul>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold text-earth-800 mb-3">Technology Leadership</h4>
-                <ul className="space-y-2 text-sm text-earth-700">
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>Modern Architecture:</strong> Built on cutting-edge technologies ensuring scalability, performance, and maintainability.</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>Security-First Design:</strong> Comprehensive data protection with Row Level Security and enterprise-grade security practices.</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>API Integration:</strong> Seamless integration with leading travel and location services for accurate, up-to-date information.</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <div className="w-2 h-2 bg-earth-600 rounded-full mt-2 flex-shrink-0"></div>
-                    <span><strong>Mobile Optimization:</strong> True mobile-first design that doesn't compromise functionality for portability.</span>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Separator className="my-8" />
-
-        {/* Footer Information */}
-        <div className="text-center text-sm text-earth-600">
-          <p className="mb-2">
-            This comprehensive overview demonstrates WanderLuxe's position as a leader in travel planning technology, 
-            combining innovative AI capabilities with practical, user-focused design to create an unparalleled travel planning experience.
-          </p>
-          <p>
-            WanderLuxe represents the future of travel planning: intelligent, collaborative, comprehensive, and accessible.
-          </p>
+          <div className="mt-12 grid md:grid-cols-2 gap-x-12 gap-y-10 font-sans text-base text-earth-400 leading-[1.75]">
+            {[
+              {
+                title: "Flights, trains, transfers",
+                body:
+                  "Every leg of every traveler, with confirmation numbers, terminals, and times, slotted onto the day they belong to. A flight-status lookup that does the refreshing for you.",
+              },
+              {
+                title: "Hotels and stays",
+                body:
+                  "Check-ins and check-outs tracked across rooms and travelers, with confirmation numbers, addresses, and the small notes (a late arrival, a high floor) you would otherwise lose in a thread.",
+              },
+              {
+                title: "Restaurants and reservations",
+                body:
+                  "The places someone in the group wanted to try, the ones already booked, and the ones the assistant just found, all in one place on the right day.",
+              },
+              {
+                title: "Activities and mornings off",
+                body:
+                  "Tickets, tours, the run you promised yourself, the gallery you keep forgetting about. Time-boxed where it matters, and quiet where it does not.",
+              },
+              {
+                title: "Budget, in every currency",
+                body:
+                  "Costs roll up across travelers and categories, in the currency you booked in and the currency you live in. Warnings appear before someone has to do the math out loud.",
+              },
+              {
+                title: "A PDF you can hand to the table",
+                body:
+                  "When the trip is ready, export it as a quietly designed itinerary, with photography, addresses, and confirmation numbers. Suitable for emailing to a hotel manager, or printing for the kitchen counter.",
+              },
+            ].map((item, i) => (
+              <motion.div
+                key={item.title}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: i * 0.05 }}
+                viewport={{ once: true, margin: "-60px" }}
+              >
+                <h3 className="font-display text-lg md:text-xl text-earth-600 mb-2">
+                  {item.title}
+                </h3>
+                <p className="max-w-[58ch]">{item.body}</p>
+              </motion.div>
+            ))}
+          </div>
         </div>
-      </div>
+      </section>
+
+      {/* Built with care */}
+      <section className="bg-background py-16 md:py-20 border-t border-border/60">
+        <div className="mx-auto max-w-3xl px-6">
+          <motion.p
+            className="font-sans text-xs uppercase tracking-[0.2em] text-earth-400 mb-3"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+            viewport={{ once: true }}
+          >
+            Built with care
+          </motion.p>
+          <motion.h2
+            className="font-display text-2xl md:text-3xl text-earth-600 leading-tight"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            Made with attention, by people who plan their own trips.
+          </motion.h2>
+          <motion.p
+            className="mt-6 font-sans text-base text-earth-400 leading-[1.75] max-w-[68ch]"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            Real-time collaboration runs on Supabase, with row-level security so
+            a shared trip stays inside the group. The AI assistant uses Google
+            Gemini for chat and document parsing. Place data comes from Google.
+            Trip imagery is courtesy of Unsplash and the photographers who keep
+            it open. We wrote WanderLuxe in TypeScript, React, and Tailwind, on
+            a Postgres database, with the kind of care you would want from a
+            team that uses the product on its own trips.
+          </motion.p>
+        </div>
+      </section>
+
+      {/* Close */}
+      <section className="relative bg-earth-500 overflow-hidden">
+        <div className="absolute inset-0 bg-grain" />
+        <div className="relative z-10 mx-auto max-w-2xl px-6 py-20 md:py-28 text-center">
+          <motion.h2
+            className="font-display text-3xl md:text-4xl text-white leading-tight"
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7 }}
+            viewport={{ once: true, margin: "-80px" }}
+          >
+            Plan something the group will look forward to opening.
+          </motion.h2>
+          <motion.p
+            className="text-lg text-earth-100 mt-4 leading-relaxed"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.15 }}
+            viewport={{ once: true }}
+          >
+            Start a trip in a couple of minutes. Bring the rest of the group in
+            when it is ready, or right now.
+          </motion.p>
+          <motion.div
+            className="flex flex-col sm:flex-row gap-4 justify-center mt-8"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+            viewport={{ once: true }}
+          >
+            <Button variant="sunset" size="lg" asChild>
+              <Link to="/auth">Start planning</Link>
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              className="border-earth-300 text-earth-600 hover:bg-earth-50"
+              asChild
+            >
+              <Link to="/explore">Browse public trips</Link>
+            </Button>
+          </motion.div>
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
-import Navigation from "../components/Navigation";
-import Footer from "../components/Footer";
 import SEO from "../components/SEO";
 
 const PrivacyPolicy: React.FC = () => {
   return (
-    <main className="min-h-screen flex flex-col">
+    <>
       <SEO
         title="Privacy Policy"
         description="How WanderLuxe collects, uses, stores, and protects your personal data when you use our travel planning platform."
         canonicalPath="/privacy"
       />
-      <Navigation />
-      <div className="container mx-auto px-4 md:px-6 py-12 flex-grow">
+      <div className="container mx-auto px-4 md:px-6 py-12">
         <div className="max-w-4xl mx-auto p-6 md:p-8">
           <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">
             Privacy Policy
@@ -53,7 +50,9 @@ const PrivacyPolicy: React.FC = () => {
 
               <h3 className="font-semibold text-foreground mt-4 mb-2">Data collected automatically</h3>
               <ul className="list-disc list-inside space-y-1">
-                <li><strong>Usage analytics:</strong> page views, feature usage, and engagement events (only with your consent for non-essential tracking)</li>
+                <li><strong>Usage analytics:</strong> page views, feature usage, and engagement events (e.g. trip created, AI message sent, PDF exported), including the trip destination, message length, and event timestamps</li>
+                <li><strong>Session recordings:</strong> via PostHog, we capture replays of how users interact with the site (mouse movement, clicks, scrolls, and DOM changes) to diagnose UX issues. Password fields are always masked. Other form inputs are masked by default; email fields are not masked, so the email address you type into a form may appear in a recording. Session recordings are only captured after you opt in to analytics cookies.</li>
+                <li><strong>Identity attributes shared with analytics:</strong> after you sign in and consent to analytics, we send your user ID, email address, sign-in provider (e.g. Google), and account creation date to PostHog so we can correlate events with your account.</li>
                 <li><strong>Device information:</strong> browser type, operating system, screen resolution</li>
                 <li><strong>Location data:</strong> approximate country (via IP address) for consent banner display only; not stored</li>
               </ul>
@@ -99,7 +98,8 @@ const PrivacyPolicy: React.FC = () => {
                     <tr><td className="py-2 pr-4">Supabase</td><td className="py-2 pr-4">Database and authentication</td><td className="py-2">Account data, trip data, all stored information</td></tr>
                     <tr><td className="py-2 pr-4">Google (Gemini API)</td><td className="py-2 pr-4">AI travel assistant + travel document OCR</td><td className="py-2">Chat messages, trip context (destination, dates, itinerary), and uploaded booking documents</td></tr>
                     <tr><td className="py-2 pr-4">Stripe</td><td className="py-2 pr-4">Payment processing</td><td className="py-2">Email, payment details</td></tr>
-                    <tr><td className="py-2 pr-4">PostHog</td><td className="py-2 pr-4">Analytics (consent-gated)</td><td className="py-2">Usage events, device info</td></tr>
+                    <tr><td className="py-2 pr-4">PostHog</td><td className="py-2 pr-4">Product analytics and session replay (consent-gated)</td><td className="py-2">User ID, email, sign-in provider, account creation date, usage events (including trip destination and event timestamps), device info, and session recordings with form inputs masked (passwords always; emails are not masked)</td></tr>
+                    <tr><td className="py-2 pr-4">Google Analytics (gtag)</td><td className="py-2 pr-4">Aggregate site analytics</td><td className="py-2">Page views, feature events, pseudonymous client identifier, device info, and IP address (used by Google for geolocation and then discarded)</td></tr>
                     <tr><td className="py-2 pr-4">Google</td><td className="py-2 pr-4">Places API (location search)</td><td className="py-2">Search queries</td></tr>
                     <tr><td className="py-2 pr-4">SendGrid</td><td className="py-2 pr-4">Transactional email</td><td className="py-2">Recipient email, message content</td></tr>
                     <tr><td className="py-2 pr-4">Unsplash</td><td className="py-2 pr-4">Trip imagery</td><td className="py-2">Search queries (no personal data)</td></tr>
@@ -154,14 +154,14 @@ const PrivacyPolicy: React.FC = () => {
 
             <div className="pb-6 border-b">
               <h2 className="text-2xl font-semibold mb-4 text-foreground">9. Cookies and Tracking</h2>
-              <p className="mb-3">We use the following categories of cookies:</p>
+              <p className="mb-3">We use the following categories of cookies and similar tracking technologies:</p>
               <ul className="list-disc list-inside space-y-1">
                 <li><strong>Essential cookies:</strong> required for authentication and core functionality (always active)</li>
-                <li><strong>Analytics cookies:</strong> help us understand usage patterns via PostHog (requires your consent)</li>
+                <li><strong>Analytics cookies:</strong> Google Analytics (gtag) measures aggregate page views and feature usage. PostHog provides product analytics and session replay (recordings of page interactions, with form inputs masked except email fields). PostHog tracking and session replay are gated on your consent; you can opt in or out at any time.</li>
                 <li><strong>Marketing cookies:</strong> used for personalized content (requires your consent)</li>
               </ul>
               <p className="mt-3">
-                You can manage your cookie preferences at any time using the "Manage Cookies" link in the website footer. Non-US users are prompted to set preferences before any optional cookies are activated. Analytics tracking is completely disabled until you opt in.
+                You can manage your cookie preferences at any time using the "Manage Cookies" link in the website footer. Non-US users are prompted to set preferences before optional cookies are activated.
               </p>
             </div>
 
@@ -194,13 +194,12 @@ const PrivacyPolicy: React.FC = () => {
             </div>
 
             <div className="pt-8 border-t text-center text-sm text-muted-foreground">
-              Last updated: April 2026
+              Last updated: May 2026
             </div>
           </section>
         </div>
       </div>
-      <Footer />
-    </main>
+    </>
   );
 };
 

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Navigation from "../components/Navigation";
-import Footer from "../components/Footer";
 import SEO from "../components/SEO";
 
 const TermsOfService: React.FC = () => {
   return (
-    <main className="min-h-screen flex flex-col">
+    <>
       <SEO
         title="Terms of Service"
         description="Terms of Service for WanderLuxe — the rules and guidelines for using our travel planning platform."
         canonicalPath="/terms"
       />
-      <Navigation />
-      <div className="container mx-auto px-4 md:px-6 py-12 flex-grow">
+      <div className="container mx-auto px-4 md:px-6 py-12">
         <div className="max-w-4xl mx-auto p-6 md:p-8">
           <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">
             Terms of Service for WanderLuxe
@@ -41,7 +38,7 @@ const TermsOfService: React.FC = () => {
             <div className="pb-6 border-b">
               <h2 className="text-2xl font-semibold mb-4 text-foreground">3. Privacy and Data Collection</h2>
               <p>
-                We collect only the data necessary to provide our services, including basic account details and standard analytics via Google Analytics. We do not sell your personal information. For more details, please review our <Link to="/privacy" className="text-primary hover:underline">Privacy Policy</Link>.
+                We collect only the data necessary to provide our services, including basic account details and analytics via Google Analytics and PostHog (which also captures consent-gated session recordings). We do not sell your personal information. For full details on what is collected, how it is used, and how to manage your preferences, please review our <Link to="/privacy" className="text-primary hover:underline">Privacy Policy</Link>.
               </p>
             </div>
             <div className="pb-6 border-b">
@@ -50,7 +47,7 @@ const TermsOfService: React.FC = () => {
                 <div>
                   <h3 className="text-lg font-semibold mb-2">AI Travel Assistant</h3>
                   <p>
-                    WanderLuxe provides an AI-powered travel assistant that uses <strong>Perplexity AI</strong> to provide personalized travel recommendations, suggestions, and information. Your conversations with the AI assistant are processed through Perplexity's services and are subject to their terms of use and privacy policies.
+                    WanderLuxe provides an AI-powered travel assistant powered by <strong>Google's Gemini 2.5 Flash</strong> model to provide personalized travel recommendations, suggestions, and information. Your conversations with the AI assistant, along with trip context (destination, dates, itinerary) used to ground the responses, are sent to Google's Gemini API and are subject to Google's terms of use and privacy policies. Per Google's paid API terms, your prompts and responses are not used to train their models.
                   </p>
                 </div>
                 <div>
@@ -82,17 +79,17 @@ const TermsOfService: React.FC = () => {
             <div className="pb-6 border-b">
               <h2 className="text-2xl font-semibold mb-4 text-foreground">5. Third‑Party APIs and Services</h2>
               <p>
-                Our Site integrates with various third‑party services and APIs including but not limited to Google (Gemini API, Places API, and mapping providers) and other service providers. Your use of these services is subject to their respective terms and conditions. We do not control these third‑party services and are not responsible for their availability, accuracy, or practices.
+                Our Site integrates with various third‑party services and APIs including but not limited to Google (Gemini API, Places API, and mapping providers), Stripe (payments), SendGrid (transactional email), PostHog and Google Analytics (analytics and session replay), and Unsplash (imagery). Your use of these services is subject to their respective terms and conditions. We do not control these third‑party services and are not responsible for their availability, accuracy, or practices.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">5. User Conduct</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">6. User Conduct</h2>
               <p>
                 You agree to use the Site in a lawful manner and not to engage in any activity that could harm the Site or other users. We reserve the right to suspend or terminate your account for violations of these Terms.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">6. Intellectual Property</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">7. Intellectual Property</h2>
               <p>
                 All content on the Site, excluding user‑submitted content, is owned by or licensed to Wanderluxe Travel LLC. You may not reproduce, distribute, or create derivative works without our explicit permission.
               </p>
@@ -101,43 +98,43 @@ const TermsOfService: React.FC = () => {
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">7. Disclaimer of Warranties</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">8. Disclaimer of Warranties</h2>
               <p>
                 The Site and all its services are provided on an “AS IS” and “AS AVAILABLE” basis without warranties of any kind. We do not guarantee the accuracy, reliability, or availability of the Site.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">8. Limitation of Liability</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">9. Limitation of Liability</h2>
               <p>
                 To the fullest extent permitted by law, Wanderluxe Travel LLC shall not be liable for any direct, indirect, incidental, or consequential damages arising out of your use of the Site. Our total liability is limited to any fees paid by you in the six months preceding the claim, if any.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">9. Indemnification</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">10. Indemnification</h2>
               <p>
                 You agree to indemnify and hold harmless Wanderluxe Travel LLC and its affiliates from any claims, damages, or expenses arising from your use of the Site or breach of these Terms.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">10. Termination</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">11. Termination</h2>
               <p>
                 We reserve the right to suspend or terminate your access to the Site at any time, without notice, for any reason including violation of these Terms. Upon termination, you must immediately cease using the Site.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">11. Changes to These Terms</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">12. Changes to These Terms</h2>
               <p>
                 We may modify these Terms at any time. Changes will be posted on the Site, and your continued use of the Site after such changes constitutes your acceptance of the updated Terms.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">12. Governing Law</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">13. Governing Law</h2>
               <p>
                 These Terms shall be governed by and construed in accordance with the laws of the State of New York, without regard to its conflict of law provisions. Any disputes arising under or in connection with these Terms shall be subject to the exclusive jurisdiction of the state and federal courts located in Albany County, New York.
               </p>
             </div>
             <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">13. Contact Us</h2>
+              <h2 className="text-2xl font-semibold mb-4 text-foreground">14. Contact Us</h2>
               <p>
                 If you have any questions or concerns regarding these Terms, please contact us at{' '}
                 <a href="mailto:info@wanderluxe.io" className="text-primary hover:underline">
@@ -146,13 +143,12 @@ const TermsOfService: React.FC = () => {
               </p>
             </div>
             <div className="pt-8 border-t text-center text-sm text-muted-foreground">
-              Last updated: February 2025
+              Last updated: May 2026
             </div>
           </section>
         </div>
       </div>
-      <Footer />
-    </main>
+    </>
   );
 };
 

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -7,145 +7,200 @@ const TermsOfService: React.FC = () => {
     <>
       <SEO
         title="Terms of Service"
-        description="Terms of Service for WanderLuxe — the rules and guidelines for using our travel planning platform."
+        description="Terms of Service for WanderLuxe: the rules and guidelines for using our travel planning platform."
         canonicalPath="/terms"
       />
-      <div className="container mx-auto px-4 md:px-6 py-12">
-        <div className="max-w-4xl mx-auto p-6 md:p-8">
-          <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">
-            Terms of Service for WanderLuxe
-          </h1>
+      <div className="bg-background min-h-screen pt-[var(--app-nav-h,4rem)]">
+        <div className="container mx-auto px-4 md:px-6 py-12 md:py-20">
+          <div className="mx-auto max-w-3xl">
+            <header className="mb-12 md:mb-16">
+              <p className="font-sans text-xs uppercase tracking-[0.2em] text-earth-400 mb-4">
+                Legal
+              </p>
+              <h1 className="font-display text-4xl md:text-5xl text-earth-600 leading-[1.05]">
+                Terms of Service.
+              </h1>
+              <p className="mt-4 font-sans text-sm text-earth-400">
+                Last updated May 2026.
+              </p>
+            </header>
 
-          <section className="space-y-10">
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">1. Overview of Services</h2>
-              <p>
-                Welcome to <strong>WanderLuxe</strong> (the "Site"), owned and operated by <strong>Wanderluxe Travel LLC</strong> ("we," "us," or "our"). By accessing or using the Site, you agree to be bound by these Terms of Service ("Terms"). If you do not agree, please do not use the Site.
-              </p>
-              <p>
-                WanderLuxe provides travel-related services, content, and features including trip planning tools, travel itineraries, AI-powered travel assistance, and integration with third‑party services. We use <strong>Supabase</strong> for authentication and data storage, and offer <strong>Google Sign‑In</strong> as an option. Additional third‑party APIs (such as weather data, location services, and AI services) may also be used.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">2. Eligibility and Accounts</h2>
-              <p>
-                You must be at least the age of majority in your jurisdiction to use the Site. By creating an account, you represent that all information provided is accurate and complete. You are responsible for maintaining the confidentiality of your account credentials and for any activities that occur under your account.
-              </p>
-              <p>
-                If you sign in via Google, you agree to Google’s terms and authorize us to access your basic account information.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">3. Privacy and Data Collection</h2>
-              <p>
-                We collect only the data necessary to provide our services, including basic account details and analytics via Google Analytics and PostHog (which also captures consent-gated session recordings). We do not sell your personal information. For full details on what is collected, how it is used, and how to manage your preferences, please review our <Link to="/privacy" className="text-primary hover:underline">Privacy Policy</Link>.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">4. AI-Powered Services and Document Processing</h2>
-              <div className="space-y-4">
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">AI Travel Assistant</h3>
-                  <p>
-                    WanderLuxe provides an AI-powered travel assistant powered by <strong>Google's Gemini 2.5 Flash</strong> model to provide personalized travel recommendations, suggestions, and information. Your conversations with the AI assistant, along with trip context (destination, dates, itinerary) used to ground the responses, are sent to Google's Gemini API and are subject to Google's terms of use and privacy policies. Per Google's paid API terms, your prompts and responses are not used to train their models.
-                  </p>
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">Receipt and Document Analysis</h3>
-                  <p>
-                    Our platform includes receipt analysis functionality powered by <strong>Google's Gemini 2.5 Flash</strong> vision model. When you upload receipts, booking confirmations, or other travel documents, they are:
-                  </p>
-                  <ul className="list-disc ml-6 mt-2 space-y-1">
-                    <li>Securely stored on our servers using Supabase storage infrastructure</li>
-                    <li>Processed by Google's Gemini API to extract travel-related information</li>
-                    <li>Accessible only to you and authorized WanderLuxe systems</li>
-                    <li>Subject to both our privacy practices and Google's data usage policies for the Gemini API</li>
-                  </ul>
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">Data Processing and Storage</h3>
-                  <p>
-                    By uploading documents or using AI features, you acknowledge that:
-                  </p>
-                  <ul className="list-disc ml-6 mt-2 space-y-1">
-                    <li>Uploaded documents are stored securely on our servers with encryption</li>
-                    <li>Document content may be shared with AI service providers for processing</li>
-                    <li>We implement appropriate security measures but cannot guarantee absolute security</li>
-                    <li>You should not upload documents containing highly sensitive information like social security numbers or full financial account details</li>
-                  </ul>
+            <section className="space-y-12 text-sm leading-relaxed text-muted-foreground">
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  1. Overview of Services
+                </h2>
+                <p>
+                  Welcome to <strong>WanderLuxe</strong> (the "Site"), owned and operated by <strong>Wanderluxe Travel LLC</strong> ("we," "us," or "our"). By accessing or using the Site, you agree to be bound by these Terms of Service ("Terms"). If you do not agree, please do not use the Site.
+                </p>
+                <p className="mt-3">
+                  WanderLuxe provides travel-related services, content, and features including trip planning tools, travel itineraries, AI-powered travel assistance, and integration with third‑party services. We use <strong>Supabase</strong> for authentication and data storage, and offer <strong>Google Sign‑In</strong> as an option. Additional third‑party APIs (such as weather data, location services, and AI services) may also be used.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  2. Eligibility and Accounts
+                </h2>
+                <p>
+                  You must be at least the age of majority in your jurisdiction to use the Site. By creating an account, you represent that all information provided is accurate and complete. You are responsible for maintaining the confidentiality of your account credentials and for any activities that occur under your account.
+                </p>
+                <p className="mt-3">
+                  If you sign in via Google, you agree to Google's terms and authorize us to access your basic account information.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  3. Privacy and Data Collection
+                </h2>
+                <p>
+                  We collect only the data necessary to provide our services, including basic account details and analytics via Google Analytics and PostHog (which also captures consent-gated session recordings). We do not sell your personal information. For full details on what is collected, how it is used, and how to manage your preferences, please review our{' '}
+                  <Link to="/privacy" className="text-primary hover:underline">
+                    Privacy Policy
+                  </Link>.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  4. AI-Powered Services and Document Processing
+                </h2>
+                <div className="space-y-6">
+                  <div>
+                    <h3 className="font-display text-lg md:text-xl mb-2 text-foreground">
+                      AI Travel Assistant
+                    </h3>
+                    <p>
+                      WanderLuxe provides an AI-powered travel assistant powered by <strong>Google's Gemini 2.5 Flash</strong> model to provide personalized travel recommendations, suggestions, and information. Your conversations with the AI assistant, along with trip context (destination, dates, itinerary) used to ground the responses, are sent to Google's Gemini API and are subject to Google's terms of use and privacy policies. Per Google's paid API terms, your prompts and responses are not used to train their models.
+                    </p>
+                  </div>
+                  <div>
+                    <h3 className="font-display text-lg md:text-xl mb-2 text-foreground">
+                      Receipt and Document Analysis
+                    </h3>
+                    <p>
+                      Our platform includes receipt analysis functionality powered by <strong>Google's Gemini 2.5 Flash</strong> vision model. When you upload receipts, booking confirmations, or other travel documents, they are:
+                    </p>
+                    <ul className="list-disc ml-6 mt-3 space-y-1.5">
+                      <li>Securely stored on our servers using Supabase storage infrastructure</li>
+                      <li>Processed by Google's Gemini API to extract travel-related information</li>
+                      <li>Accessible only to you and authorized WanderLuxe systems</li>
+                      <li>Subject to both our privacy practices and Google's data usage policies for the Gemini API</li>
+                    </ul>
+                  </div>
+                  <div>
+                    <h3 className="font-display text-lg md:text-xl mb-2 text-foreground">
+                      Data Processing and Storage
+                    </h3>
+                    <p>By uploading documents or using AI features, you acknowledge that:</p>
+                    <ul className="list-disc ml-6 mt-3 space-y-1.5">
+                      <li>Uploaded documents are stored securely on our servers with encryption</li>
+                      <li>Document content may be shared with AI service providers for processing</li>
+                      <li>We implement appropriate security measures but cannot guarantee absolute security</li>
+                      <li>You should not upload documents containing highly sensitive information like social security numbers or full financial account details</li>
+                    </ul>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">5. Third‑Party APIs and Services</h2>
-              <p>
-                Our Site integrates with various third‑party services and APIs including but not limited to Google (Gemini API, Places API, and mapping providers), Stripe (payments), SendGrid (transactional email), PostHog and Google Analytics (analytics and session replay), and Unsplash (imagery). Your use of these services is subject to their respective terms and conditions. We do not control these third‑party services and are not responsible for their availability, accuracy, or practices.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">6. User Conduct</h2>
-              <p>
-                You agree to use the Site in a lawful manner and not to engage in any activity that could harm the Site or other users. We reserve the right to suspend or terminate your account for violations of these Terms.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">7. Intellectual Property</h2>
-              <p>
-                All content on the Site, excluding user‑submitted content, is owned by or licensed to Wanderluxe Travel LLC. You may not reproduce, distribute, or create derivative works without our explicit permission.
-              </p>
-              <p>
-                “WanderLuxe” and associated logos are trademarks of Wanderluxe Travel LLC.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">8. Disclaimer of Warranties</h2>
-              <p>
-                The Site and all its services are provided on an “AS IS” and “AS AVAILABLE” basis without warranties of any kind. We do not guarantee the accuracy, reliability, or availability of the Site.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">9. Limitation of Liability</h2>
-              <p>
-                To the fullest extent permitted by law, Wanderluxe Travel LLC shall not be liable for any direct, indirect, incidental, or consequential damages arising out of your use of the Site. Our total liability is limited to any fees paid by you in the six months preceding the claim, if any.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">10. Indemnification</h2>
-              <p>
-                You agree to indemnify and hold harmless Wanderluxe Travel LLC and its affiliates from any claims, damages, or expenses arising from your use of the Site or breach of these Terms.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">11. Termination</h2>
-              <p>
-                We reserve the right to suspend or terminate your access to the Site at any time, without notice, for any reason including violation of these Terms. Upon termination, you must immediately cease using the Site.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">12. Changes to These Terms</h2>
-              <p>
-                We may modify these Terms at any time. Changes will be posted on the Site, and your continued use of the Site after such changes constitutes your acceptance of the updated Terms.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">13. Governing Law</h2>
-              <p>
-                These Terms shall be governed by and construed in accordance with the laws of the State of New York, without regard to its conflict of law provisions. Any disputes arising under or in connection with these Terms shall be subject to the exclusive jurisdiction of the state and federal courts located in Albany County, New York.
-              </p>
-            </div>
-            <div className="pb-6 border-b">
-              <h2 className="text-2xl font-semibold mb-4 text-foreground">14. Contact Us</h2>
-              <p>
-                If you have any questions or concerns regarding these Terms, please contact us at{' '}
-                <a href="mailto:info@wanderluxe.io" className="text-primary hover:underline">
-                  info@wanderluxe.io
-                </a>.
-              </p>
-            </div>
-            <div className="pt-8 border-t text-center text-sm text-muted-foreground">
-              Last updated: May 2026
-            </div>
-          </section>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  5. Third‑Party APIs and Services
+                </h2>
+                <p>
+                  Our Site integrates with various third‑party services and APIs including but not limited to Google (Gemini API, Places API, and mapping providers), Stripe (payments), SendGrid (transactional email), PostHog and Google Analytics (analytics and session replay), and Unsplash (imagery). Your use of these services is subject to their respective terms and conditions. We do not control these third‑party services and are not responsible for their availability, accuracy, or practices.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  6. User Conduct
+                </h2>
+                <p>
+                  You agree to use the Site in a lawful manner and not to engage in any activity that could harm the Site or other users. We reserve the right to suspend or terminate your account for violations of these Terms.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  7. Intellectual Property
+                </h2>
+                <p>
+                  All content on the Site, excluding user‑submitted content, is owned by or licensed to Wanderluxe Travel LLC. You may not reproduce, distribute, or create derivative works without our explicit permission.
+                </p>
+                <p className="mt-3">
+                  "WanderLuxe" and associated logos are trademarks of Wanderluxe Travel LLC.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  8. Disclaimer of Warranties
+                </h2>
+                <p>
+                  The Site and all its services are provided on an "AS IS" and "AS AVAILABLE" basis without warranties of any kind. We do not guarantee the accuracy, reliability, or availability of the Site.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  9. Limitation of Liability
+                </h2>
+                <p>
+                  To the fullest extent permitted by law, Wanderluxe Travel LLC shall not be liable for any direct, indirect, incidental, or consequential damages arising out of your use of the Site. Our total liability is limited to any fees paid by you in the six months preceding the claim, if any.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  10. Indemnification
+                </h2>
+                <p>
+                  You agree to indemnify and hold harmless Wanderluxe Travel LLC and its affiliates from any claims, damages, or expenses arising from your use of the Site or breach of these Terms.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  11. Termination
+                </h2>
+                <p>
+                  We reserve the right to suspend or terminate your access to the Site at any time, without notice, for any reason including violation of these Terms. Upon termination, you must immediately cease using the Site.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  12. Changes to These Terms
+                </h2>
+                <p>
+                  We may modify these Terms at any time. Changes will be posted on the Site, and your continued use of the Site after such changes constitutes your acceptance of the updated Terms.
+                </p>
+              </div>
+
+              <div className="pb-8 border-b border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  13. Governing Law
+                </h2>
+                <p>
+                  These Terms shall be governed by and construed in accordance with the laws of the State of New York, without regard to its conflict of law provisions. Any disputes arising under or in connection with these Terms shall be subject to the exclusive jurisdiction of the state and federal courts located in Albany County, New York.
+                </p>
+              </div>
+
+              <div>
+                <h2 className="font-display text-2xl md:text-3xl mb-4 text-foreground leading-snug">
+                  14. Contact Us
+                </h2>
+                <p>
+                  Questions or concerns about these Terms? Reach us at{' '}
+                  <a href="mailto:info@wanderluxe.io" className="text-primary hover:underline">
+                    info@wanderluxe.io
+                  </a>.
+                </p>
+              </div>
+            </section>
+          </div>
         </div>
       </div>
     </>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,13 +1,18 @@
 
 interface Window {
-  gtag: (
-    command: 'event',
-    action: string,
-    params: {
-      event_category?: string;
-      event_label?: string;
-      value?: number;
-      [key: string]: unknown;
-    }
-  ) => void;
+  gtag: {
+    (
+      command: 'event',
+      action: string,
+      params: {
+        event_category?: string;
+        event_label?: string;
+        value?: number;
+        [key: string]: unknown;
+      }
+    ): void;
+    (command: 'js', date: Date): void;
+    (command: 'config', measurementId: string, params?: Record<string, unknown>): void;
+    (command: 'consent', state: 'default' | 'update', params: Record<string, unknown>): void;
+  };
 }


### PR DESCRIPTION
## Summary
- **Terms of Service** — rebuilt to the editorial system (eyebrow + DM Serif H1, quiet last-updated stamp, max-w-3xl reading column, muted body, warm dividers). Content unchanged.
- **/about** — replaced the SaaS card-grid pitch with a Condé Nast-style editorial flow (serif hero, numbered principles, prose capabilities, single sunset CTA) consistent with the landing sections.
- **Privacy / GA / disclosures** — stopped loading `gtag.js` unconditionally and gated it behind consent via a new `GoogleAnalyticsConsentSync`; documented PostHog session replay (with the email-not-masked caveat), broader identify payload, and GA as a separate processor in the Privacy Policy; fixed ToS to name Gemini (not Perplexity) and the PostHog + GA stack, and removed duplicate Footer renders since AppLayout already provides one.
- **Timeline header** — removed the redundant Share button + dialog mount from `TimelineView` (sharing is already reachable from trip details; the duplicate was crowding the mobile header next to Export PDF).

## Test plan
- [ ] Visit `/terms` and `/about` on desktop and mobile and confirm the editorial typography reads correctly and only one Footer renders.
- [ ] With analytics consent denied, confirm no `gtag.js` request fires and `window.gtag(...)` calls do not throw.
- [ ] Grant consent and confirm `gtag.js` loads, then revoke and confirm the documented `ga-disable` flag is set.
- [ ] Re-read Privacy Policy and ToS to confirm session replay, PostHog identify fields, and the GA/Gemini wording match what's actually shipped.
- [ ] Open a trip timeline on mobile and desktop and confirm the Share button is gone, Export PDF still works, and sharing is still reachable elsewhere in the trip surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)