### PR TITLE
feat(mcp): write tools — create/update/delete for trips and all itinerary items

### DIFF
--- a/docs/superpowers/specs/2026-06-16-mcp-write-tools-design.md
+++ b/docs/superpowers/specs/2026-06-16-mcp-write-tools-design.md
@@ -1,0 +1,207 @@
+# MCP Write Tools — Design Spec
+
+**Date:** 2026-06-16
+**Branch:** `mcp-server`
+**Status:** Approved, pending implementation plan
+
+## Goal
+
+Extend the WanderLuxe MCP server (`server/routes/mcp.ts`) from read-only to read+write so a
+Claude.ai connector can fully manage a user's trips: create trips, add items, update existing
+items, and delete items. Sharing/travelers and whole-trip deletion are intentionally excluded
+from v1.
+
+## Background
+
+The MCP server today exposes 3 read-only tools (`list_trips`, `get_trip`, `get_trip_budget`)
+over stateless streamable HTTP, authenticated by Supabase-issued ES256 user JWTs validated
+against the project JWKS via `jose`. Every query runs through a **per-request, user-scoped
+Supabase client** (anon key + the user's bearer token), so RLS enforces all access control. No
+service-role key is ever used. See `mcp-server-rollout` memory for the broader rollout context.
+
+Writes are **not** simple inserts. The app's create/update flows carry business logic that the
+tools must mirror:
+
+- **Create trip** → insert `trips` + generate one `trip_days` row per date in the range + add
+  an owner record to `trip_shares`.
+- **Add activity / dining** → resolve `day_id` from a date, compute `order_index`, insert with
+  both `trip_id` and `day_id`.
+- **Add accommodation** → insert `accommodations` + fan out `accommodations_days` (one row per
+  night, each mapped to a `trip_days.day_id`).
+- **Update trip dates** → add `trip_days` for new dates, remove `trip_days` for dropped dates
+  (which can orphan items scheduled on those days).
+
+This logic currently lives in client-side services (`src/services/tripDaysService.ts`,
+`src/services/accommodation/accommodationService.ts`, `CreateTripForm.tsx`) that use the
+**browser** Supabase singleton — so they cannot be imported by the Express server, which uses a
+different (per-request, user-scoped) client.
+
+## Architecture
+
+### New module: `server/lib/tripWrites.ts`
+
+Pure functions, each taking the user-scoped Supabase client as its first argument:
+
+```
+createTrip(supabase, input)            → { trip_id, day_dates[] }
+updateTrip(supabase, input)            → updated trip (+ removed-day report on the destructive path)
+addActivity(supabase, input)           → created activity
+updateActivity(supabase, input)        → updated activity
+deleteActivity(supabase, id)           → { deleted: true }
+addDining(supabase, input)             → created reservation
+updateDining(supabase, input)          → updated reservation
+deleteDining(supabase, id)             → { deleted: true }
+addAccommodation(supabase, input)      → created accommodation (+ accommodations_days fan-out)
+updateAccommodation(supabase, input)   → updated accommodation (re-fans accommodations_days)
+deleteAccommodation(supabase, id)      → { deleted: true }
+addTransportation(supabase, input)     → created transportation
+updateTransportation(supabase, input)  → updated transportation
+deleteTransportation(supabase, id)     → { deleted: true }
+addExpense(supabase, input)            → created other_expense
+updateExpense(supabase, input)         → updated other_expense
+deleteExpense(supabase, id)            → { deleted: true }
+```
+
+Benefits: testable in isolation, keeps `mcp.ts` focused, no risky refactor of working client
+code. Trade-off accepted: the write logic is mirrored in two places (client service + server
+lib). To minimize duplication, extract the **pure** date helpers (date-range → dates array) into
+a shared, unit-tested helper that both server and — where convenient — client can use.
+
+### New module: `server/lib/mcpTools.ts`
+
+Move tool registration (both the existing read tools and the new write tools) out of `mcp.ts`
+into this module. `mcp.ts` shrinks to transport, auth, and OAuth discovery only. `mcpTools.ts`
+exports a function that registers all tools onto an `McpServer` given a user-scoped client.
+
+This is a targeted refactor justified by the registration code roughly doubling in size; it is
+not unrelated cleanup.
+
+### Unchanged
+
+- Auth (`authenticate`, JWKS, `unauthorized`), the per-request client factory
+  (`createUserClient`), transport wiring, rate limiting, and OAuth discovery metadata in
+  `mcp.ts`.
+- The 3 read tools' behavior. They already return item ids (`activity id`, `reservation id`,
+  `stay_id`, transportation `id`), which the update/delete tools rely on for addressing.
+
+## Tool surface (17 tools)
+
+| Entity | Create | Update | Delete |
+|---|---|---|---|
+| Trip | `create_trip` | `update_trip` | — (excluded) |
+| Activity | `add_activity` | `update_activity` | `delete_activity` |
+| Dining | `add_dining` | `update_dining` | `delete_dining` |
+| Accommodation | `add_accommodation` | `update_accommodation` | `delete_accommodation` |
+| Transportation | `add_transportation` | `update_transportation` | `delete_transportation` |
+| Other expense | `add_expense` | `update_expense` | `delete_expense` |
+
+Plus the existing read tools (`list_trips`, `get_trip`, `get_trip_budget`), unchanged.
+
+### Per-tool input contracts
+
+Dates are ISO `YYYY-MM-DD`; times are 24h `HH:MM`; ids are uuids; currency is a 3-letter code.
+All validated with `zod`. Required vs optional fields below match the underlying table
+constraints found during exploration.
+
+- **create_trip** — required: `destination`, `arrival_date`, `departure_date`. Optional:
+  `budget`. Side effects: generates `trip_days`, inserts owner `trip_shares`. Returns `trip_id`
+  and the generated `day_dates[]`.
+- **update_trip** — required: `trip_id`. Optional: `destination`, `budget`, `arrival_date`,
+  `departure_date`, `confirm_remove_days` (boolean, default false). See date-change safety below.
+- **add_activity** — required: `trip_id`, `date`, `title`. Optional: `description`,
+  `start_time`, `end_time`, `cost`, `currency`, `location_address`. Resolves `day_id` from
+  `date`; computes `order_index`.
+- **update_activity** — required: `activity_id`. Optional: any of the above fields. Changing
+  `date` re-resolves `day_id`.
+- **delete_activity** — required: `activity_id`.
+- **add_dining** — required: `trip_id`, `date`, `restaurant_name`. Optional: `reservation_time`,
+  `number_of_people`, `address`, `confirmation_number`, `notes`, `cost`, `currency`. Resolves
+  `day_id`; computes `order_index`.
+- **update_dining / delete_dining** — by `reservation_id`, analogous to activity.
+- **add_accommodation** — required: `trip_id`, `hotel`, `hotel_checkin_date`,
+  `hotel_checkout_date`. Optional: `hotel_address`, `checkin_time`, `checkout_time`,
+  `hotel_phone`, `hotel_website`, `cost`, `currency`. Sets `title = hotel`, computes
+  `order_index`, fans out `accommodations_days`.
+- **update_accommodation** — by `stay_id`; if check-in/out dates change, re-fan
+  `accommodations_days`.
+- **delete_accommodation** — by `stay_id` (cascade/explicit cleanup of `accommodations_days`).
+- **add_transportation** — required: `trip_id`, `type` (enum: flight|train|bus|car|other),
+  `start_date`. Optional: `provider`, `flight_number`, `confirmation_number`,
+  `departure_location`, `arrival_location`, `start_time`, `end_date`, `end_time`, `cost`,
+  `currency`. No daily fan-out.
+- **update_transportation / delete_transportation** — by transportation `id`.
+- **add_expense** — required: `trip_id`, `description`, `cost`, `currency`. Optional:
+  `amount_paid`, `is_paid`.
+- **update_expense / delete_expense** — by expense `id`.
+
+## Addressing model
+
+- **Items**: addressed by their own id, which the read tools already surface.
+- **Days**: addressed by **date**, never `day_id`. The server resolves date→`day_id` and returns
+  a clear error ("That date is outside the trip's range") if no matching day exists. This matches
+  the app's own forms and is natural for an LLM.
+- **New-trip flow**: `create_trip` returns `trip_id` + `day_dates[]` so Claude can add items in
+  the same turn without a round-trip read.
+
+## Trip date-change safety (the two-call confirm pattern)
+
+`update_trip` with changed `arrival_date`/`departure_date`:
+
+1. Compute the new date range and diff against existing `trip_days`.
+2. **Days to add** (in new range, no existing row): always created. No confirmation needed.
+3. **Days to drop** (existing row, outside new range): run a content pre-check — does each
+   dropped day have any `day_activities`, `reservations`, or `accommodations_days`?
+   - **No content on any dropped day** → drop them and apply the date change.
+   - **Content exists on ≥1 dropped day** and `confirm_remove_days` is not `true` → **refuse**.
+     Return a structured report listing each at-risk day and what's on it (counts + titles), and
+     do **not** mutate anything. Claude relays this to the user for validation.
+   - Caller re-invokes with `confirm_remove_days: true` → cascade: delete the dropped
+     `trip_days` (and their dependent items via FK cascade / explicit cleanup) and apply the date
+     change.
+
+This realizes the user's "validate first, then cascade" intent within MCP's single
+request→response model — no dependency on the elicitation capability, which Claude.ai connectors
+may not support.
+
+## Security
+
+- All writes use the **user-scoped (RLS) Supabase client** — anon key + the request's user
+  bearer token. Identical security posture to the read tools. **Never** service-role.
+- RLS guarantees a user can only write to trips they own or have an edit share on. "Not found"
+  and "no access" are indistinguishable by design.
+- `create_trip` sets `user_id` to the authenticated `userId` from the validated JWT (not from
+  input).
+
+## MCP annotations
+
+- Create/update tools: `readOnlyHint: false`, `destructiveHint: false`. Update tools that are
+  naturally idempotent set `idempotentHint: true`.
+- Delete tools and the destructive (cascade) branch of `update_trip`: `destructiveHint: true`.
+
+## Error handling
+
+- Validation errors (`zod`) surface as tool errors with actionable messages.
+- Supabase errors return `toolError(...)` with the DB message, matching the existing read tools.
+- Out-of-range date, missing parent trip, and not-found item all return clear, distinct messages.
+
+## Testing
+
+- **Unit (`.test.ts`, runs in CI):** pure date-range helper; `update_trip` data-loss pre-check
+  (days-to-add / days-to-drop diff and the content-detection branch).
+- **Eval (`evals/mcp`, on-demand):** a lifecycle case against the eval-user fixture —
+  create_trip → add_activity → add_dining → update → delete → (clean up). Asserts RLS scoping and
+  that the confirm pattern blocks then allows a destructive date edit.
+
+## Out of scope (v1)
+
+- Sharing / travelers / any `*_travelers` junction writes.
+- Whole-trip deletion.
+- Image/cover uploads and Unsplash metadata.
+- Bulk/nested create (atomic tools compose without it).
+
+## Open considerations (non-blocking)
+
+- `order_index` computation: mirror the app's "next index" approach (max+1 within the
+  trip/day scope) so MCP-created items sort consistently with app-created ones.
+- Currency defaulting: if omitted on a cost-bearing item, leave null (the app treats null
+  currency as unset) rather than guessing.

--- a/evals/mcp/tools.eval.ts
+++ b/evals/mcp/tools.eval.ts
@@ -33,13 +33,32 @@ describe.skipIf(missing.length > 0)('mcp tools', () => {
       expect(client.getInstructions()).toContain('list_trips');
     }));
 
