### PR TITLE
feat(mcp): expose trip timezones through MCP read and write tools

### DIFF
--- a/server/lib/mcpTools.test.ts
+++ b/server/lib/mcpTools.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { timezoneField, GET_TRIP_SELECT } from './mcpTools';
+
+describe('timezoneField', () => {
+  it('accepts real IANA zone ids', () => {
+    expect(timezoneField.safeParse('Europe/Paris').success).toBe(true);
+    expect(timezoneField.safeParse('Asia/Tokyo').success).toBe(true);
+  });
+
+  it('rejects strings Intl cannot resolve as a zone', () => {
+    expect(timezoneField.safeParse('Paris').success).toBe(false);
+    expect(timezoneField.safeParse('Not/AZone').success).toBe(false);
+    expect(timezoneField.safeParse('').success).toBe(false);
+  });
+});
+
+describe('GET_TRIP_SELECT', () => {
+  it('exposes timezone metadata on the trip and every timed entity', () => {
+    expect(GET_TRIP_SELECT.trip.split(',')).toContain('timezone');
+    expect(GET_TRIP_SELECT.activities.split(',')).toContain('timezone');
+    expect(GET_TRIP_SELECT.dining.split(',')).toContain('timezone');
+    expect(GET_TRIP_SELECT.accommodations.split(',')).toContain('timezone');
+    expect(GET_TRIP_SELECT.transportation.split(',')).toContain('departure_timezone');
+    expect(GET_TRIP_SELECT.transportation.split(',')).toContain('arrival_timezone');
+  });
+});

