### PR TITLE
feat(seo): drop "luxury" positioning, target free collaborative trip planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="WanderLuxe" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>WanderLuxe — AI-powered luxury travel planning</title>
-    <meta name="description" content="WanderLuxe is an AI-powered luxury travel planning platform with real-time collaboration, curated itineraries, and professional PDF export." />
+    <title>WanderLuxe: Free Collaborative Trip Planner &amp; Itinerary Builder</title>
+    <meta name="description" content="Plan trips together, for free. WanderLuxe is a collaborative travel itinerary builder with AI-assisted search to help you discover, organize, and share your next trip." />
     <!--
       Google Analytics stub: defines window.gtag and dataLayer so existing
       call sites don't throw before consent. The actual gtag.js script and

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -116,7 +116,7 @@ const Hero = () => {
                 className="w-full h-full object-cover pointer-events-none select-none"
                 style={{ minHeight: "calc(var(--app-height, 1vh) * 100)" }}
                 objectPosition="center center"
-                alt={`Luxury travel destination photographed by ${current.photographer} on Unsplash`}
+                alt={`Travel destination photographed by ${current.photographer} on Unsplash`}
                 showAttribution={false}
                 draggable={false}
               />
@@ -157,10 +157,10 @@ const Hero = () => {
         className="relative flex h-full items-center justify-center text-center"
       >
         <h1 className="sr-only">
-          WanderLuxe — AI-powered luxury travel planning with real-time collaboration and curated itineraries
+          Plan your next trip together — free collaborative itinerary builder
         </h1>
         <p className="sr-only">
-          Plan luxury trips with AI-assisted recommendations, coordinate accommodations, activities, dining, and transportation in one place, and share polished itineraries with travel companions.
+          Build, share, and edit travel itineraries with friends. WanderLuxe is a free collaborative trip planner with AI-assisted search to help you find stays, flights, dining, and activities faster.
         </p>
         <div className="space-y-6 px-4">
           <motion.div

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -4,7 +4,7 @@ export const SITE_URL = "https://wanderluxe.io";
 export const DEFAULT_OG_IMAGE =
   "https://arnengxblsfnezrqcsxw.supabase.co/storage/v1/object/public/logos/Black%20Full_v2.png";
 const DEFAULT_DESCRIPTION =
-  "WanderLuxe is an AI-assisted luxury travel planning platform with real-time collaboration, curated itineraries, and professional PDF export.";
+  "WanderLuxe is a free, collaborative travel itinerary builder with AI-assisted search, real-time collaboration, and professional PDF export.";
 
 interface SEOProps {
   title?: string;
@@ -29,7 +29,7 @@ export default function SEO({
     ? title.endsWith("WanderLuxe")
       ? title
       : `${title} | WanderLuxe`
-    : "WanderLuxe — AI-assisted collaborative travel planning";
+    : "WanderLuxe: Free Collaborative Trip Planner & Itinerary Builder";
 
   const canonical = canonicalPath
     ? `${SITE_URL}${canonicalPath.startsWith("/") ? canonicalPath : `/${canonicalPath}`}`

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -185,7 +185,7 @@ const Explore = () => {
     ? {
         "@context": "https://schema.org",
         "@type": "ItemList",
-        name: "Curated luxury trip itineraries",
+        name: "Curated trip itineraries",
         itemListElement: publicTrips.slice(0, 20).map((trip, idx) => ({
           "@type": "ListItem",
           position: idx + 1,
@@ -200,14 +200,14 @@ const Explore = () => {
   return (
     <div className="flex flex-col min-h-screen bg-sand-50">
       <SEO
-        title="Explore curated luxury trip itineraries"
-        description="Discover hand-crafted luxury travel itineraries from Paris to Tokyo. Get inspired by expertly designed trips covering accommodations, activities, dining, and more."
+        title="Explore curated trip itineraries"
+        description="Discover hand-crafted travel itineraries from Paris to Tokyo. Get inspired by expertly designed trips covering accommodations, activities, dining, and more."
         canonicalPath="/explore"
         jsonLd={itemListJsonLd}
       />
       <Navigation />
       <div className="container mx-auto px-4 pt-12 md:pt-20 pb-8 safe-pb">
-        <h1 className="sr-only">Explore curated luxury trip itineraries</h1>
+        <h1 className="sr-only">Explore curated trip itineraries</h1>
 
         {/* Hero — single primary surface */}
         <motion.div

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -34,15 +34,15 @@ const Index = () => {
         priceCurrency: "USD",
       },
       description:
-        "AI-powered luxury travel planning with real-time collaboration, curated itineraries, and professional PDF export.",
+        "Free, collaborative travel itinerary builder with AI-assisted search, real-time collaboration, and professional PDF export.",
     },
   ];
 
   return (
     <main className="min-h-screen flex flex-col">
       <SEO
-        title="WanderLuxe — AI-powered luxury travel planning"
-        description="Plan luxury trips with AI-assisted recommendations, real-time collaboration, and polished itineraries. WanderLuxe makes travel planning effortless."
+        title="WanderLuxe: Free Collaborative Trip Planner & Itinerary Builder"
+        description="Plan trips together, for free. WanderLuxe is a collaborative travel itinerary builder with AI-assisted search to help you discover, organize, and share your next trip."
         canonicalPath="/"
         jsonLd={jsonLd}
       />

--- a/src/pages/LLMTraining.tsx
+++ b/src/pages/LLMTraining.tsx
@@ -12,15 +12,15 @@ const LLMTraining = () => {
   return (
     <div className="min-h-screen bg-background pt-[var(--app-nav-h,4rem)]">
       <SEO
-        title="About WanderLuxe"
-        description="WanderLuxe is a travel planner for the friend who took on the trip. Real-time collaboration, AI that does the busywork, and a timeline the whole group trusts."
+        title="About WanderLuxe — Free Collaborative Trip Planner"
+        description="WanderLuxe is a free collaborative trip planner for the friend who took on the trip. Real-time collaboration, AI-assisted search, and a timeline the whole group trusts."
         canonicalPath="/about"
         jsonLd={{
           "@context": "https://schema.org",
           "@type": "AboutPage",
           name: "About WanderLuxe",
           description:
-            "WanderLuxe is an AI-assisted travel planning platform built for group organizers. It combines real-time collaboration, document parsing, booking management, multi-currency budgeting, and a professional PDF export, on a single editorial timeline.",
+            "WanderLuxe is a free, collaborative trip planning platform built for group organizers. It combines real-time collaboration, document parsing, booking management, multi-currency budgeting, and a professional PDF export, on a single editorial timeline.",
         }}
       />
 

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -198,10 +198,10 @@ const TripDetails = () => {
     : null;
 
   const seoTitle = isPublicTrip && nights
-    ? `${displayData.destination} — ${nights}-Night Luxury Itinerary`
+    ? `${displayData.destination} — ${nights}-Night Itinerary`
     : `${displayData.destination} itinerary`;
   const seoDescription = displaySummary
-    || `Explore a curated luxury itinerary for ${displayData.destination} on WanderLuxe — accommodations, activities, dining, and transportation in one place.`;
+    || `Explore a curated itinerary for ${displayData.destination} on WanderLuxe — accommodations, activities, dining, and transportation in one place.`;
 
   const tripJsonLd = isPublicTrip
     ? [
@@ -210,7 +210,7 @@ const TripDetails = () => {
           "@type": "TouristTrip",
           name: seoTitle,
           description: seoDescription,
-          touristType: "Luxury traveler",
+          touristType: "Leisure traveler",
           inLanguage: "en",
           url: canonicalUrl,
           provider: {


### PR DESCRIPTION
## Summary
- Rewrite homepage `<title>`, meta description, sr-only H1, and About / Explore / TripDetails meta to target "free collaborative trip planner / itinerary builder" keywords instead of the luxury-concierge cluster
- Update `SoftwareApplication` JSON-LD description on the homepage and `TouristTrip.touristType` on per-trip pages (`"Luxury traveler"` → `"Leisure traveler"`)
- Fix a stray `ß` character in `src/components/SEO.tsx` (real UTF-8 syntax error sitting on this branch, confirmed via hex dump `c3 9f`)

## Why
Search Console / SERP analysis showed Google clustering the site with luxury concierge agencies ("WanderLuxe Travel LLC" et al.) rather than free AI trip planners (Wanderlog, TripIt, Layla, Mindtrip), where actual search intent and competitor space lives. Dropping "luxury" from the meta-critical surfaces and emphasizing "free" + "collaborative" + "itinerary builder" should move the site into the right cluster over the next few weeks of re-crawl.

## Out of scope
- Visible hero is still logo-forward; analysis recommends a visible text H1 — left for a separate UX pass
- `HookSection` H2 (visible landing copy) still doesn't include "free" — also left for separate copy review
- `BookingView.tsx` concierge advisor bio still mentions "luxury experiences" / "Luxury Travel" expertise tag — that's a person's professional specialty, not platform positioning
- `LuxuryDateTimeRangePicker` component name and its 4 usages — internal naming, no SEO impact

## Test plan
- [ ] `bun run type-check` passes locally (verified before commit)
- [ ] After deploy, `view-source:wanderluxe.io` shows new `<title>` and `<meta name="description">`
- [ ] After deploy, `view-source:wanderluxe.io/about` shows new SEO tags
- [ ] After deploy, `view-source:wanderluxe.io/explore` shows new SEO tags
- [ ] Submit homepage + /about for re-indexing in Google Search Console once deployed
- [ ] Confirm prerendered HTML in `dist/` (from `bun run build`) reflects the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)