-  it('tools/list: exactly the three tools, all read-only annotated', () =>
+  it('tools/list: full read+write surface with correct annotations', () =>
     runCase('mcp', 'tools-list', async () => {
       const { tools } = await client.listTools();
-      expect(tools.map((t) => t.name).sort()).toEqual(['get_trip', 'get_trip_budget', 'list_trips']);
-      for (const tool of tools) {
-        expect(tool.annotations?.readOnlyHint, `${tool.name} readOnlyHint`).toBe(true);
-        expect(tool.annotations?.destructiveHint, `${tool.name} destructiveHint`).toBe(false);
+      const names = tools.map((t) => t.name).sort();
+
+      const READ = ['get_trip', 'get_trip_budget', 'list_trips'];
+      const WRITE = [
+        'add_accommodation', 'add_activity', 'add_dining', 'add_expense', 'add_transportation',
+        'create_trip',
+        'delete_accommodation', 'delete_activity', 'delete_dining', 'delete_expense', 'delete_transportation',
+        'update_accommodation', 'update_activity', 'update_dining', 'update_expense', 'update_transportation',
+        'update_trip',
+      ];
+      expect(names).toEqual([...READ, ...WRITE].sort());
+
+      const byName = new Map(tools.map((t) => [t.name, t]));
+      for (const name of READ) {
+        expect(byName.get(name)?.annotations?.readOnlyHint, `${name} readOnlyHint`).toBe(true);
+      }
+      for (const name of WRITE) {
+        expect(byName.get(name)?.annotations?.readOnlyHint, `${name} readOnlyHint`).toBe(false);
+      }
+      // Delete tools (and only they, among writes) are destructive-hinted.
+      const destructive = WRITE.filter((n) => n.startsWith('delete_'));
+      for (const name of destructive) {
+        expect(byName.get(name)?.annotations?.destructiveHint, `${name} destructiveHint`).toBe(true);
       }
     }));
 

--- a/evals/mcp/tools.eval.ts
+++ b/evals/mcp/tools.eval.ts
@@ -55,7 +55,8 @@ describe.skipIf(missing.length > 0)('mcp tools', () => {
       for (const name of WRITE) {
         expect(byName.get(name)?.annotations?.readOnlyHint, `${name} readOnlyHint`).toBe(false);
       }
-      // Delete tools (and only they, among writes) are destructive-hinted.
+      // delete_* tools are destructive-hinted (update_trip is too, via its
+      // cascade branch — but we only assert the delete_* tools here).
       const destructive = WRITE.filter((n) => n.startsWith('delete_'));
       for (const name of destructive) {
         expect(byName.get(name)?.annotations?.destructiveHint, `${name} destructiveHint`).toBe(true);

--- a/evals/mcp/writes.eval.ts
+++ b/evals/mcp/writes.eval.ts
@@ -19,6 +19,9 @@ describe.skipIf(missing.length > 0)('mcp writes (lifecycle)', () => {
   });
 
   afterAll(async () => {
+    // NOTE: each run leaves its "Eval Sandbox City" trip in the eval user's
+    // account — there is no whole-trip delete tool (out of scope for v1), so
+    // these 2030-dated throwaway trips accumulate across runs.
     await client?.close();
   });
 

--- a/evals/mcp/writes.eval.ts
+++ b/evals/mcp/writes.eval.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { signInEvalUser } from '../helpers/auth';
+import { missingEnv } from '../helpers/env';
+import { connectMcp, toolJson } from '../helpers/mcpClient';
+import { recordSuiteSkip, runCase } from '../helpers/runCase';
+
+const REQUIRED = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY', 'EVAL_USER_EMAIL', 'EVAL_USER_PASSWORD'];
+const missing = missingEnv(REQUIRED);
+recordSuiteSkip('mcp', missing);
+
+describe.skipIf(missing.length > 0)('mcp writes (lifecycle)', () => {
+  let client: Client;
+  let tripId: string;
+
+  beforeAll(async () => {
+    const { token } = await signInEvalUser();
+    client = await connectMcp(process.env.EVALS_BASE_URL!, token);
+  });
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it('create_trip returns trip_id and generated day_dates', () =>
+    runCase('mcp', 'create-trip', async () => {
+      const payload = toolJson(
+        await client.callTool({
+          name: 'create_trip',
+          arguments: {
+            destination: 'Eval Sandbox City',
+            arrival_date: '2030-01-10',
+            departure_date: '2030-01-12',
+            budget: 1000,
+          },
+        }),
+      );
+      expect(payload.trip_id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(payload.day_dates).toEqual(['2030-01-10', '2030-01-11', '2030-01-12']);
+      tripId = payload.trip_id;
+    }));
+
+  it('add_activity and add_dining attach to a resolved day', () =>
+    runCase('mcp', 'add-items', async () => {
+      const activity = toolJson(
+        await client.callTool({
+          name: 'add_activity',
+          arguments: { trip_id: tripId, date: '2030-01-10', title: 'Eval museum', cost: 20, currency: 'USD' },
+        }),
+      );
+      expect(activity.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(activity.title).toBe('Eval museum');
+
+      const dining = toolJson(
+        await client.callTool({
+          name: 'add_dining',
+          arguments: { trip_id: tripId, date: '2030-01-10', restaurant_name: 'Eval Bistro', reservation_time: '19:30' },
+        }),
+      );
+      expect(dining.restaurant_name).toBe('Eval Bistro');
+    }));
+
+  it('add_activity on an out-of-range date returns a clear error', () =>
+    runCase('mcp', 'add-activity-out-of-range', async () => {
+      const result = await client.callTool({
+        name: 'add_activity',
+        arguments: { trip_id: tripId, date: '2030-02-01', title: 'Should fail' },
+      });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+    }));
+
+  it('update_trip blocks a destructive date shrink, then allows it with confirm_remove_days', () =>
+    runCase('mcp', 'update-trip-confirm', async () => {
+      // Day 2030-01-10 has an activity + dining → shrinking to exclude it must be blocked.
+      const blocked = toolJson(
+        await client.callTool({
+          name: 'update_trip',
+          arguments: { trip_id: tripId, arrival_date: '2030-01-11', departure_date: '2030-01-12' },
+        }),
+      );
+      expect(blocked.status).toBe('confirmation_required');
+      expect(blocked.at_risk_days.map((d: { date: string }) => d.date)).toContain('2030-01-10');
+
+      const applied = toolJson(
+        await client.callTool({
+          name: 'update_trip',
+          arguments: {
+            trip_id: tripId,
+            arrival_date: '2030-01-11',
+            departure_date: '2030-01-12',
+            confirm_remove_days: true,
+          },
+        }),
+      );
+      expect(applied.status).toBe('updated');
+      expect(applied.days_removed).toContain('2030-01-10');
+    }));
+
+  it('get_trip reflects the writes (the removed day and its items are gone)', () =>
+    runCase('mcp', 'verify-after-writes', async () => {
+      const payload = toolJson(await client.callTool({ name: 'get_trip', arguments: { trip_id: tripId } }));
+      expect(payload.days.map((d: { date: string }) => d.date)).toEqual(['2030-01-11', '2030-01-12']);
+    }));
+});

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -11,6 +11,9 @@ import {
   addDining,
   updateDining,
   deleteDining,
+  addAccommodation,
+  updateAccommodation,
+  deleteAccommodation,
   WriteError,
 } from './tripWrites';
 import type { UserContext } from './tripWrites';
@@ -405,6 +408,80 @@ function registerWriteTools(
         return toolResult(await deleteDining(supabase, reservation_id));
       } catch (err) {
         return toolError(err instanceof WriteError ? err.message : `Failed to delete dining: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'add_accommodation',
+    {
+      description:
+        'Add a hotel / accommodation to a trip. Maps each night between check-in and check-out to its trip day. Returns the created stay, including its stay_id.',
+      inputSchema: {
+        trip_id: z.string().uuid().describe('Trip ID from list_trips'),
+        hotel: z.string().min(1).describe('Hotel / property name'),
+        hotel_checkin_date: dateField,
+        hotel_checkout_date: dateField,
+        hotel_address: z.string().optional(),
+        checkin_time: timeField.optional(),
+        checkout_time: timeField.optional(),
+        hotel_phone: z.string().optional(),
+        hotel_website: z.string().optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+      },
+      annotations: WRITE,
+    },
+    async (args) => {
+      try {
+        return toolResult(await addAccommodation(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to add accommodation: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_accommodation',
+    {
+      description:
+        'Update an accommodation by its stay_id (from get_trip). If check-in/out dates change, night mappings are recomputed. Only the fields you pass are changed.',
+      inputSchema: {
+        stay_id: z.string().uuid().describe('Accommodation stay_id from get_trip'),
+        hotel: z.string().min(1).optional(),
+        hotel_checkin_date: dateField.optional(),
+        hotel_checkout_date: dateField.optional(),
+        hotel_address: z.string().optional(),
+        checkin_time: timeField.optional(),
+        checkout_time: timeField.optional(),
+        hotel_phone: z.string().optional(),
+        hotel_website: z.string().optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+      },
+      annotations: WRITE_IDEMPOTENT,
+    },
+    async (args) => {
+      try {
+        return toolResult(await updateAccommodation(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to update accommodation: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_accommodation',
+    {
+      description: 'Delete an accommodation by its stay_id (from get_trip). Also removes its night mappings.',
+      inputSchema: { stay_id: z.string().uuid().describe('Accommodation stay_id from get_trip') },
+      annotations: DESTRUCTIVE,
+    },
+    async ({ stay_id }) => {
+      try {
+        return toolResult(await deleteAccommodation(supabase, stay_id));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to delete accommodation: ${String(err)}`);
       }
     },
   );

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -14,6 +14,9 @@ import {
   addAccommodation,
   updateAccommodation,
   deleteAccommodation,
+  addTransportation,
+  updateTransportation,
+  deleteTransportation,
   WriteError,
 } from './tripWrites';
 import type { UserContext } from './tripWrites';
@@ -31,6 +34,15 @@ const WRITE = { readOnlyHint: false, destructiveHint: false };
 const WRITE_IDEMPOTENT = { readOnlyHint: false, destructiveHint: false, idempotentHint: true };
 const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true };
 const DESTRUCTIVE_IDEMPOTENT = { readOnlyHint: false, destructiveHint: true, idempotentHint: true };
+
+const transportTypeField = z.enum([
+  'flight',
+  'train',
+  'car_service',
+  'shuttle',
+  'ferry',
+  'rental_car',
+]);
 
 const dateField = z
   .string()
@@ -482,6 +494,84 @@ function registerWriteTools(
         return toolResult(await deleteAccommodation(supabase, stay_id));
       } catch (err) {
         return toolError(err instanceof WriteError ? err.message : `Failed to delete accommodation: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'add_transportation',
+    {
+      description:
+        'Add a transportation leg (flight, train, car_service, shuttle, ferry, or rental_car) to a trip. Returns the created leg, including its id.',
+      inputSchema: {
+        trip_id: z.string().uuid().describe('Trip ID from list_trips'),
+        type: transportTypeField,
+        start_date: dateField,
+        provider: z.string().optional(),
+        flight_number: z.string().optional(),
+        confirmation_number: z.string().optional(),
+        departure_location: z.string().optional(),
+        arrival_location: z.string().optional(),
+        start_time: timeField.optional(),
+        end_date: dateField.optional(),
+        end_time: timeField.optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+      },
+      annotations: WRITE,
+    },
+    async (args) => {
+      try {
+        return toolResult(await addTransportation(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to add transportation: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_transportation',
+    {
+      description:
+        'Update a transportation leg by its id (from get_trip). Only the fields you pass are changed.',
+      inputSchema: {
+        id: z.string().uuid().describe('Transportation id from get_trip'),
+        type: transportTypeField.optional(),
+        start_date: dateField.optional(),
+        provider: z.string().optional(),
+        flight_number: z.string().optional(),
+        confirmation_number: z.string().optional(),
+        departure_location: z.string().optional(),
+        arrival_location: z.string().optional(),
+        start_time: timeField.optional(),
+        end_date: dateField.optional(),
+        end_time: timeField.optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+      },
+      annotations: WRITE_IDEMPOTENT,
+    },
+    async (args) => {
+      try {
+        return toolResult(await updateTransportation(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to update transportation: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_transportation',
+    {
+      description: 'Delete a transportation leg by its id (from get_trip).',
+      inputSchema: { id: z.string().uuid().describe('Transportation id from get_trip') },
+      annotations: DESTRUCTIVE,
+    },
+    async ({ id }) => {
+      try {
+        return toolResult(await deleteTransportation(supabase, id));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to delete transportation: ${String(err)}`);
       }
     },
   );

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -8,6 +8,9 @@ import {
   addActivity,
   updateActivity,
   deleteActivity,
+  addDining,
+  updateDining,
+  deleteDining,
   WriteError,
 } from './tripWrites';
 import type { UserContext } from './tripWrites';
@@ -330,6 +333,78 @@ function registerWriteTools(
         return toolResult(await deleteActivity(supabase, activity_id));
       } catch (err) {
         return toolError(err instanceof WriteError ? err.message : `Failed to delete activity: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'add_dining',
+    {
+      description:
+        'Add a dining reservation to a trip on a given date (the server resolves the trip day). Returns the created reservation, including its id.',
+      inputSchema: {
+        trip_id: z.string().uuid().describe('Trip ID from list_trips'),
+        date: dateField.describe('Date within the trip range (YYYY-MM-DD)'),
+        restaurant_name: z.string().min(1),
+        reservation_time: timeField.optional(),
+        number_of_people: z.number().int().positive().optional(),
+        address: z.string().optional(),
+        confirmation_number: z.string().optional(),
+        notes: z.string().optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+      },
+      annotations: WRITE,
+    },
+    async (args) => {
+      try {
+        return toolResult(await addDining(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to add dining: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_dining',
+    {
+      description:
+        'Update an existing dining reservation by its id (from get_trip). Changing date moves it to that trip day. Only the fields you pass are changed.',
+      inputSchema: {
+        reservation_id: z.string().uuid().describe('Reservation id from get_trip'),
+        date: dateField.optional(),
+        restaurant_name: z.string().min(1).optional(),
+        reservation_time: timeField.optional(),
+        number_of_people: z.number().int().positive().optional(),
+        address: z.string().optional(),
+        confirmation_number: z.string().optional(),
+        notes: z.string().optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+      },
+      annotations: WRITE_IDEMPOTENT,
+    },
+    async (args) => {
+      try {
+        return toolResult(await updateDining(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to update dining: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_dining',
+    {
+      description: 'Delete a dining reservation by its id (from get_trip).',
+      inputSchema: { reservation_id: z.string().uuid().describe('Reservation id from get_trip') },
+      annotations: DESTRUCTIVE,
+    },
+    async ({ reservation_id }) => {
+      try {
+        return toolResult(await deleteDining(supabase, reservation_id));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to delete dining: ${String(err)}`);
       }
     },
   );

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -17,6 +17,7 @@ const READ_ONLY = { readOnlyHint: true, destructiveHint: false };
 const WRITE = { readOnlyHint: false, destructiveHint: false };
 const WRITE_IDEMPOTENT = { readOnlyHint: false, destructiveHint: false, idempotentHint: true };
 const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true };
