### PR TITLE
Expose more trip fields to the MCP server

### DIFF
--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -117,24 +117,24 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
         supabase
           .from('accommodations')
           .select(
-            'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
+            'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid',
           )
           .eq('trip_id', trip_id),
         supabase
           .from('transportation')
           .select(
-            'id,type,provider,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency',
+            'id,type,provider,details,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency',
           )
           .eq('trip_id', trip_id)
           .order('start_date'),
         supabase
           .from('day_activities')
-          .select('id,day_id,title,description,start_time,end_time,location_address,cost,currency')
+          .select('id,day_id,title,description,start_time,end_time,location_address,location_phone,location_website,cost,currency,amount_paid,is_paid')
           .eq('trip_id', trip_id),
         supabase
           .from('reservations')
           .select(
-            'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
+            'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,phone_number,website,cost,currency,amount_paid,is_paid',
           )
           .eq('trip_id', trip_id),
       ]);
@@ -192,7 +192,7 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
         supabase.from('reservations').select('cost,currency,amount_paid,is_paid').eq('trip_id', trip_id),
         supabase
           .from('other_expenses')
-          .select('description,cost,currency,amount_paid,is_paid')
+          .select('description,date,cost,currency,amount_paid,is_paid')
           .eq('trip_id', trip_id),
       ]);
 
@@ -230,7 +230,7 @@ function registerWriteTools(
     'create_trip',
     {
       description:
-        'Create a new trip. Generates one day per date from arrival to departure (inclusive) and returns the new trip_id plus the generated day_dates, so you can add items right away without a separate read.',
+        'Create a new trip. Generates one day per date from arrival to departure (inclusive) and returns the new trip_id plus the generated day_dates, so you can add items right away without a separate read. Required: destination, arrival_date, and departure_date — if the traveler has not given specific arrival and departure dates, ask for them rather than inventing dates.',
       inputSchema: {
         destination: z.string().min(1).describe('Trip name / destination, e.g. "Paris, France"'),
         arrival_date: dateField.describe('First day of the trip (YYYY-MM-DD)'),
@@ -299,6 +299,8 @@ function registerWriteTools(
         end_time: timeField.optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
+        is_paid: z.boolean().optional().describe('Whether this item is fully paid'),
         location_address: z.string().optional(),
       },
       annotations: WRITE,
@@ -326,6 +328,8 @@ function registerWriteTools(
         end_time: timeField.optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
+        is_paid: z.boolean().optional().describe('Whether this item is fully paid'),
         location_address: z.string().optional(),
       },
       annotations: WRITE_IDEMPOTENT,
@@ -371,6 +375,8 @@ function registerWriteTools(
         notes: z.string().optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
+        is_paid: z.boolean().optional().describe('Whether this reservation is fully paid'),
       },
       annotations: WRITE,
     },
@@ -399,6 +405,8 @@ function registerWriteTools(
         notes: z.string().optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
+        is_paid: z.boolean().optional().describe('Whether this reservation is fully paid'),
       },
       annotations: WRITE_IDEMPOTENT,
     },
@@ -442,8 +450,11 @@ function registerWriteTools(
         checkout_time: timeField.optional(),
         hotel_phone: z.string().optional(),
         hotel_website: z.string().optional(),
+        hotel_details: z.string().optional().describe('Free-text notes about the stay (room type, booking notes, etc.)'),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
+        is_paid: z.boolean().optional().describe('Whether this stay is fully paid'),
       },
       annotations: WRITE,
     },
@@ -471,8 +482,11 @@ function registerWriteTools(
         checkout_time: timeField.optional(),
         hotel_phone: z.string().optional(),
         hotel_website: z.string().optional(),
+        hotel_details: z.string().optional().describe('Free-text notes about the stay (room type, booking notes, etc.)'),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
+        is_paid: z.boolean().optional().describe('Whether this stay is fully paid'),
       },
       annotations: WRITE_IDEMPOTENT,
     },