--- a/server/lib/mcpTools.ts
+++ b/server/lib/mcpTools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
+import { isValidTimeZone } from '../../src/utils/timezoneLabel';
 import { summarizeCosts } from './budgetSummary';
 import {
   createTrip,
@@ -61,6 +62,27 @@ const timeField = z
 const currencyField = z
   .string()
   .regex(/^[A-Z]{3}$/, 'Use a 3-letter currency code, e.g. EUR');
+export const timezoneField = z
+  .string()
+  .refine(isValidTimeZone, 'Use an IANA timezone id, e.g. "Europe/Paris"');
+
+const ENTITY_TZ_DESCRIPTION =
+  'IANA timezone the times are local to, e.g. "Asia/Tokyo". Only set it when it differs from ' +
+  'the trip default; omit to inherit the trip default, or pass null to clear back to inheriting. ' +
+  'A display label only — times are stored as wall-clock values and never converted.';
+
+/** get_trip column lists. Exported so tests can pin the timezone columns. */
+export const GET_TRIP_SELECT = {
+  trip: 'trip_id,destination,arrival_date,departure_date,budget,timezone',
+  accommodations:
+    'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid,timezone',
+  transportation:
+    'id,type,provider,details,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency,departure_timezone,arrival_timezone',
+  activities:
+    'id,day_id,title,description,start_time,end_time,location_address,location_phone,location_website,cost,currency,amount_paid,is_paid,timezone',
+  dining:
+    'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,phone_number,website,cost,currency,amount_paid,is_paid,timezone',
+} as const;
 
 /**
  * Register every WanderLuxe tool on the given server. `supabase` is the
@@ -81,13 +103,13 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
     'list_trips',
     {
       description:
-        'List the trips the user owns or that are shared with them, newest first. Returns trip_id, destination, dates, and budget.',
+        'List the trips the user owns or that are shared with them, newest first. Returns trip_id, destination, dates, budget, and the trip default timezone.',
       annotations: READ_ONLY,
     },
     async () => {
       const { data, error } = await supabase
         .from('trips')
-        .select('trip_id,destination,arrival_date,departure_date,budget,created_at')
+        .select('trip_id,destination,arrival_date,departure_date,budget,timezone,created_at')
         .order('arrival_date', { ascending: false });
       if (error) return toolError(`Failed to list trips: ${error.message}`);
       return toolResult({ trips: data ?? [] });
@@ -98,7 +120,7 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
     'get_trip',
     {
       description:
-        'Get the full itinerary for one trip: day-by-day activities and dining reservations, plus accommodations and transportation. Use list_trips to find the trip_id.',
+        "Get the full itinerary for one trip: day-by-day activities and dining reservations, plus accommodations and transportation. Use list_trips to find the trip_id. All times are wall-clock values local to each item's timezone field; a null timezone means the trip's default timezone.",
       inputSchema: { trip_id: z.string().uuid().describe('Trip ID from list_trips') },
       annotations: READ_ONLY,
     },
@@ -106,7 +128,7 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
       const [tripRes, daysRes, staysRes, transportRes, activitiesRes, diningRes] = await Promise.all([
         supabase
           .from('trips')
-          .select('trip_id,destination,arrival_date,departure_date,budget')
+          .select(GET_TRIP_SELECT.trip)
           .eq('trip_id', trip_id)
           .maybeSingle(),
         supabase
@@ -116,26 +138,20 @@ function registerReadTools(server: McpServer, supabase: SupabaseClient): void {
           .order('date'),
         supabase
           .from('accommodations')
-          .select(
-            'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid',
-          )
+          .select(GET_TRIP_SELECT.accommodations)
           .eq('trip_id', trip_id),
         supabase
           .from('transportation')
-          .select(
-            'id,type,provider,details,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency',
-          )
+          .select(GET_TRIP_SELECT.transportation)
           .eq('trip_id', trip_id)
           .order('start_date'),
         supabase
           .from('day_activities')
-          .select('id,day_id,title,description,start_time,end_time,location_address,location_phone,location_website,cost,currency,amount_paid,is_paid')
+          .select(GET_TRIP_SELECT.activities)
           .eq('trip_id', trip_id),
         supabase
           .from('reservations')
-          .select(
-            'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,phone_number,website,cost,currency,amount_paid,is_paid',
-          )
+          .select(GET_TRIP_SELECT.dining)
           .eq('trip_id', trip_id),
       ]);
 
@@ -236,6 +252,11 @@ function registerWriteTools(
         arrival_date: dateField.describe('First day of the trip (YYYY-MM-DD)'),
         departure_date: dateField.describe('Last day of the trip (YYYY-MM-DD)'),
         budget: z.number().positive().optional().describe('Total trip budget (optional)'),
+        timezone: timezoneField
+          .optional()
+          .describe(
+            'IANA timezone of the destination, e.g. "Asia/Tokyo" — the default zone trip times are read in. Set it when the destination is known. Label only; times are stored as wall-clock values and never converted.',
+          ),
       },
       annotations: WRITE,
     },
@@ -266,6 +287,12 @@ function registerWriteTools(
         trip_id: z.string().uuid().describe('Trip ID from list_trips'),
         destination: z.string().min(1).optional(),
         budget: z.number().positive().nullable().optional().describe('Set to null to clear the budget'),
+        timezone: timezoneField
+          .nullable()
+          .optional()
+          .describe(
+            'IANA default timezone for the trip, e.g. "Asia/Tokyo". Pass null to clear it (the app then re-resolves it from the destination). Label only; changing it never converts stored times.',
+          ),
         arrival_date: dateField.optional(),
         departure_date: dateField.optional(),
         confirm_remove_days: z
@@ -302,6 +329,7 @@ function registerWriteTools(
         amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
         is_paid: z.boolean().optional().describe('Whether this item is fully paid'),
         location_address: z.string().optional(),
+        timezone: timezoneField.nullable().optional().describe(ENTITY_TZ_DESCRIPTION),
       },
       annotations: WRITE,
     },
@@ -331,6 +359,7 @@ function registerWriteTools(
         amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
         is_paid: z.boolean().optional().describe('Whether this item is fully paid'),
         location_address: z.string().optional(),
+        timezone: timezoneField.nullable().optional().describe(ENTITY_TZ_DESCRIPTION),
       },
       annotations: WRITE_IDEMPOTENT,
     },
@@ -377,6 +406,7 @@ function registerWriteTools(
         currency: currencyField.optional(),
         amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
         is_paid: z.boolean().optional().describe('Whether this reservation is fully paid'),
+        timezone: timezoneField.nullable().optional().describe(ENTITY_TZ_DESCRIPTION),
       },
       annotations: WRITE,
     },
@@ -407,6 +437,7 @@ function registerWriteTools(
         currency: currencyField.optional(),
         amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
         is_paid: z.boolean().optional().describe('Whether this reservation is fully paid'),
+        timezone: timezoneField.nullable().optional().describe(ENTITY_TZ_DESCRIPTION),
       },
       annotations: WRITE_IDEMPOTENT,
     },
@@ -455,6 +486,7 @@ function registerWriteTools(
         currency: currencyField.optional(),
         amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
         is_paid: z.boolean().optional().describe('Whether this stay is fully paid'),
+        timezone: timezoneField.nullable().optional().describe(ENTITY_TZ_DESCRIPTION),
       },
       annotations: WRITE,
     },
@@ -487,6 +519,7 @@ function registerWriteTools(
         currency: currencyField.optional(),
         amount_paid: z.number().nonnegative().optional().describe('Amount already paid, in the same currency as cost'),
         is_paid: z.boolean().optional().describe('Whether this stay is fully paid'),
+        timezone: timezoneField.nullable().optional().describe(ENTITY_TZ_DESCRIPTION),
       },
       annotations: WRITE_IDEMPOTENT,
     },
@@ -535,6 +568,18 @@ function registerWriteTools(
         end_time: timeField.optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        departure_timezone: timezoneField
+          .nullable()
+          .optional()
+          .describe(
+            'IANA timezone the departure date/time are local to, e.g. "America/New_York". Set both zones on cross-timezone legs like international flights. Omit to inherit the trip default. Label only — times are never converted.',
+          ),
+        arrival_timezone: timezoneField
+          .nullable()
+          .optional()
+          .describe(
+            'IANA timezone the arrival date/time are local to, e.g. "Europe/London". Set both zones on cross-timezone legs like international flights. Omit to inherit the trip default. Label only — times are never converted.',
+          ),
       },
       annotations: WRITE,
     },
@@ -567,6 +612,18 @@ function registerWriteTools(
         end_time: timeField.optional(),
         cost: z.number().nonnegative().optional(),
         currency: currencyField.optional(),
+        departure_timezone: timezoneField
+          .nullable()
+          .optional()
+          .describe(
+            'IANA timezone the departure date/time are local to, e.g. "America/New_York". Pass null to clear back to inheriting the trip default. Label only — times are never converted.',
+          ),
+        arrival_timezone: timezoneField
+          .nullable()
+          .optional()
+          .describe(
+            'IANA timezone the arrival date/time are local to, e.g. "Europe/London". Pass null to clear back to inheriting the trip default. Label only — times are never converted.',
+          ),
       },
       annotations: WRITE_IDEMPOTENT,
     },

--- a/server/lib/tripWrites.test.ts
+++ b/server/lib/tripWrites.test.ts
@@ -45,3 +45,204 @@ describe('buildDroppedDayReport', () => {
     expect(report).toHaveLength(2);
   });
 });
+
+// ---- Timezone flow-through (recording fake client) ----
+//
+// These guard the field-wiring bug class this repo has hit before: a new
+// column added to the app but silently dropped by one of these explicit
+// insert/update/select lists.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  addActivity,
+  updateActivity,
+  addDining,
+  updateDining,
+  addAccommodation,
+  updateAccommodation,
+  addTransportation,
+  updateTransportation,
+  createTrip,
+  updateTrip,
+} from './tripWrites';
+
+interface FakeResponse {
+  data?: unknown;
+  error?: { message: string } | null;
+}
+
+interface RecordedCall {
+  table: string;
+  method: string;
+  payload?: unknown;
+  columns?: string;
+}
+
+/**
+ * Chainable, thenable fake of the Supabase client. Each `await` on a chain
+ * consumes the next scripted response for that table; every insert/update/
+ * select call is recorded for assertions.
+ */
+function createFakeSupabase(responses: Record<string, FakeResponse[]>) {
+  const calls: RecordedCall[] = [];
+  const from = (table: string) => {
+    const b: Record<string, unknown> = {};
+    for (const m of ['insert', 'update', 'delete', 'select', 'eq', 'in', 'order', 'limit', 'single', 'maybeSingle']) {
+      b[m] = (arg?: unknown) => {
+        if (m === 'insert' || m === 'update') calls.push({ table, method: m, payload: arg });
+        else if (m === 'select') calls.push({ table, method: m, columns: String(arg) });
+        else if (m === 'delete') calls.push({ table, method: m });
+        return b;
+      };
+    }
+    b.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) => {
+      const queue = responses[table] ?? [];
+      const next = queue.length > 0 ? queue.shift() : {};
+      return Promise.resolve({ data: null, error: null, ...next }).then(resolve, reject);
+    };
+    return b;
+  };
+  return { supabase: { from } as unknown as SupabaseClient, calls };
+}
+
+function lastCall(calls: RecordedCall[], table: string, method: string): RecordedCall | undefined {
+  return calls.filter((c) => c.table === table && c.method === method).at(-1);
+}
+
+describe('timezone flows through write payloads and return selects', () => {
+  it('addActivity persists timezone and selects it back', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      trip_days: [{ data: { day_id: 'day-1' } }],
+      day_activities: [{ data: [] }, { data: { id: 'a1' } }],
+    });
+    await addActivity(supabase, {
+      trip_id: 'trip-1',
+      date: '2026-09-14',
+      title: 'Sushi class',
+      timezone: 'Asia/Tokyo',
+    });
+    expect(lastCall(calls, 'day_activities', 'insert')?.payload).toMatchObject({ timezone: 'Asia/Tokyo' });
+    expect(lastCall(calls, 'day_activities', 'select')?.columns?.split(',')).toContain('timezone');
+  });
+
+  it('updateActivity sets timezone and allows null to re-inherit the trip zone', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      day_activities: [{ data: { id: 'a1' } }],
+    });
+    await updateActivity(supabase, { activity_id: 'a1', timezone: null });
+    expect(lastCall(calls, 'day_activities', 'update')?.payload).toMatchObject({ timezone: null });
+  });
+
+  it('addDining persists timezone and selects it back', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      trip_days: [{ data: { day_id: 'day-1' } }],
+      reservations: [{ data: [] }, { data: { id: 'r1' } }],
+    });
+    await addDining(supabase, {
+      trip_id: 'trip-1',
+      date: '2026-09-14',
+      restaurant_name: 'Le Cinq',
+      timezone: 'Europe/Paris',
+    });
+    expect(lastCall(calls, 'reservations', 'insert')?.payload).toMatchObject({ timezone: 'Europe/Paris' });
+    expect(lastCall(calls, 'reservations', 'select')?.columns?.split(',')).toContain('timezone');
+  });
+
+  it('updateDining passes timezone through', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      reservations: [{ data: { id: 'r1' } }],
+    });
+    await updateDining(supabase, { reservation_id: 'r1', timezone: 'Europe/Paris' });
+    expect(lastCall(calls, 'reservations', 'update')?.payload).toMatchObject({ timezone: 'Europe/Paris' });
+  });
+
+  it('addAccommodation persists timezone and selects it back', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      accommodations: [{ data: [] }, { data: { stay_id: 's1' } }],
+      trip_days: [{ data: [] }],
+    });
+    await addAccommodation(supabase, {
+      trip_id: 'trip-1',
+      hotel: 'Park Hyatt',
+      hotel_checkin_date: '2026-09-14',
+      hotel_checkout_date: '2026-09-16',
+      timezone: 'Asia/Tokyo',
+    });
+    expect(lastCall(calls, 'accommodations', 'insert')?.payload).toMatchObject({ timezone: 'Asia/Tokyo' });
+    expect(lastCall(calls, 'accommodations', 'select')?.columns?.split(',')).toContain('timezone');
+  });
+
+  it('updateAccommodation passes timezone through', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      accommodations: [{ data: { stay_id: 's1', trip_id: 'trip-1' } }],
+    });
+    await updateAccommodation(supabase, { stay_id: 's1', timezone: 'Asia/Tokyo' });
+    expect(lastCall(calls, 'accommodations', 'update')?.payload).toMatchObject({ timezone: 'Asia/Tokyo' });
+  });
+
+  it('addTransportation persists both per-leg zones and selects them back', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      transportation: [{ data: { id: 't1' } }],
+    });
+    await addTransportation(supabase, {
+      trip_id: 'trip-1',
+      type: 'flight',
+      start_date: '2026-09-14',
+      departure_timezone: 'America/New_York',
+      arrival_timezone: 'Europe/London',
+    });
+    expect(lastCall(calls, 'transportation', 'insert')?.payload).toMatchObject({
+      departure_timezone: 'America/New_York',
+      arrival_timezone: 'Europe/London',
+    });
+    const columns = lastCall(calls, 'transportation', 'select')?.columns?.split(',');
+    expect(columns).toContain('departure_timezone');
+    expect(columns).toContain('arrival_timezone');
+  });
+
+  it('updateTransportation passes per-leg zones through, including null', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      transportation: [{ data: { id: 't1' } }],
+    });
+    await updateTransportation(supabase, {
+      id: 't1',
+      departure_timezone: 'Europe/London',
+      arrival_timezone: null,
+    });
+    expect(lastCall(calls, 'transportation', 'update')?.payload).toMatchObject({
+      departure_timezone: 'Europe/London',
+      arrival_timezone: null,
+    });
+  });
+
+  it('createTrip persists the trip default timezone', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      trips: [{ data: { trip_id: 'trip-1' } }],
+      profiles: [{ data: null }],
+      trip_shares: [{}],
+      trip_days: [{}],
+    });
+    await createTrip(
+      supabase,
+      { userId: 'u1', email: 'kevin@wanderluxe.io' },
+      {
+        destination: 'Tokyo, Japan',
+        arrival_date: '2026-09-14',
+        departure_date: '2026-09-16',
+        timezone: 'Asia/Tokyo',
+      },
+    );
+    expect(lastCall(calls, 'trips', 'insert')?.payload).toMatchObject({ timezone: 'Asia/Tokyo' });
+  });
+
+  it('updateTrip applies timezone as a plain field update', async () => {
+    const { supabase, calls } = createFakeSupabase({
+      trips: [
+        { data: { trip_id: 'trip-1', arrival_date: '2026-09-14', departure_date: '2026-09-16' } },
+        {},
+      ],
+    });
+    await updateTrip(supabase, { trip_id: 'trip-1', timezone: 'Asia/Tokyo' });
+    expect(lastCall(calls, 'trips', 'update')?.payload).toMatchObject({ timezone: 'Asia/Tokyo' });
+  });
+});