+const DESTRUCTIVE_IDEMPOTENT = { readOnlyHint: false, destructiveHint: true, idempotentHint: true };
 
 const dateField = z
   .string()
@@ -236,7 +237,7 @@ function registerWriteTools(
       inputSchema: {
         trip_id: z.string().uuid().describe('Trip ID from list_trips'),
         destination: z.string().min(1).optional(),
-        budget: z.number().positive().optional(),
+        budget: z.number().positive().nullable().optional().describe('Set to null to clear the budget'),
         arrival_date: dateField.optional(),
         departure_date: dateField.optional(),
         confirm_remove_days: z
@@ -244,7 +245,7 @@ function registerWriteTools(
           .optional()
           .describe('Set true to confirm deleting days (and their items) that fall outside the new range'),
       },
-      annotations: WRITE_IDEMPOTENT,
+      annotations: DESTRUCTIVE_IDEMPOTENT,
     },
     async (args) => {
       try {

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -2,7 +2,14 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { summarizeCosts } from './budgetSummary';
-import { createTrip, updateTrip, WriteError } from './tripWrites';
+import {
+  createTrip,
+  updateTrip,
+  addActivity,
+  updateActivity,
+  deleteActivity,
+  WriteError,
+} from './tripWrites';
 import type { UserContext } from './tripWrites';
 
 export function toolResult(payload: unknown) {
@@ -253,6 +260,76 @@ function registerWriteTools(
         return toolResult(result);
       } catch (err) {
         return toolError(err instanceof WriteError ? err.message : `Failed to update trip: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'add_activity',
+    {
+      description:
+        'Add an activity to a trip on a given date (the server resolves the trip day). Returns the created activity, including its id.',
+      inputSchema: {
+        trip_id: z.string().uuid().describe('Trip ID from list_trips'),
+        date: dateField.describe('Date within the trip range (YYYY-MM-DD)'),
+        title: z.string().min(1),
+        description: z.string().optional(),
+        start_time: timeField.optional(),
+        end_time: timeField.optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+        location_address: z.string().optional(),
+      },
+      annotations: WRITE,
+    },
+    async (args) => {
+      try {
+        return toolResult(await addActivity(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to add activity: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_activity',
+    {
+      description:
+        'Update an existing activity by its id (from get_trip). Changing date moves it to that trip day. Only the fields you pass are changed.',
+      inputSchema: {
+        activity_id: z.string().uuid().describe('Activity id from get_trip'),
+        date: dateField.optional(),
+        title: z.string().min(1).optional(),
+        description: z.string().optional(),
+        start_time: timeField.optional(),
+        end_time: timeField.optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+        location_address: z.string().optional(),
+      },
+      annotations: WRITE_IDEMPOTENT,
+    },
+    async (args) => {
+      try {
+        return toolResult(await updateActivity(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to update activity: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_activity',
+    {
+      description: 'Delete an activity by its id (from get_trip).',
+      inputSchema: { activity_id: z.string().uuid().describe('Activity id from get_trip') },
+      annotations: DESTRUCTIVE,
+    },
+    async ({ activity_id }) => {
+      try {
+        return toolResult(await deleteActivity(supabase, activity_id));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to delete activity: ${String(err)}`);
       }
     },
   );

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -20,7 +20,12 @@ const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true };
 
 const dateField = z
   .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Use an ISO date, YYYY-MM-DD');
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Use an ISO date, YYYY-MM-DD')
+  .refine((s) => {
+    const [y, m, d] = s.split('-').map(Number);
+    const dt = new Date(Date.UTC(y, m - 1, d));
+    return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+  }, 'Not a valid calendar date');
 const timeField = z
   .string()
   .regex(/^\d{2}:\d{2}$/, 'Use a 24h time, HH:MM');

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -1,0 +1,174 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { summarizeCosts } from './budgetSummary';
+import type { UserContext } from './tripWrites';
+
+export function toolResult(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+export function toolError(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], isError: true };
+}
+
+const READ_ONLY = { readOnlyHint: true, destructiveHint: false };
+
+/**
+ * Register every WanderLuxe tool on the given server. `supabase` is the
+ * per-request user-scoped client; `ctx` is the authenticated user identity
+ * (used by create_trip / owner-share — never trusted from tool input).
+ */
+export function registerWanderluxeTools(
+  server: McpServer,
+  supabase: SupabaseClient,
+  ctx: UserContext,
+): void {
+  registerReadTools(server, supabase);
+  // Write tools are registered by later tasks (see registerWriteTools).
+}
+
+function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
+  server.registerTool(
+    'list_trips',
+    {
+      description:
+        'List the trips the user owns or that are shared with them, newest first. Returns trip_id, destination, dates, and budget.',
+      annotations: READ_ONLY,
+    },
+    async () => {
+      const { data, error } = await supabase
+        .from('trips')
+        .select('trip_id,destination,arrival_date,departure_date,budget,created_at')
+        .order('arrival_date', { ascending: false });
+      if (error) return toolError(`Failed to list trips: ${error.message}`);
+      return toolResult({ trips: data ?? [] });
+    },
+  );
+
+  server.registerTool(
+    'get_trip',
+    {
+      description:
+        'Get the full itinerary for one trip: day-by-day activities and dining reservations, plus accommodations and transportation. Use list_trips to find the trip_id.',
+      inputSchema: { trip_id: z.string().uuid().describe('Trip ID from list_trips') },
+      annotations: READ_ONLY,
+    },
+    async ({ trip_id }) => {
+      const [tripRes, daysRes, staysRes, transportRes, activitiesRes, diningRes] = await Promise.all([
+        supabase
+          .from('trips')
+          .select('trip_id,destination,arrival_date,departure_date,budget')
+          .eq('trip_id', trip_id)
+          .maybeSingle(),
+        supabase
+          .from('trip_days')
+          .select('day_id,date,title,description')
+          .eq('trip_id', trip_id)
+          .order('date'),
+        supabase
+          .from('accommodations')
+          .select(
+            'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
+          )
+          .eq('trip_id', trip_id),
+        supabase
+          .from('transportation')
+          .select(
+            'id,type,provider,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency',
+          )
+          .eq('trip_id', trip_id)
+          .order('start_date'),
+        supabase
+          .from('day_activities')
+          .select('id,day_id,title,description,start_time,end_time,location_address,cost,currency')
+          .eq('trip_id', trip_id),
+        supabase
+          .from('reservations')
+          .select(
+            'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
+          )
+          .eq('trip_id', trip_id),
+      ]);
+
+      if (tripRes.error) return toolError(`Failed to load trip: ${tripRes.error.message}`);
+      if (!tripRes.data) return toolError('Trip not found, or you do not have access to it.');
+
+      const activitiesByDay = new Map<string, unknown[]>();
+      for (const a of activitiesRes.data ?? []) {
+        const { day_id, ...rest } = a;
+        const list = activitiesByDay.get(day_id) ?? [];
+        list.push(rest);
+        activitiesByDay.set(day_id, list);
+      }
+      const diningByDay = new Map<string, unknown[]>();
+      for (const r of diningRes.data ?? []) {
+        const { day_id, ...rest } = r;
+        if (!day_id) continue;
+        const list = diningByDay.get(day_id) ?? [];
+        list.push(rest);
+        diningByDay.set(day_id, list);
+      }
+
+      const days = (daysRes.data ?? []).map((d) => ({
+        date: d.date,
+        title: d.title,
+        description: d.description,
+        activities: activitiesByDay.get(d.day_id) ?? [],
+        dining: diningByDay.get(d.day_id) ?? [],
+      }));
+
+      return toolResult({
+        trip: tripRes.data,
+        days,
+        accommodations: staysRes.data ?? [],
+        transportation: transportRes.data ?? [],
+      });
+    },
+  );
+
+  server.registerTool(
+    'get_trip_budget',
+    {
+      description:
+        'Get the budget breakdown for one trip: total budget, spend per category (accommodations, transportation, activities, dining, other), and paid vs unpaid amounts.',
+      inputSchema: { trip_id: z.string().uuid().describe('Trip ID from list_trips') },
+      annotations: READ_ONLY,
+    },
+    async ({ trip_id }) => {
+      const [tripRes, staysRes, transportRes, activitiesRes, diningRes, otherRes] = await Promise.all([
+        supabase.from('trips').select('budget').eq('trip_id', trip_id).maybeSingle(),
+        supabase.from('accommodations').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
+        supabase.from('transportation').select('cost,currency').eq('trip_id', trip_id),
+        supabase.from('day_activities').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
+        supabase.from('reservations').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
+        supabase
+          .from('other_expenses')
+          .select('description,cost,currency,amount_paid,is_paid')
+          .eq('trip_id', trip_id),
+      ]);
+
+      if (tripRes.error) return toolError(`Failed to load trip: ${tripRes.error.message}`);
+      if (!tripRes.data) return toolError('Trip not found, or you do not have access to it.');
+
+      const categories = {
+        accommodations: summarizeCosts(staysRes.data),
+        transportation: summarizeCosts(transportRes.data),
+        activities: summarizeCosts(activitiesRes.data),
+        dining: summarizeCosts(diningRes.data),
+        other: summarizeCosts(otherRes.data),
+      };
+      const totalCost = Object.values(categories).reduce((sum, c) => sum + c.total, 0);
+      const totalPaid = Object.values(categories).reduce((sum, c) => sum + c.paid, 0);
+
+      return toolResult({
+        budget: tripRes.data.budget,
+        total_cost: totalCost,
+        total_paid: totalPaid,
+        categories,
+        other_expenses: otherRes.data ?? [],
+        note: "Amounts are in each item's own currency; check `currencies` per category before summing across categories.",
+      });
+    },
+  );
+}

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { summarizeCosts } from './budgetSummary';
+import { createTrip, WriteError } from './tripWrites';
 import type { UserContext } from './tripWrites';
 
 export function toolResult(payload: unknown) {
@@ -13,6 +14,19 @@ export function toolError(message: string) {
 }
 
 const READ_ONLY = { readOnlyHint: true, destructiveHint: false };
+const WRITE = { readOnlyHint: false, destructiveHint: false };
+const WRITE_IDEMPOTENT = { readOnlyHint: false, destructiveHint: false, idempotentHint: true };
+const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true };
+
+const dateField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Use an ISO date, YYYY-MM-DD');
+const timeField = z
+  .string()
+  .regex(/^\d{2}:\d{2}$/, 'Use a 24h time, HH:MM');
+const currencyField = z
+  .string()
+  .regex(/^[A-Z]{3}$/, 'Use a 3-letter currency code, e.g. EUR');
 
 /**
  * Register every WanderLuxe tool on the given server. `supabase` is the
@@ -25,7 +39,7 @@ export function registerWanderluxeTools(
   ctx: UserContext,
 ): void {
   registerReadTools(server, supabase);
-  // Write tools are registered by later tasks (see registerWriteTools).
+  registerWriteTools(server, supabase, ctx);
 }
 
 function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
@@ -169,6 +183,43 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
         other_expenses: otherRes.data ?? [],
         note: "Amounts are in each item's own currency; check `currencies` per category before summing across categories.",
       });
+    },
+  );
+}
+
+function registerWriteTools(
+  server: McpServer,
+  supabase: SupabaseClient,
+  ctx: UserContext,
+): void {
+  server.registerTool(
+    'create_trip',
+    {
+      description:
+        'Create a new trip. Generates one day per date from arrival to departure (inclusive) and returns the new trip_id plus the generated day_dates, so you can add items right away without a separate read.',
+      inputSchema: {
+        destination: z.string().min(1).describe('Trip name / destination, e.g. "Paris, France"'),
+        arrival_date: dateField.describe('First day of the trip (YYYY-MM-DD)'),
+        departure_date: dateField.describe('Last day of the trip (YYYY-MM-DD)'),
+        budget: z.number().positive().optional().describe('Total trip budget (optional)'),
+      },
+      annotations: WRITE,
+    },
+    async (args) => {
+      try {
+        if (args.departure_date < args.arrival_date) {
+          return toolError('departure_date must be on or after arrival_date.');
+        }
+        const result = await createTrip(supabase, ctx, {
+          destination: args.destination,
+          arrival_date: args.arrival_date,
+          departure_date: args.departure_date,
+          budget: args.budget ?? null,
+        });
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to create trip: ${String(err)}`);
+      }
     },
   );
 }

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { summarizeCosts } from './budgetSummary';
-import { createTrip, WriteError } from './tripWrites';
+import { createTrip, updateTrip, WriteError } from './tripWrites';
 import type { UserContext } from './tripWrites';
 
 export function toolResult(payload: unknown) {
@@ -224,6 +224,34 @@ function registerWriteTools(
         return toolResult(result);
       } catch (err) {
         return toolError(err instanceof WriteError ? err.message : `Failed to create trip: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_trip',
+    {
+      description:
+        "Update a trip's destination, budget, or dates. Changing dates adds new days automatically. If shrinking the range would drop days that still have items, the tool returns status 'confirmation_required' with the at-risk days and changes nothing; re-call with confirm_remove_days: true to delete those days and their items.",
+      inputSchema: {
+        trip_id: z.string().uuid().describe('Trip ID from list_trips'),
+        destination: z.string().min(1).optional(),
+        budget: z.number().positive().optional(),
+        arrival_date: dateField.optional(),
+        departure_date: dateField.optional(),
+        confirm_remove_days: z
+          .boolean()
+          .optional()
+          .describe('Set true to confirm deleting days (and their items) that fall outside the new range'),
+      },
+      annotations: WRITE_IDEMPOTENT,
+    },
+    async (args) => {
+      try {
+        const result = await updateTrip(supabase, args);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to update trip: ${String(err)}`);
       }
     },
   );

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -17,6 +17,9 @@ import {
   addTransportation,
   updateTransportation,
   deleteTransportation,
+  addExpense,
+  updateExpense,
+  deleteExpense,
   WriteError,
 } from './tripWrites';
 import type { UserContext } from './tripWrites';
@@ -572,6 +575,70 @@ function registerWriteTools(
         return toolResult(await deleteTransportation(supabase, id));
       } catch (err) {
         return toolError(err instanceof WriteError ? err.message : `Failed to delete transportation: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'add_expense',
+    {
+      description:
+        'Add a miscellaneous (non-booking) expense to a trip — e.g. tickets, shopping, fees. Returns the created expense, including its id.',
+      inputSchema: {
+        trip_id: z.string().uuid().describe('Trip ID from list_trips'),
+        description: z.string().min(1),
+        cost: z.number().nonnegative(),
+        currency: currencyField,
+        amount_paid: z.number().nonnegative().optional(),
+        is_paid: z.boolean().optional(),
+      },
+      annotations: WRITE,
+    },
+    async (args) => {
+      try {
+        return toolResult(await addExpense(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to add expense: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_expense',
+    {
+      description:
+        'Update a miscellaneous expense by its id (from get_trip_budget). Only the fields you pass are changed.',
+      inputSchema: {
+        id: z.string().uuid().describe('Expense id from get_trip_budget'),
+        description: z.string().min(1).optional(),
+        cost: z.number().nonnegative().optional(),
+        currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional(),
+        is_paid: z.boolean().optional(),
+      },
+      annotations: WRITE_IDEMPOTENT,
+    },
+    async (args) => {
+      try {
+        return toolResult(await updateExpense(supabase, args));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to update expense: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_expense',
+    {
+      description: 'Delete a miscellaneous expense by its id (from get_trip_budget).',
+      inputSchema: { id: z.string().uuid().describe('Expense id from get_trip_budget') },
+      annotations: DESTRUCTIVE,
+    },
+    async ({ id }) => {
+      try {
+        return toolResult(await deleteExpense(supabase, id));
+      } catch (err) {
+        return toolError(err instanceof WriteError ? err.message : `Failed to delete expense: ${String(err)}`);
       }
     },
   );

--- a/server/lib/tripDates.test.ts
+++ b/server/lib/tripDates.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { dateRange, planDateChange } from './tripDates';
+
+describe('dateRange', () => {
+  it('returns an inclusive list of YYYY-MM-DD dates', () => {
+    expect(dateRange('2026-09-14', '2026-09-16')).toEqual([
+      '2026-09-14',
+      '2026-09-15',
+      '2026-09-16',
+    ]);
+  });
+
+  it('returns a single date when start === end', () => {
+    expect(dateRange('2026-09-14', '2026-09-14')).toEqual(['2026-09-14']);
+  });
+
+  it('crosses a month boundary correctly', () => {
+    expect(dateRange('2026-01-31', '2026-02-02')).toEqual([
+      '2026-01-31',
+      '2026-02-01',
+      '2026-02-02',
+    ]);
+  });
+
+  it('is stable across a spring-forward DST date (UTC stepping)', () => {
+    // US DST began 2026-03-08; UTC stepping must not skip or duplicate a day.
+    expect(dateRange('2026-03-07', '2026-03-09')).toEqual([
+      '2026-03-07',
+      '2026-03-08',
+      '2026-03-09',
+    ]);
+  });
+
+  it('returns an empty array when start is after end', () => {
+    expect(dateRange('2026-09-16', '2026-09-14')).toEqual([]);
+  });
+});
+
+describe('planDateChange', () => {
+  it('reports days to add and days to drop against the new range', () => {
+    const existing = ['2026-09-14', '2026-09-15', '2026-09-16'];
+    const target = ['2026-09-15', '2026-09-16', '2026-09-17'];
+    expect(planDateChange(existing, target)).toEqual({
+      toAdd: ['2026-09-17'],
+      toDrop: ['2026-09-14'],
+    });
+  });
+
+  it('reports only additions when the range only grows', () => {
+    expect(planDateChange(['2026-09-14'], ['2026-09-14', '2026-09-15'])).toEqual({
+      toAdd: ['2026-09-15'],
+      toDrop: [],
+    });
+  });
+
+  it('reports nothing when ranges are identical', () => {
+    const same = ['2026-09-14', '2026-09-15'];
+    expect(planDateChange(same, same)).toEqual({ toAdd: [], toDrop: [] });
+  });
+});

--- a/server/lib/tripDates.ts
+++ b/server/lib/tripDates.ts
@@ -1,0 +1,43 @@
+// Pure date helpers for the MCP write tools. No I/O, no external deps, so they
+// run in the main Vitest CI suite. All arithmetic is on UTC midnights, so DST
+// transitions can never skip or duplicate a day.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function toUtcMidnight(date: string): number {
+  const [y, m, d] = date.split('-').map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+function fromUtcMidnight(ms: number): string {
+  const dt = new Date(ms);
+  return `${dt.getUTCFullYear()}-${pad(dt.getUTCMonth() + 1)}-${pad(dt.getUTCDate())}`;
+}
+
+/** Inclusive list of YYYY-MM-DD dates from start to end. Empty if start > end. */
+export function dateRange(start: string, end: string): string[] {
+  const startMs = toUtcMidnight(start);
+  const endMs = toUtcMidnight(end);
+  const out: string[] = [];
+  for (let cur = startMs; cur <= endMs; cur += DAY_MS) {
+    out.push(fromUtcMidnight(cur));
+  }
+  return out;
+}
+
+/** Diff existing trip-day dates against a target range. */
+export function planDateChange(
+  existing: string[],
+  target: string[],
+): { toAdd: string[]; toDrop: string[] } {
+  const existingSet = new Set(existing);
+  const targetSet = new Set(target);
+  return {
+    toAdd: target.filter((d) => !existingSet.has(d)),
+    toDrop: existing.filter((d) => !targetSet.has(d)),
+  };
+}

