### PR TITLE
fix(deploy): add .npmrc legacy-peer-deps so Replit's npm install resolves

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Vite 8 declares an optional peer of esbuild ^0.27||^0.28, but tsx and others
+# pull esbuild 0.25.x, so a strict `npm install` fails with ERESOLVE. The
+# lockfile was resolved with legacy peer handling; pin it here so every npm
+# invocation (including Replit's deploy `npm install`) tolerates the mismatch.
+legacy-peer-deps=true


### PR DESCRIPTION
**This is the commit that missed the #257 merge.** #257 merged the Bun-toolchain removal (which fixed `npm: not found`), but closed before this `.npmrc` was pushed — so `main-agent` has no `.npmrc` and the deploy now fails at the install step:

```
--> npm install
npm error code ERESOLVE
npm error peerOptional esbuild@"^0.27.0 || ^0.28.0" from vite@8.0.16
npm error Found: esbuild@0.25.11
```

## Why

With Bun removed, Replit's install phase runs `npm install`, which **re-resolves** peers and chokes on Vite 8's optional `esbuild ^0.27||^0.28` peer vs the `0.25.x` that tsx/others pull. (`npm ci` — our build command — installs from the lockfile and doesn't re-resolve, but Replit's `npm install` runs first.)

## Fix

`.npmrc` with `legacy-peer-deps=true`, so every npm invocation (Replit's `npm install` included) tolerates the optional-peer mismatch — matching how the lockfile was generated.

## Verified locally
- `npm install` with `.npmrc` → resolves, no ERESOLVE ✓
- `npm ci` exits 0; full `npm run build` passes ✓

After merge: **redeploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)