### PR TITLE
Fix "now" indicator placement in day timeline

### DIFF
--- a/src/components/trip/day/components/useDayTimeline.ts
+++ b/src/components/trip/day/components/useDayTimeline.ts
@@ -434,11 +434,22 @@ export function useDayTimeline({
       groupMap.set(period as TimePeriod, []);
     });
 
+    // Period the "now" indicator belongs to, based on the current local time.
+    // Anchoring to the current time (rather than the previous row's period) keeps
+    // the marker in its correct section even when no timed item precedes it.
+    const nowDate = new Date();
+    const nowPeriod = getTimePeriod(
+      `${String(nowDate.getHours()).padStart(2, '0')}:${String(nowDate.getMinutes()).padStart(2, '0')}`,
+    );
+
     // Distribute rows to periods
     let lastItemPeriod: TimePeriod = 'no-time';
     rows.forEach(row => {
-      if (row.kind === 'hint' || row.kind === 'now') {
-        // Attach hint/now to the period of the last item
+      if (row.kind === 'now') {
+        // Anchor the now indicator to the period of the current time
+        groupMap.get(nowPeriod)?.push(row);
+      } else if (row.kind === 'hint') {
+        // Attach hint to the period of the last item
         groupMap.get(lastItemPeriod)?.push(row);
       } else if (row.kind === 'grouped') {
         // For grouped items, use the time of the first item


### PR DESCRIPTION
## Summary
Fixed the "now" indicator in the day timeline to anchor to the current time period instead of the previous item's period. This ensures the indicator appears in the correct time section even when no timed item precedes it.

## Key Changes
- **Anchor "now" indicator to current time**: Calculate the current local time and determine which time period it belongs to using `getTimePeriod()`, then attach the "now" row to that period
- **Separate hint and now row handling**: Split the conditional logic to handle "now" rows independently from "hint" rows, which continue to attach to the last item's period
- **Added explanatory comments**: Clarified the reasoning behind anchoring to current time vs. previous row's period

## Implementation Details
The fix calculates the current time at render time and uses it to determine the correct `TimePeriod` for the "now" indicator:
```typescript
const nowDate = new Date();
const nowPeriod = getTimePeriod(
  `${String(nowDate.getHours()).padStart(2, '0')}:${String(nowDate.getMinutes()).padStart(2, '0')}`
);
```

This approach ensures the "now" indicator stays in its semantically correct section regardless of the timeline's item distribution, improving the visual accuracy of the day timeline display.

https://claude.ai/code/session_01VfqZNjqSYCvATXDF94EXgK