--- a/server/lib/tripWrites.test.ts
+++ b/server/lib/tripWrites.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildDroppedDayReport } from './tripWrites';
+
+describe('buildDroppedDayReport', () => {
+  const droppedDays = [
+    { day_id: 'd1', date: '2026-09-14' },
+    { day_id: 'd2', date: '2026-09-15' },
+  ];
+
+  it('summarizes activities, dining, and accommodation nights per dropped day', () => {
+    const report = buildDroppedDayReport(droppedDays, {
+      activities: [
+        { day_id: 'd1', title: 'Louvre' },
+        { day_id: 'd1', title: 'Seine cruise' },
+      ],
+      reservations: [{ day_id: 'd2', restaurant_name: 'Le Cinq' }],
+      accommodationDays: [{ day_id: 'd1' }],
+    });
+
+    expect(report).toEqual([
+      {
+        date: '2026-09-14',
+        activities: ['Louvre', 'Seine cruise'],
+        dining: [],
+        accommodation_nights: 1,
+        total: 3,
+      },
+      {
+        date: '2026-09-15',
+        activities: [],
+        dining: ['Le Cinq'],
+        accommodation_nights: 0,
+        total: 1,
+      },
+    ]);
+  });
+
+  it('returns zero-total entries for days with no content', () => {
+    const report = buildDroppedDayReport(droppedDays, {
+      activities: [],
+      reservations: [],
+      accommodationDays: [],
+    });
+    expect(report.every((r) => r.total === 0)).toBe(true);
+    expect(report).toHaveLength(2);
+  });
+});

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -548,3 +548,174 @@ export async function deleteDining(supabase: SupabaseClient, reservationId: stri
   }
   return { deleted: true, id: reservationId };
 }
