### PR TITLE
Fix custom end time picker closing in activity modal

### DIFF
--- a/src/components/trip/ActivityForm.tsx
+++ b/src/components/trip/ActivityForm.tsx
@@ -147,20 +147,27 @@ const ActivityForm: React.FC<ActivityFormProps> = ({
   useEffect(() => {
     if (activity.start_time) setStartTime(activity.start_time);
     if (activity.end_time) setEndTime(activity.end_time);
-
-    // Determine if existing activity uses a preset duration or custom end time
-    if (activity.start_time && activity.end_time) {
-      const duration = calculateDuration(activity.start_time, activity.end_time);
-      const matchingPreset = DURATION_PRESETS.find(p => p.minutes === duration);
-      if (matchingPreset) {
-        setSelectedDuration(matchingPreset.minutes);
-        setUseCustomEndTime(false);
-      } else if (duration !== null) {
-        setSelectedDuration(null);
-        setUseCustomEndTime(true);
-      }
-    }
   }, [activity.start_time, activity.end_time]);
+
+  // Detect preset vs. custom end time ONCE when loading an existing activity.
+  // Must not re-run on live edits, or picking a preset-length custom end time
+  // would flip useCustomEndTime off and unmount the picker mid-selection.
+  const didInitDurationMode = React.useRef(false);
+  useEffect(() => {
+    if (didInitDurationMode.current || !activityId) return;
+    if (!activity.start_time || !activity.end_time) return;
+
+    const duration = calculateDuration(activity.start_time, activity.end_time);
+    const matchingPreset = DURATION_PRESETS.find(p => p.minutes === duration);
+    if (matchingPreset) {
+      setSelectedDuration(matchingPreset.minutes);
+      setUseCustomEndTime(false);
+    } else if (duration !== null) {
+      setSelectedDuration(null);
+      setUseCustomEndTime(true);
+    }
+    didInitDurationMode.current = true;
+  }, [activityId, activity.start_time, activity.end_time]);
 
   // Sync local startTime with parent activity
   useEffect(() => {


### PR DESCRIPTION
The duration-mode effect re-ran on every start_time/end_time change and
toggled useCustomEndTime whenever the in-progress duration matched a preset.
Focusing the custom end-time input defaults it to start + 60min, which equals
the "1h" preset, so the effect immediately flipped back to preset mode and
unmounted the time input, closing the native picker mid-selection.

Split time syncing from mode detection and gate detection to run once for
existing activities (edit mode) only, so live user input no longer fights it.

https://claude.ai/code/session_013jddjq5Prkhjnkpq1wxjaE