### PR TITLE
feat: trip calendar view + v6.0.0 major version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "5.3.1",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "5.3.1",
+      "version": "6.0.0",
       "dependencies": {
         "@anthropic-ai/claude-code": "^2.1.178",
         "@anthropic-ai/sdk": "^0.104.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "5.3.1",
+  "version": "6.0.0",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"NODE_ENV=development npx tsx server/index.ts\"",


### PR DESCRIPTION
## Summary
- New trip calendar view: 3-day default view anchored at trip start (today when mid-trip)
- Time grid starts at 7am with a show-full-day toggle for early-morning items
- Bumps app version 5.3.1 → 6.0.0 for the major release deploy (package.json + lockfile top-level fields; version flows into `__APP_VERSION__` and `dist/version.json` at build time)

## Test plan
- [ ] `npm run build` stamps 6.0.0 into `dist/version.json`
- [ ] Calendar view renders 3-day window by default and toggle reveals full day

🤖 Generated with [Claude Code](https://claude.com/claude-code)