@@ -511,6 +525,7 @@ function registerWriteTools(
         type: transportTypeField,
         start_date: dateField,
         provider: z.string().optional(),
+        details: z.string().optional().describe('Free-text notes (terminal, gate, seat, baggage, etc.)'),
         flight_number: z.string().optional(),
         confirmation_number: z.string().optional(),
         departure_location: z.string().optional(),
@@ -542,6 +557,7 @@ function registerWriteTools(
         type: transportTypeField.optional(),
         start_date: dateField.optional(),
         provider: z.string().optional(),
+        details: z.string().optional().describe('Free-text notes (terminal, gate, seat, baggage, etc.)'),
         flight_number: z.string().optional(),
         confirmation_number: z.string().optional(),
         departure_location: z.string().optional(),
@@ -589,6 +605,7 @@ function registerWriteTools(
         description: z.string().min(1),
         cost: z.number().nonnegative(),
         currency: currencyField,
+        date: dateField.optional().describe('Date the expense occurred (YYYY-MM-DD)'),
         amount_paid: z.number().nonnegative().optional(),
         is_paid: z.boolean().optional(),
       },
@@ -613,6 +630,7 @@ function registerWriteTools(
         description: z.string().min(1).optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        date: dateField.optional().describe('Date the expense occurred (YYYY-MM-DD)'),
         amount_paid: z.number().nonnegative().optional(),
         is_paid: z.boolean().optional(),
       },

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -355,6 +355,8 @@ export interface AddActivityInput {
   end_time?: string;
   cost?: number;
   currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
   location_address?: string;
 }
 
@@ -373,9 +375,11 @@ export async function addActivity(supabase: SupabaseClient, input: AddActivityIn
       end_time: input.end_time ?? null,
       cost: input.cost ?? null,
       currency: input.currency ?? null,
+      amount_paid: input.amount_paid ?? null,
+      is_paid: input.is_paid ?? null,
       location_address: input.location_address ?? null,
     })
-    .select('id,day_id,title,description,start_time,end_time,cost,currency,location_address')
+    .select('id,day_id,title,description,start_time,end_time,cost,currency,amount_paid,is_paid,location_address')
     .single();
   if (error || !data) throw new WriteError(`Failed to add activity: ${error?.message ?? 'no row returned'}`);
   return data;
@@ -390,6 +394,8 @@ export interface UpdateActivityInput {
   end_time?: string;
   cost?: number;
   currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
   location_address?: string;
 }
 
@@ -401,6 +407,8 @@ export async function updateActivity(supabase: SupabaseClient, input: UpdateActi
   if (input.end_time !== undefined) updates.end_time = input.end_time;
   if (input.cost !== undefined) updates.cost = input.cost;
   if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
+  if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
   if (input.location_address !== undefined) updates.location_address = input.location_address;
 
   // Changing the date re-resolves day_id (scoped to the activity's own trip).
@@ -423,7 +431,7 @@ export async function updateActivity(supabase: SupabaseClient, input: UpdateActi
     .from('day_activities')
     .update(updates)
     .eq('id', input.activity_id)
-    .select('id,day_id,title,description,start_time,end_time,cost,currency,location_address')
+    .select('id,day_id,title,description,start_time,end_time,cost,currency,amount_paid,is_paid,location_address')
     .maybeSingle();
   if (error) throw new WriteError(`Failed to update activity: ${error.message}`);
   if (!data) throw new WriteError('Activity not found, or you do not have access to it.');
@@ -456,6 +464,8 @@ export interface AddDiningInput {
   notes?: string;
   cost?: number;
   currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
 }
 
 export async function addDining(supabase: SupabaseClient, input: AddDiningInput) {
@@ -475,9 +485,11 @@ export async function addDining(supabase: SupabaseClient, input: AddDiningInput)
       notes: input.notes ?? null,
       cost: input.cost ?? null,
       currency: input.currency ?? null,
+      amount_paid: input.amount_paid ?? null,
+      is_paid: input.is_paid ?? null,
     })
     .select(
-      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
+      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency,amount_paid,is_paid',
     )
     .single();
   if (error || !data) throw new WriteError(`Failed to add dining reservation: ${error?.message ?? 'no row returned'}`);
@@ -495,6 +507,8 @@ export interface UpdateDiningInput {
   notes?: string;
   cost?: number;
   currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
 }
 
 export async function updateDining(supabase: SupabaseClient, input: UpdateDiningInput) {
@@ -507,6 +521,8 @@ export async function updateDining(supabase: SupabaseClient, input: UpdateDining
   if (input.notes !== undefined) updates.notes = input.notes;
   if (input.cost !== undefined) updates.cost = input.cost;
   if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
+  if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
 
   if (input.date !== undefined) {
     const { data: existing, error: exErr } = await supabase
@@ -528,7 +544,7 @@ export async function updateDining(supabase: SupabaseClient, input: UpdateDining
     .update(updates)
     .eq('id', input.reservation_id)
     .select(
-      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency',
+      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency,amount_paid,is_paid',
     )
     .maybeSingle();
   if (error) throw new WriteError(`Failed to update reservation: ${error.message}`);
@@ -590,8 +606,11 @@ export interface AddAccommodationInput {
   checkout_time?: string;
   hotel_phone?: string;
   hotel_website?: string;
+  hotel_details?: string;
   cost?: number;
   currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
 }
 
 export async function addAccommodation(supabase: SupabaseClient, input: AddAccommodationInput) {
@@ -613,11 +632,14 @@ export async function addAccommodation(supabase: SupabaseClient, input: AddAccom
       checkout_time: input.checkout_time ?? null,
       hotel_phone: input.hotel_phone ?? null,
       hotel_website: input.hotel_website ?? null,
+      hotel_details: input.hotel_details ?? null,
       cost: input.cost ?? null,
       currency: input.currency ?? null,
+      amount_paid: input.amount_paid ?? null,
+      is_paid: input.is_paid ?? null,
     })
     .select(
-      'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
+      'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid',
     )
     .single();
   if (error || !data) throw new WriteError(`Failed to add accommodation: ${error?.message ?? 'no row returned'}`);
@@ -642,8 +664,11 @@ export interface UpdateAccommodationInput {
   checkout_time?: string;
   hotel_phone?: string;
   hotel_website?: string;
+  hotel_details?: string;
   cost?: number;
   currency?: string;
+  amount_paid?: number;
+  is_paid?: boolean;
 }
 
 export async function updateAccommodation(supabase: SupabaseClient, input: UpdateAccommodationInput) {
@@ -659,8 +684,11 @@ export async function updateAccommodation(supabase: SupabaseClient, input: Updat
   if (input.checkout_time !== undefined) updates.checkout_time = input.checkout_time;
   if (input.hotel_phone !== undefined) updates.hotel_phone = input.hotel_phone;
   if (input.hotel_website !== undefined) updates.hotel_website = input.hotel_website;
+  if (input.hotel_details !== undefined) updates.hotel_details = input.hotel_details;
   if (input.cost !== undefined) updates.cost = input.cost;
   if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
+  if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
 
   if (Object.keys(updates).length === 0) {
     throw new WriteError('Nothing to update: provide at least one field to change.');
@@ -692,7 +720,7 @@ export async function updateAccommodation(supabase: SupabaseClient, input: Updat
     .update(updates)
     .eq('stay_id', input.stay_id)
     .select(
-      'stay_id,trip_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,cost,currency',
+      'stay_id,trip_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid',
     )
     .maybeSingle();
   if (error) throw new WriteError(`Failed to update accommodation: ${error.message}`);
@@ -754,6 +782,7 @@ export interface AddTransportationInput {
   type: TransportationType;
   start_date: string;
   provider?: string;
+  details?: string;
   flight_number?: string;
   confirmation_number?: string;
   departure_location?: string;
@@ -766,7 +795,7 @@ export interface AddTransportationInput {
 }
 
 const TRANSPORT_SELECT =
-  'id,type,provider,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency';
+  'id,type,provider,details,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency';
 
 export async function addTransportation(supabase: SupabaseClient, input: AddTransportationInput) {
   const { data, error } = await supabase
@@ -776,6 +805,7 @@ export async function addTransportation(supabase: SupabaseClient, input: AddTran
       type: input.type,
       start_date: input.start_date,
       provider: input.provider ?? null,
+      details: input.details ?? null,
       flight_number: input.flight_number ?? null,
       confirmation_number: input.confirmation_number ?? null,
       departure_location: input.departure_location ?? null,
@@ -797,6 +827,7 @@ export interface UpdateTransportationInput {
   type?: TransportationType;
   start_date?: string;
   provider?: string;
+  details?: string;
   flight_number?: string;
   confirmation_number?: string;
   departure_location?: string;
@@ -813,6 +844,7 @@ export async function updateTransportation(supabase: SupabaseClient, input: Upda
   if (input.type !== undefined) updates.type = input.type;
   if (input.start_date !== undefined) updates.start_date = input.start_date;
   if (input.provider !== undefined) updates.provider = input.provider;
+  if (input.details !== undefined) updates.details = input.details;
   if (input.flight_number !== undefined) updates.flight_number = input.flight_number;
   if (input.confirmation_number !== undefined) updates.confirmation_number = input.confirmation_number;
   if (input.departure_location !== undefined) updates.departure_location = input.departure_location;
@@ -853,13 +885,14 @@ export async function deleteTransportation(supabase: SupabaseClient, id: string)
 
 // ---- Other expenses ----
 
-const EXPENSE_SELECT = 'id,description,cost,currency,amount_paid,is_paid';
+const EXPENSE_SELECT = 'id,description,date,cost,currency,amount_paid,is_paid';
 
 export interface AddExpenseInput {
   trip_id: string;
   description: string;
   cost: number;
   currency: string;
+  date?: string;
   amount_paid?: number;
   is_paid?: boolean;
 }
@@ -872,6 +905,7 @@ export async function addExpense(supabase: SupabaseClient, input: AddExpenseInpu
       description: input.description,
       cost: input.cost,
       currency: input.currency,
+      date: input.date ?? null,
       amount_paid: input.amount_paid ?? null,
       is_paid: input.is_paid ?? null,
     })
@@ -886,6 +920,7 @@ export interface UpdateExpenseInput {
   description?: string;
   cost?: number;
   currency?: string;
+  date?: string;
   amount_paid?: number;
   is_paid?: boolean;
 }
@@ -895,6 +930,7 @@ export async function updateExpense(supabase: SupabaseClient, input: UpdateExpen
   if (input.description !== undefined) updates.description = input.description;
   if (input.cost !== undefined) updates.cost = input.cost;
   if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.date !== undefined) updates.date = input.date;
   if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
   if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
 

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -101,7 +101,7 @@ function buildMcpServer(auth: { token: string; userId: string; email: string | n
     { name: 'wanderluxe', version: '0.2.0' },
     {
       instructions:
-        "Tools for reading and managing the user's WanderLuxe trips. Call list_trips first to get trip IDs — they are not guessable. Add items by date (YYYY-MM-DD); the server resolves the matching trip day. Times are 24h HH:MM, local to the destination. To change a trip's dates in a way that would drop days containing items, the update_trip tool will first return the at-risk days for confirmation; re-call it with confirm_remove_days: true to proceed.",
+        "Tools for reading and managing the user's WanderLuxe trips. Call list_trips first to get trip IDs — they are not guessable. Add items by date (YYYY-MM-DD); the server resolves the matching trip day. Times are 24h HH:MM, local to the destination. When a tool's required fields are not established from the conversation, ask the user rather than guessing — especially dates and names. To change a trip's dates in a way that would drop days containing items, the update_trip tool will first return the at-risk days for confirmation; re-call it with confirm_remove_days: true to proceed.",
     },
   );
 


### PR DESCRIPTION
The MCP tool surface only ever read/wrote a hand-listed subset of each
table's columns, so several useful fields the app populates were invisible
to the connector (e.g. transportation.details). Widen the surface for the
high-value, low-risk fields:

- Notes: transportation.details and accommodations.hotel_details (read +
  write). Skipped accommodations.description — it is a dead column the app
  no longer reads or writes.
- Per-item payment: amount_paid / is_paid on accommodations, day_activities,
  and reservations (read in get_trip + write). Previously these only fed the
  aggregate in get_trip_budget and could not be set or seen per item.
- Contact on read: phone_number/website (dining) and
  location_phone/location_website (activities) now returned by get_trip.
- other_expenses.date is now settable via add_expense / update_expense.

Also steer the client model to collect missing required fields instead of
fabricating them: note create_trip's required fields in its description and
add a general "ask, don't guess — especially dates and names" line to the
server instructions.

is_public / hidden remain intentionally unexposed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DgmJcUFjLjThrekCs9631r