### PR TITLE
Fix timezone handling for date-only trip dates

### DIFF
--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -23,6 +23,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { acceptTripShare, getSharedTrips, removeTripShare } from '@/services/tripSharingService';
 import { Share2, EyeOff } from 'lucide-react';
 import { differenceInDays } from 'date-fns';
+import { parseLocal } from '@/utils/dateUtils';
 
 import { ActiveTripCard, NextTripBoardingPass, DefaultHeroCard } from '@/components/trip/hero';
 import { useTravelStats } from '@/hooks/useTravelStats';
@@ -177,21 +178,29 @@ const MyTrips = () => {
 
   // Utility functions to categorize trips
   const getTripCategory = (trip: Trip): 'upcoming' | 'current' | 'past' => {
+    // Compare date-only values in the viewer's local time zone. The stored
+    // arrival/departure values are date-only strings (YYYY-MM-DD); parsing them
+    // with `new Date()` would treat them as UTC midnight and shift the trip a
+    // day in time zones behind UTC, so a current trip would drop off a day
+    // early. parseLocal anchors them to local midnight, making this time-zone
+    // agnostic and inclusive through the end of the departure day.
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const arrivalDate = new Date(trip.arrival_date || '');
-    const departureDate = new Date(trip.departure_date || '');
-    
+    const arrivalDate = parseLocal(trip.arrival_date || '');
+    arrivalDate.setHours(0, 0, 0, 0);
+    const departureDate = parseLocal(trip.departure_date || '');
+    departureDate.setHours(0, 0, 0, 0);
+
     // Current trip: today is between arrival and departure (inclusive)
     if (today >= arrivalDate && today <= departureDate) {
       return 'current';
     }
-    
+
     // Upcoming trip: arrival date is in the future
     if (arrivalDate > today) {
       return 'upcoming';
     }
-    
+
     // Past trip: departure date is in the past
     return 'past';
   };

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -6,9 +6,35 @@ import {
   calculateDurationInDays,
   formatDateRange,
   formatNightsCount,
+  parseLocal,
 } from './dateUtils';
 
 describe('dateUtils', () => {
+  describe('parseLocal', () => {
+    it('parses date-only strings at local midnight (not UTC midnight)', () => {
+      const d = parseLocal('2026-06-22');
+      // Local calendar fields must match the input regardless of time zone.
+      expect(d.getFullYear()).toBe(2026);
+      expect(d.getMonth()).toBe(5); // June (0-indexed)
+      expect(d.getDate()).toBe(22);
+      expect(d.getHours()).toBe(0);
+      expect(d.getMinutes()).toBe(0);
+    });
+
+    it('keeps a trip current through the end of its departure day in local time', () => {
+      // Regression: `new Date("2026-06-22")` parses as UTC midnight, which in
+      // time zones behind UTC falls before local midnight today, dropping a
+      // current trip a day early. parseLocal anchors to local midnight so the
+      // inclusive departure-day comparison holds.
+      const today = new Date('2026-06-22T15:00:00'); // some moment on departure day, local
+      today.setHours(0, 0, 0, 0);
+      const departure = parseLocal('2026-06-22');
+      departure.setHours(0, 0, 0, 0);
+      expect(today <= departure).toBe(true);
+      expect(today >= departure).toBe(true);
+    });
+  });
+
   describe('formatDate', () => {
     it('should format a date string to display format', () => {
       expect(formatDate('2024-01-15')).toBe('Jan 15, 2024');

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -2,7 +2,7 @@
 import { format, parse, parseISO, addDays, startOfDay, differenceInDays } from 'date-fns';
 
 // Parse a date string as local time (avoids UTC shift from `new Date()`)
-const parseLocal = (dateString: string): Date => {
+export const parseLocal = (dateString: string): Date => {
   // Date-only strings like "2024-01-15" → parse as local time
   if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
     return parse(dateString, 'yyyy-MM-dd', new Date());


### PR DESCRIPTION
## Summary
Fixes a timezone bug where trips would drop off a day early in time zones behind UTC. The issue occurred because `new Date("YYYY-MM-DD")` parses date-only strings as UTC midnight, which can fall before local midnight in UTC-behind zones, causing current trips to be incorrectly categorized as past.

## Changes
- **Export `parseLocal` utility** (`src/utils/dateUtils.ts`): Made the existing `parseLocal` function public so it can be used across the codebase. This function parses date-only strings as local midnight instead of UTC midnight.

- **Update trip categorization logic** (`src/pages/MyTrips.tsx`): 
  - Replaced `new Date()` calls with `parseLocal()` when parsing `trip.arrival_date` and `trip.departure_date`
  - Added explicit `.setHours(0, 0, 0, 0)` calls to normalize all date comparisons to midnight
  - Added detailed comments explaining the timezone-agnostic approach and why it's necessary for inclusive departure-day comparisons

- **Add comprehensive test coverage** (`src/utils/dateUtils.test.ts`):
  - Test verifying `parseLocal` correctly parses date-only strings at local midnight
  - Regression test ensuring trips remain current through the end of their departure day in local time, regardless of timezone

## Implementation Details
The fix ensures that date-only comparisons (arrival/departure dates) are always performed in the viewer's local timezone, making the trip categorization logic timezone-agnostic. By anchoring to local midnight rather than UTC midnight, the inclusive date range check (`today >= arrivalDate && today <= departureDate`) now works correctly across all timezones.

https://claude.ai/code/session_01Mv6uBFKrhPEqUQkpwgwvSk