+
+// ---- Accommodations ----
+
+/** Fan out accommodations_days for a stay across its nights' trip days. */
+async function fanOutAccommodationDays(
+  supabase: SupabaseClient,
+  stayId: string,
+  tripId: string,
+  checkinDate: string,
+  checkoutDate: string,
+): Promise<void> {
+  const nights = dateRange(checkinDate, checkoutDate);
+  const { data: days, error } = await supabase
+    .from('trip_days')
+    .select('day_id,date')
+    .eq('trip_id', tripId);
+  if (error) throw new WriteError(`Failed to load trip days: ${error.message}`);
+
+  const dayByDate = new Map((days ?? []).map((d) => [d.date, d.day_id]));
+  const rows = nights
+    .map((date) => {
+      const dayId = dayByDate.get(date);
+      return dayId ? { stay_id: stayId, day_id: dayId, date } : null;
+    })
+    .filter((r): r is { stay_id: string; day_id: string; date: string } => r !== null);
+
+  if (rows.length > 0) {
+    const { error: insErr } = await supabase.from('accommodations_days').insert(rows);
+    if (insErr) throw new WriteError(`Failed to map accommodation nights: ${insErr.message}`);
+  }
+}
+
+export interface AddAccommodationInput {
+  trip_id: string;
+  hotel: string;
+  hotel_checkin_date: string;
+  hotel_checkout_date: string;
+  hotel_address?: string;
+  checkin_time?: string;
+  checkout_time?: string;
+  hotel_phone?: string;
+  hotel_website?: string;
+  cost?: number;
+  currency?: string;
+}
+
+export async function addAccommodation(supabase: SupabaseClient, input: AddAccommodationInput) {
+  if (input.hotel_checkout_date < input.hotel_checkin_date) {
+    throw new WriteError('hotel_checkout_date must be on or after hotel_checkin_date.');
+  }
+  const orderIndex = await nextOrderIndex(supabase, 'accommodations', 'trip_id', input.trip_id);
+  const { data, error } = await supabase
+    .from('accommodations')
+    .insert({
+      trip_id: input.trip_id,
+      order_index: orderIndex,
+      title: input.hotel,
+      hotel: input.hotel,
+      hotel_address: input.hotel_address ?? null,
+      hotel_checkin_date: input.hotel_checkin_date,
+      hotel_checkout_date: input.hotel_checkout_date,
+      checkin_time: input.checkin_time ?? null,
+      checkout_time: input.checkout_time ?? null,
+      hotel_phone: input.hotel_phone ?? null,
+      hotel_website: input.hotel_website ?? null,
+      cost: input.cost ?? null,
+      currency: input.currency ?? null,
+    })
+    .select(
+      'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
+    )
+    .single();
+  if (error || !data) throw new WriteError(`Failed to add accommodation: ${error?.message ?? 'no row returned'}`);
+
+  await fanOutAccommodationDays(
+    supabase,
+    data.stay_id,
+    input.trip_id,
+    input.hotel_checkin_date,
+    input.hotel_checkout_date,
+  );
+  return data;
+}
+
+export interface UpdateAccommodationInput {
+  stay_id: string;
+  hotel?: string;
+  hotel_address?: string;
+  hotel_checkin_date?: string;
+  hotel_checkout_date?: string;
+  checkin_time?: string;
+  checkout_time?: string;
+  hotel_phone?: string;
+  hotel_website?: string;
+  cost?: number;
+  currency?: string;
+}
+
+export async function updateAccommodation(supabase: SupabaseClient, input: UpdateAccommodationInput) {
+  const updates: Record<string, unknown> = {};
+  if (input.hotel !== undefined) {
+    updates.hotel = input.hotel;
+    updates.title = input.hotel; // title tracks hotel name, matching the app
+  }
+  if (input.hotel_address !== undefined) updates.hotel_address = input.hotel_address;
+  if (input.hotel_checkin_date !== undefined) updates.hotel_checkin_date = input.hotel_checkin_date;
+  if (input.hotel_checkout_date !== undefined) updates.hotel_checkout_date = input.hotel_checkout_date;
+  if (input.checkin_time !== undefined) updates.checkin_time = input.checkin_time;
+  if (input.checkout_time !== undefined) updates.checkout_time = input.checkout_time;
+  if (input.hotel_phone !== undefined) updates.hotel_phone = input.hotel_phone;
+  if (input.hotel_website !== undefined) updates.hotel_website = input.hotel_website;
+  if (input.cost !== undefined) updates.cost = input.cost;
+  if (input.currency !== undefined) updates.currency = input.currency;
+
+  if (Object.keys(updates).length === 0) {
+    throw new WriteError('Nothing to update: provide at least one field to change.');
+  }
+
+  const { data, error } = await supabase
+    .from('accommodations')
+    .update(updates)
+    .eq('stay_id', input.stay_id)
+    .select(
+      'stay_id,trip_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
+    )
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to update accommodation: ${error.message}`);
+  if (!data) throw new WriteError('Accommodation not found, or you do not have access to it.');
+
+  // If either date changed, re-fan the night mappings.
+  const datesChanged =
+    input.hotel_checkin_date !== undefined || input.hotel_checkout_date !== undefined;
+  if (datesChanged) {
+    if (data.hotel_checkin_date && data.hotel_checkout_date) {
+      const { error: delErr } = await supabase
+        .from('accommodations_days')
+        .delete()
+        .eq('stay_id', input.stay_id);
+      if (delErr) throw new WriteError(`Failed to clear accommodation nights: ${delErr.message}`);
+      await fanOutAccommodationDays(
+        supabase,
+        input.stay_id,
+        data.trip_id,
+        data.hotel_checkin_date,
+        data.hotel_checkout_date,
+      );
+    }
+  }
+  const { trip_id: _omit, ...rest } = data;
+  return rest;
+}
+
+export async function deleteAccommodation(supabase: SupabaseClient, stayId: string) {
+  // Clear night mappings first (don't rely on FK cascade config).
+  const { error: daysErr } = await supabase
+    .from('accommodations_days')
+    .delete()
+    .eq('stay_id', stayId);
+  if (daysErr) throw new WriteError(`Failed to clear accommodation nights: ${daysErr.message}`);
+
+  const { data, error } = await supabase
+    .from('accommodations')
+    .delete()
+    .eq('stay_id', stayId)
+    .select('stay_id');
+  if (error) throw new WriteError(`Failed to delete accommodation: ${error.message}`);
+  if (!data || data.length === 0) {
+    throw new WriteError('Accommodation not found, or you do not have access to it.');
+  }
+  return { deleted: true, stay_id: stayId };
+}

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -442,3 +442,109 @@ export async function deleteActivity(supabase: SupabaseClient, activityId: strin
   }
   return { deleted: true, id: activityId };
 }
+
+// ---- Dining (reservations) ----
+
+export interface AddDiningInput {
+  trip_id: string;
+  date: string;
+  restaurant_name: string;
+  reservation_time?: string;
+  number_of_people?: number;
+  address?: string;
+  confirmation_number?: string;
+  notes?: string;
+  cost?: number;
+  currency?: string;
+}
+
+export async function addDining(supabase: SupabaseClient, input: AddDiningInput) {
+  const dayId = await resolveDayId(supabase, input.trip_id, input.date);
+  const orderIndex = await nextOrderIndex(supabase, 'reservations', 'day_id', dayId);
+  const { data, error } = await supabase
+    .from('reservations')
+    .insert({
+      trip_id: input.trip_id,
+      day_id: dayId,
+      order_index: orderIndex,
+      restaurant_name: input.restaurant_name,
+      reservation_time: input.reservation_time ?? null,
+      number_of_people: input.number_of_people ?? null,
+      address: input.address ?? null,
+      confirmation_number: input.confirmation_number ?? null,
+      notes: input.notes ?? null,
+      cost: input.cost ?? null,
+      currency: input.currency ?? null,
+    })
+    .select(
+      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
+    )
+    .single();
+  if (error || !data) throw new WriteError(`Failed to add dining reservation: ${error?.message ?? 'no row returned'}`);
+  return data;
+}
+
+export interface UpdateDiningInput {
+  reservation_id: string;
+  date?: string;
+  restaurant_name?: string;
+  reservation_time?: string;
+  number_of_people?: number;
+  address?: string;
+  confirmation_number?: string;
+  notes?: string;
+  cost?: number;
+  currency?: string;
+}
+
+export async function updateDining(supabase: SupabaseClient, input: UpdateDiningInput) {
+  const updates: Record<string, unknown> = {};
+  if (input.restaurant_name !== undefined) updates.restaurant_name = input.restaurant_name;
+  if (input.reservation_time !== undefined) updates.reservation_time = input.reservation_time;
+  if (input.number_of_people !== undefined) updates.number_of_people = input.number_of_people;
+  if (input.address !== undefined) updates.address = input.address;
+  if (input.confirmation_number !== undefined) updates.confirmation_number = input.confirmation_number;
+  if (input.notes !== undefined) updates.notes = input.notes;
+  if (input.cost !== undefined) updates.cost = input.cost;
+  if (input.currency !== undefined) updates.currency = input.currency;
+
+  if (input.date !== undefined) {
+    const { data: existing, error: exErr } = await supabase
+      .from('reservations')
+      .select('trip_id')
+      .eq('id', input.reservation_id)
+      .maybeSingle();
+    if (exErr) throw new WriteError(`Failed to load reservation: ${exErr.message}`);
+    if (!existing) throw new WriteError('Reservation not found, or you do not have access to it.');
+    updates.day_id = await resolveDayId(supabase, existing.trip_id, input.date);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw new WriteError('Nothing to update: provide at least one field to change.');
+  }
+
+  const { data, error } = await supabase
+    .from('reservations')
+    .update(updates)
+    .eq('id', input.reservation_id)
+    .select(
+      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
+    )
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to update reservation: ${error.message}`);
+  if (!data) throw new WriteError('Reservation not found, or you do not have access to it.');
+  return data;
+}
+
+export async function deleteDining(supabase: SupabaseClient, reservationId: string) {
+  const { data, error } = await supabase
+    .from('reservations')
+    .delete()
+    .eq('id', reservationId)
+    .select('id');
+  if (error) throw new WriteError(`Failed to delete reservation: ${error.message}`);
+  if (!data || data.length === 0) {
+    throw new WriteError('Reservation not found, or you do not have access to it.');
+  }
+  return { deleted: true, id: reservationId };
+}

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -343,3 +343,102 @@ export async function updateTrip(
 
   return { status: 'updated', trip_id: input.trip_id, days_added: toAdd, days_removed: toDrop };
 }
