### PR TITLE
fix(ai-assistant): accommodation bulk import 400 (missing NOT NULL columns)

### DIFF
--- a/src/integrations/supabase/types/index.ts
+++ b/src/integrations/supabase/types/index.ts
@@ -1,4 +1,4 @@
-export type { Json } from './database';
+export type { Json, Database } from './database';
 export type { Tables, TablesInsert, TablesUpdate } from './tables';
 export type { Enums } from './enums';
 export type { CompositeTypes } from './composite';

--- a/src/services/bulkImportService.test.ts
+++ b/src/services/bulkImportService.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { insertFn, fromFn } = vi.hoisted(() => {
+  const insertFn = vi.fn().mockResolvedValue({ error: null });
+  const fromFn = vi.fn(() => ({ insert: insertFn }));
+  return { insertFn, fromFn };
+});
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: fromFn } }));
+
+import bulkImportService from './bulkImportService';
+
+const { importAccommodation } = bulkImportService;
+
+describe('importAccommodation', () => {
+  beforeEach(() => {
+    insertFn.mockClear();
+    fromFn.mockClear();
+  });
+
+  it('includes the NOT NULL columns title and order_index in the insert payload', async () => {
+    const result = await importAccommodation('trip-1', {
+      name: 'Hotel Lutetia',
+      check_in_date: '2026-07-01',
+      check_out_date: '2026-07-04',
+    });
+
+    expect(result.success).toBe(true);
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Hotel Lutetia',
+        order_index: 0,
+      })
+    );
+  });
+
+  it('falls back to a non-empty title when the extraction has no name', async () => {
+    await importAccommodation('trip-1', {
+      check_in_date: '2026-07-01',
+      check_out_date: '2026-07-04',
+    });
+
+    const payload = insertFn.mock.calls[0][0];
+    expect(typeof payload.title).toBe('string');
+    expect(payload.title.length).toBeGreaterThan(0);
+  });
+
+  it('sends null instead of empty strings for missing check-in/check-out dates', async () => {
+    await importAccommodation('trip-1', { name: 'Hotel Lutetia' });
+
+    const payload = insertFn.mock.calls[0][0];
+    expect(payload.hotel_checkin_date).toBeNull();
+    expect(payload.hotel_checkout_date).toBeNull();
+  });
+});

--- a/src/services/bulkImportService.ts
+++ b/src/services/bulkImportService.ts
@@ -47,7 +47,7 @@ async function findOrCreateDay(tripId: string, date: string | null, label: strin
   return newDay.day_id;
 }
 
-async function getNextOrderIndex(table: string, dayId: string): Promise<number> {
+async function getNextOrderIndex(table: 'day_activities' | 'reservations', dayId: string): Promise<number> {
   const { data } = await supabase
     .from(table)
     .select('order_index')
@@ -109,11 +109,13 @@ async function importAccommodation(
       .from('accommodations')
       .insert({
         trip_id: tripId,
+        title: strField(fields, 'name') || 'Unnamed Accommodation',
+        order_index: 0,
         hotel: strField(fields, 'name'),
         hotel_details: parts.join(' • '),
         hotel_url: strField(fields, 'website'),
-        hotel_checkin_date: strField(fields, 'check_in_date'),
-        hotel_checkout_date: strField(fields, 'check_out_date'),
+        hotel_checkin_date: strField(fields, 'check_in_date') || null,
+        hotel_checkout_date: strField(fields, 'check_out_date') || null,
         checkin_time: toDbTime(fields.check_in_time as string) || '15:00',
         checkout_time: toDbTime(fields.check_out_time as string) || '11:00',
         cost: costField(fields),


### PR DESCRIPTION
## Summary
- Direct "Import" from the AI-assistant chat OCR flow returned 400 for every accommodation item: the `accommodations` insert in `bulkImportService` omitted `title` and `order_index` (both NOT NULL, no default). The edit-then-finish path worked because `AccommodationDialog` supplies both. Now the import sends `title` (hotel name, fallback "Unnamed Accommodation") and `order_index: 0`.
- Missing check-in/check-out dates now insert as `null` instead of `''`, which Postgres rejects for `date` columns.
- Re-export `Database` from `src/integrations/supabase/types/index.ts`: `client.ts` imports it, and the unexported type (TS2305) left the Supabase client effectively untyped — which is how the missing required columns compiled silently. Note this surfaces pre-existing latent type errors elsewhere under `tsc -p tsconfig.app.json` (backlog grew 365 → 438); nothing new fails at runtime or build.

## Test plan
- [x] New `src/services/bulkImportService.test.ts` (TDD: all three tests observed failing before the fix) covering required columns, title fallback, and null dates
- [x] Full suite green: 446 tests / 43 files
- [x] Touched files clean under `npx tsc --noEmit -p tsconfig.app.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)