### PR TITLE
fix(parse-travel-doc): disable Gemini thinking budget for extraction

### DIFF
--- a/supabase/functions/parse-travel-doc/index.ts
+++ b/supabase/functions/parse-travel-doc/index.ts
@@ -582,7 +582,13 @@ const buildVisionPayload = (system, user, inlineData, maxTokens)=>({
   generationConfig: {
     temperature: 0,
     maxOutputTokens: maxTokens,
-    responseMimeType: "application/json"
+    responseMimeType: "application/json",
+    // gemini-2.5-flash is a thinking model and thinking tokens count against
+    // maxOutputTokens. For deterministic structured extraction we don't need
+    // thinking, and on real document images it can consume the entire token
+    // budget — leaving the JSON output empty ("No content generated") or
+    // truncated (invalid JSON), both of which surface as a 500. Disable it.
+    thinkingConfig: { thinkingBudget: 0 }
   }
 });
 


### PR DESCRIPTION
## Problem

`parse-travel-doc` calls `gemini-2.5-flash`, a **thinking model** — thinking tokens count against `maxOutputTokens`. On real document images, thinking can consume the entire token budget, leaving the JSON response either:
- **empty** → `"No content generated"`, or
- **truncated** → invalid JSON

Both surface to the user as a **500**.

## Fix

Disable thinking for this deterministic structured-extraction call:

```ts
generationConfig: {
  temperature: 0,
  maxOutputTokens: maxTokens,
  responseMimeType: "application/json",
  thinkingConfig: { thinkingBudget: 0 },
}
```

We don't need thinking for structured extraction (`temperature: 0`, fixed JSON schema), so the full token budget goes to the output.

## Scope

Single-line config change in `buildVisionPayload`. No behavioral change beyond eliminating the thinking-token contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)