+
+// ---- Activities (day_activities) ----
+
+export interface AddActivityInput {
+  trip_id: string;
+  date: string;
+  title: string;
+  description?: string;
+  start_time?: string;
+  end_time?: string;
+  cost?: number;
+  currency?: string;
+  location_address?: string;
+}
+
+export async function addActivity(supabase: SupabaseClient, input: AddActivityInput) {
+  const dayId = await resolveDayId(supabase, input.trip_id, input.date);
+  const orderIndex = await nextOrderIndex(supabase, 'day_activities', 'day_id', dayId);
+  const { data, error } = await supabase
+    .from('day_activities')
+    .insert({
+      trip_id: input.trip_id,
+      day_id: dayId,
+      order_index: orderIndex,
+      title: input.title,
+      description: input.description ?? null,
+      start_time: input.start_time ?? null,
+      end_time: input.end_time ?? null,
+      cost: input.cost ?? null,
+      currency: input.currency ?? null,
+      location_address: input.location_address ?? null,
+    })
+    .select('id,day_id,title,description,start_time,end_time,cost,currency,location_address')
+    .single();
+  if (error || !data) throw new WriteError(`Failed to add activity: ${error?.message ?? 'no row returned'}`);
+  return data;
+}
+
+export interface UpdateActivityInput {
+  activity_id: string;
+  date?: string;
+  title?: string;
+  description?: string;
+  start_time?: string;
+  end_time?: string;
+  cost?: number;
+  currency?: string;
+  location_address?: string;
+}
+
+export async function updateActivity(supabase: SupabaseClient, input: UpdateActivityInput) {
+  const updates: Record<string, unknown> = {};
+  if (input.title !== undefined) updates.title = input.title;
+  if (input.description !== undefined) updates.description = input.description;
+  if (input.start_time !== undefined) updates.start_time = input.start_time;
+  if (input.end_time !== undefined) updates.end_time = input.end_time;
+  if (input.cost !== undefined) updates.cost = input.cost;
+  if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.location_address !== undefined) updates.location_address = input.location_address;
+
+  // Changing the date re-resolves day_id (scoped to the activity's own trip).
+  if (input.date !== undefined) {
+    const { data: existing, error: exErr } = await supabase
+      .from('day_activities')
+      .select('trip_id')
+      .eq('id', input.activity_id)
+      .maybeSingle();
+    if (exErr) throw new WriteError(`Failed to load activity: ${exErr.message}`);
+    if (!existing) throw new WriteError('Activity not found, or you do not have access to it.');
+    updates.day_id = await resolveDayId(supabase, existing.trip_id, input.date);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw new WriteError('Nothing to update: provide at least one field to change.');
+  }
+
+  const { data, error } = await supabase
+    .from('day_activities')
+    .update(updates)
+    .eq('id', input.activity_id)
+    .select('id,day_id,title,description,start_time,end_time,cost,currency,location_address')
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to update activity: ${error.message}`);
+  if (!data) throw new WriteError('Activity not found, or you do not have access to it.');
+  return data;
+}
+
+export async function deleteActivity(supabase: SupabaseClient, activityId: string) {
+  const { data, error } = await supabase
+    .from('day_activities')
+    .delete()
+    .eq('id', activityId)
+    .select('id');
+  if (error) throw new WriteError(`Failed to delete activity: ${error.message}`);
+  if (!data || data.length === 0) {
+    throw new WriteError('Activity not found, or you do not have access to it.');
+  }
+  return { deleted: true, id: activityId };
+}

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -666,6 +666,27 @@ export async function updateAccommodation(supabase: SupabaseClient, input: Updat
     throw new WriteError('Nothing to update: provide at least one field to change.');
   }
 
+  const datesChanged =
+    input.hotel_checkin_date !== undefined || input.hotel_checkout_date !== undefined;
+
+  // When changing either date, validate the EFFECTIVE range (new value or the
+  // existing one) before writing, so we never persist checkin > checkout (which
+  // would also wipe the night mappings via the re-fan with nothing to re-insert).
+  if (datesChanged) {
+    const { data: existing, error: exErr } = await supabase
+      .from('accommodations')
+      .select('hotel_checkin_date,hotel_checkout_date')
+      .eq('stay_id', input.stay_id)
+      .maybeSingle();
+    if (exErr) throw new WriteError(`Failed to load accommodation: ${exErr.message}`);
+    if (!existing) throw new WriteError('Accommodation not found, or you do not have access to it.');
+    const effectiveCheckin = input.hotel_checkin_date ?? existing.hotel_checkin_date;
+    const effectiveCheckout = input.hotel_checkout_date ?? existing.hotel_checkout_date;
+    if (effectiveCheckin && effectiveCheckout && effectiveCheckout < effectiveCheckin) {
+      throw new WriteError('hotel_checkout_date must be on or after hotel_checkin_date.');
+    }
+  }
+
   const { data, error } = await supabase
     .from('accommodations')
     .update(updates)
@@ -678,8 +699,6 @@ export async function updateAccommodation(supabase: SupabaseClient, input: Updat
   if (!data) throw new WriteError('Accommodation not found, or you do not have access to it.');
 
   // If either date changed, re-fan the night mappings.
-  const datesChanged =
-    input.hotel_checkin_date !== undefined || input.hotel_checkout_date !== undefined;
   if (datesChanged) {
     if (data.hotel_checkin_date && data.hotel_checkout_date) {
       const { error: delErr } = await supabase

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -6,7 +6,7 @@
 // because they use the browser Supabase singleton.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { dateRange } from './tripDates';
+import { dateRange, planDateChange } from './tripDates';
 
 /** A user-facing error whose message is safe to return verbatim via toolError. */
 export class WriteError extends Error {}
@@ -206,4 +206,136 @@ export function buildDroppedDayReport(
       total: activities.length + dining.length + accommodationNights,
     };
   });
+}
+
+export interface UpdateTripInput {
+  trip_id: string;
+  destination?: string;
+  budget?: number | null;
+  arrival_date?: string;
+  departure_date?: string;
+  confirm_remove_days?: boolean;
+}
+
+export type UpdateTripResult =
+  | { status: 'updated'; trip_id: string; days_added: string[]; days_removed: string[] }
+  | {
+      status: 'confirmation_required';
+      message: string;
+      at_risk_days: DroppedDayReportEntry[];
+    };
+
+export async function updateTrip(
+  supabase: SupabaseClient,
+  input: UpdateTripInput,
+): Promise<UpdateTripResult> {
+  const { data: trip, error } = await supabase
+    .from('trips')
+    .select('trip_id,arrival_date,departure_date')
+    .eq('trip_id', input.trip_id)
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to load trip: ${error.message}`);
+  if (!trip) throw new WriteError('Trip not found, or you do not have access to it.');
+
+  const newArrival = input.arrival_date ?? trip.arrival_date;
+  const newDeparture = input.departure_date ?? trip.departure_date;
+  if (newDeparture < newArrival) {
+    throw new WriteError('departure_date must be on or after arrival_date.');
+  }
+  const datesChanged = newArrival !== trip.arrival_date || newDeparture !== trip.departure_date;
+
+  // Non-date field updates always apply.
+  const fieldUpdates: Record<string, unknown> = {};
+  if (input.destination !== undefined) fieldUpdates.destination = input.destination;
+  if (input.budget !== undefined) fieldUpdates.budget = input.budget;
+
+  if (!datesChanged) {
+    if (Object.keys(fieldUpdates).length > 0) {
+      const { error: updErr } = await supabase
+        .from('trips')
+        .update(fieldUpdates)
+        .eq('trip_id', input.trip_id);
+      if (updErr) throw new WriteError(`Failed to update trip: ${updErr.message}`);
+    }
+    return { status: 'updated', trip_id: input.trip_id, days_added: [], days_removed: [] };
+  }
+
+  const newRange = dateRange(newArrival, newDeparture);
+  if (newRange.length > 366) {
+    throw new WriteError('That date range is too long; a trip can span at most 366 days.');
+  }
+
+  // Date change: diff existing days against the new range.
+  const { data: existingDays, error: daysErr } = await supabase
+    .from('trip_days')
+    .select('day_id,date')
+    .eq('trip_id', input.trip_id);
+  if (daysErr) throw new WriteError(`Failed to load trip days: ${daysErr.message}`);
+
+  const { toAdd, toDrop } = planDateChange(
+    (existingDays ?? []).map((d) => d.date),
+    newRange,
+  );
+  const dropRows = (existingDays ?? []).filter((d) => toDrop.includes(d.date));
+
+  // Content pre-check on the dropped days.
+  if (dropRows.length > 0) {
+    const dropIds = dropRows.map((d) => d.day_id);
+    const [actRes, resRes, accRes] = await Promise.all([
+      supabase.from('day_activities').select('day_id,title').in('day_id', dropIds),
+      supabase.from('reservations').select('day_id,restaurant_name').in('day_id', dropIds),
+      supabase.from('accommodations_days').select('day_id').in('day_id', dropIds),
+    ]);
+    if (actRes.error) throw new WriteError(`Failed to check activities: ${actRes.error.message}`);
+    if (resRes.error) throw new WriteError(`Failed to check dining: ${resRes.error.message}`);
+    if (accRes.error) throw new WriteError(`Failed to check accommodations: ${accRes.error.message}`);
+
+    const report = buildDroppedDayReport(dropRows, {
+      activities: actRes.data ?? [],
+      reservations: resRes.data ?? [],
+      accommodationDays: accRes.data ?? [],
+    });
+    const hasContent = report.some((r) => r.total > 0);
+
+    if (hasContent && !input.confirm_remove_days) {
+      return {
+        status: 'confirmation_required',
+        message:
+          'This date change would remove days that still have items scheduled. ' +
+          'Nothing has been changed. Show the user the at_risk_days, and if they confirm, ' +
+          'call update_trip again with the same dates plus confirm_remove_days: true.',
+        at_risk_days: report.filter((r) => r.total > 0),
+      };
+    }
+  }
+
+  // Apply: add new days first.
+  if (toAdd.length > 0) {
+    const { error: addErr } = await supabase
+      .from('trip_days')
+      .insert(toAdd.map((date) => ({ trip_id: input.trip_id, date })));
+    if (addErr) throw new WriteError(`Failed to add new days: ${addErr.message}`);
+  }
+
+  // Cascade-delete dropped days' children, then the days themselves.
+  if (dropRows.length > 0) {
+    const dropIds = dropRows.map((d) => d.day_id);
+    // Explicit cleanup (don't rely on FK cascade config). Note: this removes
+    // accommodation NIGHT mappings on dropped days, not the accommodation rows.
+    for (const table of ['day_activities', 'reservations', 'accommodations_days'] as const) {
+      const { error: delErr } = await supabase.from(table).delete().in('day_id', dropIds);
+      if (delErr) throw new WriteError(`Failed to clear ${table}: ${delErr.message}`);
+    }
+    const { error: dropErr } = await supabase.from('trip_days').delete().in('day_id', dropIds);
+    if (dropErr) throw new WriteError(`Failed to remove dropped days: ${dropErr.message}`);
+  }
+
+  // Finally, apply the date change (+ any field updates) to the trip row.
+  const { error: updErr } = await supabase
+    .from('trips')
+    .update({ ...fieldUpdates, arrival_date: newArrival, departure_date: newDeparture })
+    .eq('trip_id', input.trip_id);
+  if (updErr) throw new WriteError(`Failed to update trip dates: ${updErr.message}`);
+
+  return { status: 'updated', trip_id: input.trip_id, days_added: toAdd, days_removed: toDrop };
 }

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -320,8 +320,12 @@ export async function updateTrip(
   // Cascade-delete dropped days' children, then the days themselves.
   if (dropRows.length > 0) {
     const dropIds = dropRows.map((d) => d.day_id);
-    // Explicit cleanup (don't rely on FK cascade config). Note: this removes
-    // accommodation NIGHT mappings on dropped days, not the accommodation rows.
+    // Explicit cleanup. day_activities/reservations would also cascade from
+    // trip_days, and their *_travelers junctions cascade from them — but
+    // accommodations_days.day_id is ON DELETE NO ACTION, so its night mappings
+    // MUST be deleted here before trip_days, or the trip_days delete fails.
+    // (This removes accommodation NIGHT mappings on dropped days, not the
+    // accommodation rows themselves.)
     for (const table of ['day_activities', 'reservations', 'accommodations_days'] as const) {
       const { error: delErr } = await supabase.from(table).delete().in('day_id', dropIds);
       if (delErr) throw new WriteError(`Failed to clear ${table}: ${delErr.message}`);

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -738,3 +738,115 @@ export async function deleteAccommodation(supabase: SupabaseClient, stayId: stri
   }
   return { deleted: true, stay_id: stayId };
 }
+
+// ---- Transportation ----
+
+export type TransportationType =
+  | 'flight'
+  | 'train'
+  | 'car_service'
+  | 'shuttle'
+  | 'ferry'
+  | 'rental_car';
+
+export interface AddTransportationInput {
+  trip_id: string;
+  type: TransportationType;
+  start_date: string;
+  provider?: string;
+  flight_number?: string;
+  confirmation_number?: string;
+  departure_location?: string;
+  arrival_location?: string;
+  start_time?: string;
+  end_date?: string;
+  end_time?: string;
+  cost?: number;
+  currency?: string;
+}
+
+const TRANSPORT_SELECT =
+  'id,type,provider,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency';
+
+export async function addTransportation(supabase: SupabaseClient, input: AddTransportationInput) {
+  const { data, error } = await supabase
+    .from('transportation')
+    .insert({
+      trip_id: input.trip_id,
+      type: input.type,
+      start_date: input.start_date,
+      provider: input.provider ?? null,
+      flight_number: input.flight_number ?? null,
+      confirmation_number: input.confirmation_number ?? null,
+      departure_location: input.departure_location ?? null,
+      arrival_location: input.arrival_location ?? null,
+      start_time: input.start_time ?? null,
+      end_date: input.end_date ?? null,
+      end_time: input.end_time ?? null,
+      cost: input.cost ?? null,
+      currency: input.currency ?? null,
+    })
+    .select(TRANSPORT_SELECT)
+    .single();
+  if (error || !data) throw new WriteError(`Failed to add transportation: ${error?.message ?? 'no row returned'}`);
+  return data;
+}
+
+export interface UpdateTransportationInput {
+  id: string;
+  type?: TransportationType;
+  start_date?: string;
+  provider?: string;
+  flight_number?: string;
+  confirmation_number?: string;
+  departure_location?: string;
+  arrival_location?: string;
+  start_time?: string;
+  end_date?: string;
+  end_time?: string;
+  cost?: number;
+  currency?: string;
+}
+
+export async function updateTransportation(supabase: SupabaseClient, input: UpdateTransportationInput) {
+  const updates: Record<string, unknown> = {};
+  if (input.type !== undefined) updates.type = input.type;
+  if (input.start_date !== undefined) updates.start_date = input.start_date;
+  if (input.provider !== undefined) updates.provider = input.provider;
+  if (input.flight_number !== undefined) updates.flight_number = input.flight_number;
+  if (input.confirmation_number !== undefined) updates.confirmation_number = input.confirmation_number;
+  if (input.departure_location !== undefined) updates.departure_location = input.departure_location;
+  if (input.arrival_location !== undefined) updates.arrival_location = input.arrival_location;
+  if (input.start_time !== undefined) updates.start_time = input.start_time;
+  if (input.end_date !== undefined) updates.end_date = input.end_date;
+  if (input.end_time !== undefined) updates.end_time = input.end_time;
+  if (input.cost !== undefined) updates.cost = input.cost;
+  if (input.currency !== undefined) updates.currency = input.currency;
+
+  if (Object.keys(updates).length === 0) {
+    throw new WriteError('Nothing to update: provide at least one field to change.');
+  }
+
+  const { data, error } = await supabase
+    .from('transportation')
+    .update(updates)
+    .eq('id', input.id)
+    .select(TRANSPORT_SELECT)
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to update transportation: ${error.message}`);
+  if (!data) throw new WriteError('Transportation not found, or you do not have access to it.');
+  return data;
+}
+
+export async function deleteTransportation(supabase: SupabaseClient, id: string) {
+  const { data, error } = await supabase
+    .from('transportation')
+    .delete()
+    .eq('id', id)
+    .select('id');
+  if (error) throw new WriteError(`Failed to delete transportation: ${error.message}`);
+  if (!data || data.length === 0) {
+    throw new WriteError('Transportation not found, or you do not have access to it.');
+  }
+  return { deleted: true, id };
+}

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -850,3 +850,78 @@ export async function deleteTransportation(supabase: SupabaseClient, id: string)
   }
   return { deleted: true, id };
 }
+
+// ---- Other expenses ----
+
+const EXPENSE_SELECT = 'id,description,cost,currency,amount_paid,is_paid';
+
+export interface AddExpenseInput {
+  trip_id: string;
+  description: string;
+  cost: number;
+  currency: string;
+  amount_paid?: number;
+  is_paid?: boolean;
+}
+
+export async function addExpense(supabase: SupabaseClient, input: AddExpenseInput) {
+  const { data, error } = await supabase
+    .from('other_expenses')
+    .insert({
+      trip_id: input.trip_id,
+      description: input.description,
+      cost: input.cost,
+      currency: input.currency,
+      amount_paid: input.amount_paid ?? null,
+      is_paid: input.is_paid ?? null,
+    })
+    .select(EXPENSE_SELECT)
+    .single();
+  if (error || !data) throw new WriteError(`Failed to add expense: ${error?.message ?? 'no row returned'}`);
+  return data;
+}
+
+export interface UpdateExpenseInput {
+  id: string;
+  description?: string;
+  cost?: number;
+  currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
+}
+
+export async function updateExpense(supabase: SupabaseClient, input: UpdateExpenseInput) {
+  const updates: Record<string, unknown> = {};
+  if (input.description !== undefined) updates.description = input.description;
+  if (input.cost !== undefined) updates.cost = input.cost;
+  if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
+  if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
+
+  if (Object.keys(updates).length === 0) {
+    throw new WriteError('Nothing to update: provide at least one field to change.');
+  }
+
+  const { data, error } = await supabase
+    .from('other_expenses')
+    .update(updates)
+    .eq('id', input.id)
+    .select(EXPENSE_SELECT)
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to update expense: ${error.message}`);
+  if (!data) throw new WriteError('Expense not found, or you do not have access to it.');
+  return data;
+}
+
+export async function deleteExpense(supabase: SupabaseClient, id: string) {
+  const { data, error } = await supabase
+    .from('other_expenses')
+    .delete()
+    .eq('id', id)
+    .select('id');
+  if (error) throw new WriteError(`Failed to delete expense: ${error.message}`);
+  if (!data || data.length === 0) {
+    throw new WriteError('Expense not found, or you do not have access to it.');
+  }
+  return { deleted: true, id };
+}

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -107,9 +107,6 @@ async function addOwnerShare(
   }
 }
 