--- a/server/lib/tripWrites.ts
+++ b/server/lib/tripWrites.ts
@@ -114,6 +114,7 @@ export interface CreateTripInput {
   arrival_date: string;
   departure_date: string;
   budget?: number | null;
+  timezone?: string | null;
 }
 
 export async function createTrip(
@@ -142,6 +143,7 @@ export async function createTrip(
       arrival_date: input.arrival_date,
       departure_date: input.departure_date,
       budget: input.budget ?? null,
+      timezone: input.timezone ?? null,
       is_public: false,
     })
     .select('trip_id')
@@ -212,6 +214,7 @@ export interface UpdateTripInput {
   trip_id: string;
   destination?: string;
   budget?: number | null;
+  timezone?: string | null;
   arrival_date?: string;
   departure_date?: string;
   confirm_remove_days?: boolean;
@@ -248,6 +251,7 @@ export async function updateTrip(
   const fieldUpdates: Record<string, unknown> = {};
   if (input.destination !== undefined) fieldUpdates.destination = input.destination;
   if (input.budget !== undefined) fieldUpdates.budget = input.budget;
+  if (input.timezone !== undefined) fieldUpdates.timezone = input.timezone;
 
   if (!datesChanged) {
     if (Object.keys(fieldUpdates).length > 0) {
@@ -358,6 +362,7 @@ export interface AddActivityInput {
   amount_paid?: number;
   is_paid?: boolean;
   location_address?: string;
+  timezone?: string | null;
 }
 
 export async function addActivity(supabase: SupabaseClient, input: AddActivityInput) {
@@ -378,8 +383,9 @@ export async function addActivity(supabase: SupabaseClient, input: AddActivityIn
       amount_paid: input.amount_paid ?? null,
       is_paid: input.is_paid ?? null,
       location_address: input.location_address ?? null,
+      timezone: input.timezone ?? null,
     })
-    .select('id,day_id,title,description,start_time,end_time,cost,currency,amount_paid,is_paid,location_address')
+    .select('id,day_id,title,description,start_time,end_time,cost,currency,amount_paid,is_paid,location_address,timezone')
     .single();
   if (error || !data) throw new WriteError(`Failed to add activity: ${error?.message ?? 'no row returned'}`);
   return data;
@@ -397,6 +403,7 @@ export interface UpdateActivityInput {
   amount_paid?: number;
   is_paid?: boolean;
   location_address?: string;
+  timezone?: string | null;
 }
 
 export async function updateActivity(supabase: SupabaseClient, input: UpdateActivityInput) {
@@ -410,6 +417,7 @@ export async function updateActivity(supabase: SupabaseClient, input: UpdateActi
   if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
   if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
   if (input.location_address !== undefined) updates.location_address = input.location_address;
+  if (input.timezone !== undefined) updates.timezone = input.timezone;
 
   // Changing the date re-resolves day_id (scoped to the activity's own trip).
   if (input.date !== undefined) {
@@ -431,7 +439,7 @@ export async function updateActivity(supabase: SupabaseClient, input: UpdateActi
     .from('day_activities')
     .update(updates)
     .eq('id', input.activity_id)
-    .select('id,day_id,title,description,start_time,end_time,cost,currency,amount_paid,is_paid,location_address')
+    .select('id,day_id,title,description,start_time,end_time,cost,currency,amount_paid,is_paid,location_address,timezone')
     .maybeSingle();
   if (error) throw new WriteError(`Failed to update activity: ${error.message}`);
   if (!data) throw new WriteError('Activity not found, or you do not have access to it.');
@@ -466,6 +474,7 @@ export interface AddDiningInput {
   currency?: string;
   amount_paid?: number;
   is_paid?: boolean;
+  timezone?: string | null;
 }
 
 export async function addDining(supabase: SupabaseClient, input: AddDiningInput) {
@@ -487,9 +496,10 @@ export async function addDining(supabase: SupabaseClient, input: AddDiningInput)
       currency: input.currency ?? null,
       amount_paid: input.amount_paid ?? null,
       is_paid: input.is_paid ?? null,
+      timezone: input.timezone ?? null,
     })
     .select(
-      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency,amount_paid,is_paid',
+      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency,amount_paid,is_paid,timezone',
     )
     .single();
   if (error || !data) throw new WriteError(`Failed to add dining reservation: ${error?.message ?? 'no row returned'}`);
@@ -509,6 +519,7 @@ export interface UpdateDiningInput {
   currency?: string;
   amount_paid?: number;
   is_paid?: boolean;
+  timezone?: string | null;
 }
 
 export async function updateDining(supabase: SupabaseClient, input: UpdateDiningInput) {
@@ -523,6 +534,7 @@ export async function updateDining(supabase: SupabaseClient, input: UpdateDining
   if (input.currency !== undefined) updates.currency = input.currency;
   if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
   if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
+  if (input.timezone !== undefined) updates.timezone = input.timezone;
 
   if (input.date !== undefined) {
     const { data: existing, error: exErr } = await supabase
@@ -544,7 +556,7 @@ export async function updateDining(supabase: SupabaseClient, input: UpdateDining
     .update(updates)
     .eq('id', input.reservation_id)
     .select(
-      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency,amount_paid,is_paid',
+      'id,day_id,restaurant_name,reservation_time,number_of_people,address,confirmation_number,notes,cost,currency,amount_paid,is_paid,timezone',
     )
     .maybeSingle();
   if (error) throw new WriteError(`Failed to update reservation: ${error.message}`);
@@ -611,6 +623,7 @@ export interface AddAccommodationInput {
   currency?: string;
   amount_paid?: number;
   is_paid?: boolean;
+  timezone?: string | null;
 }
 
 export async function addAccommodation(supabase: SupabaseClient, input: AddAccommodationInput) {
@@ -637,9 +650,10 @@ export async function addAccommodation(supabase: SupabaseClient, input: AddAccom
       currency: input.currency ?? null,
       amount_paid: input.amount_paid ?? null,
       is_paid: input.is_paid ?? null,
+      timezone: input.timezone ?? null,
     })
     .select(
-      'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid',
+      'stay_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid,timezone',
     )
     .single();
   if (error || !data) throw new WriteError(`Failed to add accommodation: ${error?.message ?? 'no row returned'}`);
@@ -669,6 +683,7 @@ export interface UpdateAccommodationInput {
   currency?: string;
   amount_paid?: number;
   is_paid?: boolean;
+  timezone?: string | null;
 }
 
 export async function updateAccommodation(supabase: SupabaseClient, input: UpdateAccommodationInput) {
@@ -689,6 +704,7 @@ export async function updateAccommodation(supabase: SupabaseClient, input: Updat
   if (input.currency !== undefined) updates.currency = input.currency;
   if (input.amount_paid !== undefined) updates.amount_paid = input.amount_paid;
   if (input.is_paid !== undefined) updates.is_paid = input.is_paid;
+  if (input.timezone !== undefined) updates.timezone = input.timezone;
 
   if (Object.keys(updates).length === 0) {
     throw new WriteError('Nothing to update: provide at least one field to change.');
@@ -720,7 +736,7 @@ export async function updateAccommodation(supabase: SupabaseClient, input: Updat
     .update(updates)
     .eq('stay_id', input.stay_id)
     .select(
-      'stay_id,trip_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid',
+      'stay_id,trip_id,hotel,hotel_address,hotel_checkin_date,hotel_checkout_date,checkin_time,checkout_time,hotel_phone,hotel_website,hotel_details,cost,currency,amount_paid,is_paid,timezone',
     )
     .maybeSingle();
   if (error) throw new WriteError(`Failed to update accommodation: ${error.message}`);
@@ -792,10 +808,12 @@ export interface AddTransportationInput {
   end_time?: string;
   cost?: number;
   currency?: string;
+  departure_timezone?: string | null;
+  arrival_timezone?: string | null;
 }
 
 const TRANSPORT_SELECT =
-  'id,type,provider,details,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency';
+  'id,type,provider,details,flight_number,confirmation_number,departure_location,arrival_location,start_date,start_time,end_date,end_time,cost,currency,departure_timezone,arrival_timezone';
 
 export async function addTransportation(supabase: SupabaseClient, input: AddTransportationInput) {
   const { data, error } = await supabase
@@ -815,6 +833,8 @@ export async function addTransportation(supabase: SupabaseClient, input: AddTran
       end_time: input.end_time ?? null,
       cost: input.cost ?? null,
       currency: input.currency ?? null,
+      departure_timezone: input.departure_timezone ?? null,
+      arrival_timezone: input.arrival_timezone ?? null,
     })
     .select(TRANSPORT_SELECT)
     .single();
@@ -837,6 +857,8 @@ export interface UpdateTransportationInput {
   end_time?: string;
   cost?: number;
   currency?: string;
+  departure_timezone?: string | null;
+  arrival_timezone?: string | null;
 }
 
 export async function updateTransportation(supabase: SupabaseClient, input: UpdateTransportationInput) {
@@ -854,6 +876,8 @@ export async function updateTransportation(supabase: SupabaseClient, input: Upda
   if (input.end_time !== undefined) updates.end_time = input.end_time;
   if (input.cost !== undefined) updates.cost = input.cost;
   if (input.currency !== undefined) updates.currency = input.currency;
+  if (input.departure_timezone !== undefined) updates.departure_timezone = input.departure_timezone;
+  if (input.arrival_timezone !== undefined) updates.arrival_timezone = input.arrival_timezone;
 
   if (Object.keys(updates).length === 0) {
     throw new WriteError('Nothing to update: provide at least one field to change.');

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -101,7 +101,7 @@ function buildMcpServer(auth: { token: string; userId: string; email: string | n
     { name: 'wanderluxe', version: '0.2.0' },
     {
       instructions:
-        "Tools for reading and managing the user's WanderLuxe trips. Call list_trips first to get trip IDs — they are not guessable. Add items by date (YYYY-MM-DD); the server resolves the matching trip day. Times are 24h HH:MM, local to the destination. When a tool's required fields are not established from the conversation, ask the user rather than guessing — especially dates and names. To change a trip's dates in a way that would drop days containing items, the update_trip tool will first return the at-risk days for confirmation; re-call it with confirm_remove_days: true to proceed.",
+        "Tools for reading and managing the user's WanderLuxe trips. Call list_trips first to get trip IDs — they are not guessable. Add items by date (YYYY-MM-DD); the server resolves the matching trip day. Times are 24h HH:MM floating wall-clock values — never convert them between zones. Each trip has a default IANA timezone its times are read in; items carry an optional timezone (transportation: departure_timezone/arrival_timezone) that is display metadata only. Set an item's zone only when it differs from the trip default (e.g. a flight landing in another country); omit it to inherit, or pass null to clear an override. When a tool's required fields are not established from the conversation, ask the user rather than guessing — especially dates and names. To change a trip's dates in a way that would drop days containing items, the update_trip tool will first return the at-risk days for confirmation; re-call it with confirm_remove_days: true to proceed.",
     },
   );
 

--- a/src/utils/timezoneLabel.test.ts
+++ b/src/utils/timezoneLabel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { effectiveTz, tzAbbrev, shouldShowBadge, transportTzLabels, getTimezoneOptions } from './timezoneLabel';
+import { effectiveTz, tzAbbrev, shouldShowBadge, transportTzLabels, getTimezoneOptions, isValidTimeZone } from './timezoneLabel';
 
 describe('effectiveTz', () => {
   it('prefers the entity zone', () => {
@@ -80,5 +80,18 @@ describe('getTimezoneOptions', () => {
     expect(zones.length).toBeGreaterThan(10);
     expect(zones).toContain('America/New_York');
     expect(zones).toContain('Europe/London');
+  });
+});
+
+describe('isValidTimeZone', () => {
+  it('accepts real IANA zone ids', () => {
+    expect(isValidTimeZone('America/New_York')).toBe(true);
+    expect(isValidTimeZone('Asia/Tokyo')).toBe(true);
+    expect(isValidTimeZone('UTC')).toBe(true);
+  });
+  it('rejects garbage and city-only names', () => {
+    expect(isValidTimeZone('Tokyo')).toBe(false);
+    expect(isValidTimeZone('Not/AZone')).toBe(false);
+    expect(isValidTimeZone('')).toBe(false);
   });
 });

--- a/src/utils/timezoneLabel.ts
+++ b/src/utils/timezoneLabel.ts
@@ -10,6 +10,17 @@ export function effectiveTz(
   return entityTz ?? tripTz ?? null;
 }
 
+/** Whether `tz` is a timezone id Intl can resolve (IANA ids and their aliases). */
+export function isValidTimeZone(tz: string): boolean {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** DST-correct short zone label (EST vs EDT) evaluated at noon UTC on `onDate`. */
 export function tzAbbrev(tz: string, onDate: string): string {
   if (!tz || !onDate) return '';


### PR DESCRIPTION
## Summary

The trip-timezone feature (#264-era work) wired zone labels into the app UI and iCal feed but left the MCP tool layer timezone-blind. This PR closes that gap:

- **Read tools**: `get_trip` now returns `timezone` on the trip, activities, dining, and accommodations, plus `departure_timezone`/`arrival_timezone` on transportation; `list_trips` includes the trip default zone. Select lists are extracted to an exported `GET_TRIP_SELECT` constant so tests pin the columns.
- **Write tools**: all add/update tools for trip, activity, dining, accommodation, and transportation accept optional IANA zone fields, validated by a new `timezoneField` (guarded `Intl` check via `isValidTimeZone` in `timezoneLabel.ts` — rejects e.g. `"Paris"`). Passing `null` clears an override back to inheriting the trip default. Fields are wired through every `tripWrites.ts` insert payload, update whitelist, and return select.
- **Server instructions**: now state the floating wall-clock model explicitly — times are never converted between zones; the timezone is display metadata, set only when it differs from the trip default (e.g. a flight landing in another country).

## Why

An MCP client reading a Tokyo trip with a flight landing in Sydney previously had no way to know those times were in different zones — and an agent adding that flight had to drop the zone info it already knew. `create_trip` via MCP also never sets a place_id, so MCP-created trips could not get a default zone until opened in the browser; the new `timezone` param on `create_trip` closes that.

## Testing

- 15 new tests (TDD; all watched fail first), including a recording fake Supabase client asserting the tz fields land in the actual DB payloads — guarding this repo's known silently-dropped-field failure mode for new columns
- Full suite 457/458 (one pre-existing `InviteRedeem` load flake, passes in isolation with and without this change); tsc error count unchanged; eslint clean on changed files
- All six timezone columns confirmed present in the live database, so the new selects are deploy-safe
- After deploy: `npm run evals:mcp` exercises the tools end-to-end against the deployed server

🤖 Generated with [Claude Code](https://claude.com/claude-code)