### PR TITLE
Fix dialog height on mobile with safe area insets

### DIFF
--- a/src/components/ui/LuxuryDateTimeRangePicker.tsx
+++ b/src/components/ui/LuxuryDateTimeRangePicker.tsx
@@ -149,8 +149,8 @@ export default function LuxuryDateTimeRangePicker({
               <DialogContent 
                 className={cn(
                   "bg-white border-0 shadow-warm-xl",
-                  isMobile 
-                    ? "w-[95vw] max-w-[95vw] h-[90dvh] max-h-[90dvh] rounded-2xl p-0" 
+                  isMobile
+                    ? "w-[95vw] max-w-[95vw] h-[calc(100dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom)_-_2rem)] max-h-[calc(100dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom)_-_2rem)] rounded-2xl p-0"
                     : "w-[420px] max-w-[420px] rounded-xl p-0"
                 )}
                 onPointerDownOutside={(e) => {

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90dvh] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-warm-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[calc(100dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom)_-_2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-warm-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       aria-describedby="dialog-description"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -40,13 +40,13 @@ const DialogContent = React.forwardRef<
         onOpenAutoFocus?.(e);
       }}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[250] flex flex-col w-[95vw] max-w-[95vw] sm:max-w-[600px] max-h-[90dvh] translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-warm-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[250] flex flex-col w-[95vw] max-w-[95vw] sm:max-w-[600px] max-h-[calc(100dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom)_-_2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-warm-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-2 top-2 z-50 flex h-10 w-10 items-center justify-center rounded-full opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>


### PR DESCRIPTION
## Summary
Updates dialog and date-time picker components to respect mobile safe area insets (notches, home indicators) when calculating maximum height, preventing content from being hidden behind device UI elements.

## Changes
- **LuxuryDateTimeRangePicker**: Updated mobile height calculation from fixed `90dvh` to `calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - 2rem)` to account for safe area insets
- **dialog.tsx**: 
  - Updated `DialogContent` max-height to use safe area inset calculation instead of fixed `90dvh`
  - Improved close button styling: repositioned from `right-4 top-4` to `right-2 top-2`, added `z-50`, and made it a centered flex container with fixed dimensions (`h-10 w-10`)
- **alert-dialog.tsx**: Updated `AlertDialogContent` max-height to use safe area inset calculation for consistency

## Implementation Details
The safe area inset approach uses CSS environment variables (`env(safe-area-inset-*)`) which are automatically set by browsers on devices with notches or home indicators. The formula `100dvh - safe-area-inset-top - safe-area-inset-bottom - 2rem` ensures dialogs fit within the safe viewport area with a 2rem bottom margin for breathing room.

The close button improvements ensure it remains accessible and visible on all screen sizes, with proper z-stacking to appear above dialog content.

https://claude.ai/code/session_013Edzq9rjuZ3ThwYbdhQziM