-// Re-export so the fan-out helpers below can use it without re-importing.
-export { dateRange };
-
 // ---- Trip ----
 
 export interface CreateTripInput {
@@ -124,6 +121,18 @@ export async function createTrip(
   ctx: UserContext,
   input: CreateTripInput,
 ): Promise<{ trip_id: string; day_dates: string[] }> {
+  // Validate the range before any insert, so an invalid range never creates an orphan trip.
+  if (input.departure_date < input.arrival_date) {
+    throw new WriteError('departure_date must be on or after arrival_date.');
+  }
+  const dates = dateRange(input.arrival_date, input.departure_date);
+  if (dates.length === 0) {
+    throw new WriteError('The trip must span at least one day.');
+  }
+  if (dates.length > 366) {
+    throw new WriteError('That date range is too long; a trip can span at most 366 days.');
+  }
+
   // 1. Insert the trip, with user_id pinned to the authenticated user.
   const { data: trip, error } = await supabase
     .from('trips')
@@ -143,13 +152,14 @@ export async function createTrip(
   await addOwnerShare(supabase, trip.trip_id, ctx);
 
   // 3. Generate one trip_days row per date in the range.
-  const dates = dateRange(input.arrival_date, input.departure_date);
   const rows = dates.map((date) => ({ trip_id: trip.trip_id, date }));
   const { error: daysError } = await supabase.from('trip_days').insert(rows);
   if (daysError) {
-    throw new WriteError(
-      `Trip created (id ${trip.trip_id}) but generating its days failed: ${daysError.message}`,
-    );
+    // Compensating cleanup so a days-insert failure doesn't leave an orphan trip
+    // (there is no whole-trip delete tool). Best-effort; ignore cleanup errors.
+    await supabase.from('trip_shares').delete().eq('trip_id', trip.trip_id);
+    await supabase.from('trips').delete().eq('trip_id', trip.trip_id);
+    throw new WriteError(`Failed to generate the trip's days, so the trip was not created: ${daysError.message}`);
   }
 
   return { trip_id: trip.trip_id, day_dates: dates };

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -109,3 +109,91 @@ async function addOwnerShare(
 
 // Re-export so the fan-out helpers below can use it without re-importing.
 export { dateRange };
+
+// ---- Trip ----
+
+export interface CreateTripInput {
+  destination: string;
+  arrival_date: string;
+  departure_date: string;
+  budget?: number | null;
+}
+
+export async function createTrip(
+  supabase: SupabaseClient,
+  ctx: UserContext,
+  input: CreateTripInput,
+): Promise<{ trip_id: string; day_dates: string[] }> {
+  // 1. Insert the trip, with user_id pinned to the authenticated user.
+  const { data: trip, error } = await supabase
+    .from('trips')
+    .insert({
+      user_id: ctx.userId,
+      destination: input.destination,
+      arrival_date: input.arrival_date,
+      departure_date: input.departure_date,
+      budget: input.budget ?? null,
+      is_public: false,
+    })
+    .select('trip_id')
+    .single();
+  if (error || !trip) throw new WriteError(`Failed to create trip: ${error?.message ?? 'no row returned'}`);
+
+  // 2. Owner share BEFORE days/children — child-table RLS can depend on it.
+  await addOwnerShare(supabase, trip.trip_id, ctx);
+
+  // 3. Generate one trip_days row per date in the range.
+  const dates = dateRange(input.arrival_date, input.departure_date);
+  const rows = dates.map((date) => ({ trip_id: trip.trip_id, date }));
+  const { error: daysError } = await supabase.from('trip_days').insert(rows);
+  if (daysError) {
+    throw new WriteError(
+      `Trip created (id ${trip.trip_id}) but generating its days failed: ${daysError.message}`,
+    );
+  }
+
+  return { trip_id: trip.trip_id, day_dates: dates };
+}
+
+// ---- Date-change content pre-check (pure) ----
+
+export interface DroppedDayReportEntry {
+  date: string;
+  activities: string[];
+  dining: string[];
+  accommodation_nights: number;
+  total: number;
+}
+
+/**
+ * Pure: given the dropped days and the items currently scheduled on them,
+ * build a per-day report of what would be lost. `total` is the count of items
+ * at risk on that day.
+ */
+export function buildDroppedDayReport(
+  droppedDays: Array<{ day_id: string; date: string }>,
+  content: {
+    activities: Array<{ day_id: string; title: string }>;
+    reservations: Array<{ day_id: string; restaurant_name: string }>;
+    accommodationDays: Array<{ day_id: string }>;
+  },
+): DroppedDayReportEntry[] {
+  return droppedDays.map((day) => {
+    const activities = content.activities
+      .filter((a) => a.day_id === day.day_id)
+      .map((a) => a.title);
+    const dining = content.reservations
+      .filter((r) => r.day_id === day.day_id)
+      .map((r) => r.restaurant_name);
+    const accommodationNights = content.accommodationDays.filter(
+      (ad) => ad.day_id === day.day_id,
+    ).length;
+    return {
+      date: day.date,
+      activities,
+      dining,
+      accommodation_nights: accommodationNights,
+      total: activities.length + dining.length + accommodationNights,
+    };
+  });
+}

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -1,0 +1,111 @@
+// Write functions for the MCP server. Each takes the per-request, user-scoped
+// Supabase client (anon key + the caller's JWT) as its first argument, so RLS
+// enforces all access control — never a service-role key. These mirror the
+// business logic in the client-side services (day generation, owner share,
+// order_index, accommodation night fan-out), which cannot be imported here
+// because they use the browser Supabase singleton.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { dateRange } from './tripDates';
+
+/** A user-facing error whose message is safe to return verbatim via toolError. */
+export class WriteError extends Error {}
+
+/** Context derived from the validated JWT (never from tool input). */
+export interface UserContext {
+  userId: string;
+  email: string | null;
+}
+
+/**
+ * Resolve a trip day's id from its date. Days are addressed by date, never by
+ * day_id, throughout the tool surface. Throws a clear WriteError when the date
+ * is outside the trip's range.
+ */
+async function resolveDayId(
+  supabase: SupabaseClient,
+  tripId: string,
+  date: string,
+): Promise<string> {
+  const { data, error } = await supabase
+    .from('trip_days')
+    .select('day_id')
+    .eq('trip_id', tripId)
+    .eq('date', date)
+    .maybeSingle();
+  if (error) throw new WriteError(`Failed to resolve the day for ${date}: ${error.message}`);
+  if (!data) {
+    throw new WriteError(
+      `No day matches ${date} on this trip. That date is outside the trip's range — ` +
+        `update the trip's dates first, or pick a date within the range.`,
+    );
+  }
+  return data.day_id;
+}
+
+/**
+ * Next order_index within a scope (max existing + 1), matching how the app
+ * orders app-created items. `scopeColumn` is 'day_id' (activities, dining) or
+ * 'trip_id' (accommodations).
+ */
+async function nextOrderIndex(
+  supabase: SupabaseClient,
+  table: 'day_activities' | 'reservations' | 'accommodations',
+  scopeColumn: 'day_id' | 'trip_id',
+  scopeValue: string,
+): Promise<number> {
+  const { data, error } = await supabase
+    .from(table)
+    .select('order_index')
+    .eq(scopeColumn, scopeValue)
+    .order('order_index', { ascending: false })
+    .limit(1);
+  if (error) throw new WriteError(`Failed to compute order: ${error.message}`);
+  return (data?.[0]?.order_index ?? -1) + 1;
+}
+
+/**
+ * Insert the owner row into trip_shares, mirroring the app's
+ * addOwnerToTripShares. Best-effort: a failure here must not abort trip
+ * creation (the trip is already accessible via trips.user_id ownership).
+ */
+async function addOwnerShare(
+  supabase: SupabaseClient,
+  tripId: string,
+  ctx: UserContext,
+): Promise<void> {
+  try {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('full_name')
+      .eq('id', ctx.userId)
+      .maybeSingle();
+
+    const email = ctx.email?.toLowerCase() ?? null;
+    let firstName = 'User';
+    let lastName: string | null = null;
+    if (profile?.full_name?.trim()) {
+      const parts = profile.full_name.trim().split(' ').filter(Boolean);
+      firstName = parts[0];
+      lastName = parts.slice(1).join(' ') || null;
+    } else if (email) {
+      const prefix = email.split('@')[0] || 'User';
+      firstName = prefix.charAt(0).toUpperCase() + prefix.slice(1);
+    }
+
+    await supabase.from('trip_shares').insert({
+      trip_id: tripId,
+      shared_by_user_id: ctx.userId,
+      shared_with_user_id: ctx.userId,
+      first_name: firstName,
+      last_name: lastName,
+      shared_with_email: email,
+      permission_level: 'edit',
+    });
+  } catch (err) {
+    console.error('addOwnerShare failed (continuing):', err);
+  }
+}
+
+// Re-export so the fan-out helpers below can use it without re-importing.
+export { dateRange };

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -4,8 +4,7 @@ import rateLimit from 'express-rate-limit';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { z } from 'zod';
-import { summarizeCosts } from '../lib/budgetSummary';
+import { registerWanderluxeTools } from '../lib/mcpTools';
 
 const router = express.Router();
 
@@ -52,7 +51,9 @@ const mcpLimiter = rateLimit({
  * `aud: "authenticated"` (the claim on all Supabase user tokens) is the
  * strictest audience check available here.
  */
-async function authenticate(req: Request): Promise<{ token: string; userId: string } | null> {
+async function authenticate(
+  req: Request,
+): Promise<{ token: string; userId: string; email: string | null } | null> {
   const authHeader = req.headers.authorization || '';
   if (!authHeader.startsWith('Bearer ')) return null;
   const token = authHeader.slice('Bearer '.length);
@@ -63,7 +64,8 @@ async function authenticate(req: Request): Promise<{ token: string; userId: stri
       algorithms: ['ES256'],
     });
     if (!payload.sub) return null;
-    return { token, userId: payload.sub };
+    const email = typeof payload.email === 'string' ? payload.email : null;
+    return { token, userId: payload.sub, email };
   } catch {
     return null;
   }
@@ -92,171 +94,18 @@ function createUserClient(token: string) {
   });
 }
 
-function toolResult(payload: unknown) {
-  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
-}
-
-function toolError(message: string) {
-  return { content: [{ type: 'text' as const, text: message }], isError: true };
-}
-
-const READ_ONLY = { readOnlyHint: true, destructiveHint: false };
-
-function buildMcpServer(token: string): McpServer {
-  const supabase = createUserClient(token);
+function buildMcpServer(auth: { token: string; userId: string; email: string | null }): McpServer {
+  const supabase = createUserClient(auth.token);
 
   const server = new McpServer(
-    { name: 'wanderluxe', version: '0.1.0' },
+    { name: 'wanderluxe', version: '0.2.0' },
     {
       instructions:
-        'Tools for reading the user\'s WanderLuxe trips. Call list_trips first to get trip IDs — they are not guessable. Dates are ISO (YYYY-MM-DD); times are 24h local to the destination.',
+        "Tools for reading and managing the user's WanderLuxe trips. Call list_trips first to get trip IDs — they are not guessable. Add items by date (YYYY-MM-DD); the server resolves the matching trip day. Times are 24h HH:MM, local to the destination. To change a trip's dates in a way that would drop days containing items, the update_trip tool will first return the at-risk days for confirmation; re-call it with confirm_remove_days: true to proceed.",
     },
   );
 
-  server.registerTool(
-    'list_trips',
-    {
-      description:
-        'List the trips the user owns or that are shared with them, newest first. Returns trip_id, destination, dates, and budget.',
-      annotations: READ_ONLY,
-    },
-    async () => {
-      const { data, error } = await supabase
-        .from('trips')
-        .select('trip_id,destination,arrival_date,departure_date,budget,created_at')
-        .order('arrival_date', { ascending: false });
-      if (error) return toolError(`Failed to list trips: ${error.message}`);
-      return toolResult({ trips: data ?? [] });
-    },
-  );
-
-  server.registerTool(
-    'get_trip',
-    {
-      description:
-        'Get the full itinerary for one trip: day-by-day activities and dining reservations, plus accommodations and transportation. Use list_trips to find the trip_id.',
-      inputSchema: { trip_id: z.string().uuid().describe('Trip ID from list_trips') },
-      annotations: READ_ONLY,
-    },
-    async ({ trip_id }) => {
-      const [tripRes, daysRes, staysRes, transportRes, activitiesRes, diningRes] = await Promise.all([
-        supabase
-          .from('trips')
-          .select('trip_id,destination,arrival_date,departure_date,budget')
-          .eq('trip_id', trip_id)
-          .maybeSingle(),
-        supabase
-          .from('trip_days')
-          .select('day_id,date,title,description')
-          .eq('trip_id', trip_id)
-          .order('date'),
-        supabase
-          .from('accommodations')
-          .select(
-            'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
-          )
-          .eq('trip_id', trip_id),
-        supabase
-          .from('transportation')
-          .select(
-            'id,type,provider,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency',
-          )
-          .eq('trip_id', trip_id)
-          .order('start_date'),
-        supabase
-          .from('day_activities')
-          .select('id,day_id,title,description,start_time,end_time,location_address,cost,currency')
-          .eq('trip_id', trip_id),
-        supabase
-          .from('reservations')
-          .select(
-            'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
-          )
-          .eq('trip_id', trip_id),
-      ]);
-
-      // RLS filters trips the user can't see, so "not found" and "no access" look identical.
-      if (tripRes.error) return toolError(`Failed to load trip: ${tripRes.error.message}`);
-      if (!tripRes.data) return toolError('Trip not found, or you do not have access to it.');
-
-      const activitiesByDay = new Map<string, unknown[]>();
-      for (const a of activitiesRes.data ?? []) {
-        const { day_id, ...rest } = a;
-        const list = activitiesByDay.get(day_id) ?? [];
-        list.push(rest);
-        activitiesByDay.set(day_id, list);
-      }
-      const diningByDay = new Map<string, unknown[]>();
-      for (const r of diningRes.data ?? []) {
-        const { day_id, ...rest } = r;
-        if (!day_id) continue;
-        const list = diningByDay.get(day_id) ?? [];
-        list.push(rest);
-        diningByDay.set(day_id, list);
-      }
-
-      const days = (daysRes.data ?? []).map((d) => ({
-        date: d.date,
-        title: d.title,
-        description: d.description,
-        activities: activitiesByDay.get(d.day_id) ?? [],
-        dining: diningByDay.get(d.day_id) ?? [],
-      }));
-
-      return toolResult({
-        trip: tripRes.data,
-        days,
-        accommodations: staysRes.data ?? [],
-        transportation: transportRes.data ?? [],
-      });
-    },
-  );
-
-  server.registerTool(
-    'get_trip_budget',
-    {
-      description:
-        'Get the budget breakdown for one trip: total budget, spend per category (accommodations, transportation, activities, dining, other), and paid vs unpaid amounts.',
-      inputSchema: { trip_id: z.string().uuid().describe('Trip ID from list_trips') },
-      annotations: READ_ONLY,
-    },
-    async ({ trip_id }) => {
-      const [tripRes, staysRes, transportRes, activitiesRes, diningRes, otherRes] = await Promise.all([
-        supabase.from('trips').select('budget').eq('trip_id', trip_id).maybeSingle(),
-        supabase.from('accommodations').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
-        supabase.from('transportation').select('cost,currency').eq('trip_id', trip_id),
-        supabase.from('day_activities').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
-        supabase.from('reservations').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
-        supabase
-          .from('other_expenses')
-          .select('description,cost,currency,amount_paid,is_paid')
-          .eq('trip_id', trip_id),
-      ]);
-
-      if (tripRes.error) return toolError(`Failed to load trip: ${tripRes.error.message}`);
-      if (!tripRes.data) return toolError('Trip not found, or you do not have access to it.');
-
-      const categories = {
-        accommodations: summarizeCosts(staysRes.data),
-        transportation: summarizeCosts(transportRes.data),
-        activities: summarizeCosts(activitiesRes.data),
-        dining: summarizeCosts(diningRes.data),
-        other: summarizeCosts(otherRes.data),
-      };
-      const totalCost = Object.values(categories).reduce((sum, c) => sum + c.total, 0);
-      const totalPaid = Object.values(categories).reduce((sum, c) => sum + c.paid, 0);
-
-      return toolResult({
-        budget: tripRes.data.budget,
-        total_cost: totalCost,
-        total_paid: totalPaid,
-        categories,
-        other_expenses: otherRes.data ?? [],
-        note: 'Amounts are in each item\'s own currency; check `currencies` per category before summing across categories.',
-      });
-    },
-  );
-
+  registerWanderluxeTools(server, supabase, { userId: auth.userId, email: auth.email });
   return server;
 }
 
@@ -301,7 +150,7 @@ router.post('/mcp', mcpLimiter, async (req: Request, res: Response) => {
   try {
     // Fresh server + transport per request: no session state, nothing shared
     // across users, and the user's token is scoped to this request only.
-    const server = buildMcpServer(auth.token);
+    const server = buildMcpServer(auth);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
       enableJsonResponse: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'server/**/*.{test,spec}.ts',
       'evals/helpers/**/*.test.ts',
     ],
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache'],


### PR DESCRIPTION
## Summary
Extends the WanderLuxe MCP server from 3 read-only tools to **20 tools** (3 read + 17 write), so a Claude.ai connector can fully manage a user's trips. All writes go through the existing per-request, **user-scoped (RLS) Supabase client** — anon key + the caller's JWT, never a service-role key.

New tools:
- **Trip:** `create_trip` (generates `trip_days` + owner share), `update_trip` (two-call confirm pattern for destructive date shrinks via `confirm_remove_days`)
- **Activity / Dining / Accommodation / Transportation / Expense:** `add_*` / `update_*` / `delete_*` (accommodation fans out per-night `accommodations_days`)

Architecture:
- `server/lib/tripDates.ts` — pure, unit-tested date helpers (inclusive range + add/drop diff)
- `server/lib/tripWrites.ts` — all write functions `(supabase, …) → result`, mirroring the client services' business logic (the client services use the browser Supabase singleton and can't be imported server-side)
- `server/lib/mcpTools.ts` — tool registration (read tools moved here verbatim + new write tools); `server/routes/mcp.ts` shrinks to transport/auth/discovery and now threads the JWT `{ userId, email }` into registration

Security: `create_trip` pins `user_id` from the validated JWT (never tool input); RLS enforces all access; "not found" and "no access" are indistinguishable by design. Sharing/travelers and whole-trip deletion are intentionally out of scope for v1.

Notable corrections made during implementation:
- The design spec's `transportation.type` enum was wrong; used the real DB enum `flight | train | car_service | shuttle | ferry | rental_car`.
- Expense tools target `other_expenses` for all ops (the app's `useBudgetMutations` has a bug pointing update/delete at a nonexistent `expenses` table — not replicated here).
- `create_trip` validates the date range up-front (order, non-empty, ≤366 days) and compensating-deletes on a days-insert failure so no orphan trip is left; all date inputs are calendar-validated.
- `update_trip` cascade deletes `accommodations_days` explicitly before `trip_days` because that FK is `ON DELETE NO ACTION` (verified against the live DB; the traveler junctions cascade automatically).

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint server/` — clean
- [x] `npx vitest run` — 343/343 pass (incl. new pure-helper unit tests: date range/diff, dropped-day content pre-check)
- [x] `node server/build.js` — server bundle builds
- [ ] On-demand: `evals/mcp/writes.eval.ts` lifecycle (create → add → out-of-range error → confirm-shrink → verify) — requires eval-user creds + running evals server
- [ ] Manual: exercise as a Claude.ai custom connector after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)