### PR TITLE
feat(calendar): clearer, denser itinerary controls for mobile and desktop

### DIFF
--- a/src/components/trip/ExportPdfButton.tsx
+++ b/src/components/trip/ExportPdfButton.tsx
@@ -9,6 +9,8 @@ import { exportItineraryPdf } from '@/services/pdfmake-export'; // new pdfMake h
 interface ExportPdfButtonProps {
   tripId: string;
   className?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -18,6 +20,8 @@ interface ExportPdfButtonProps {
 const ExportPdfButton: React.FC<ExportPdfButtonProps> = ({
   tripId,
   className,
+  open,
+  onOpenChange,
 }) => {
   /** Called by PdfExportDialog when the user presses “Export PDF” */
   const handleExport = async (options: PdfExportOptions) => {
@@ -29,6 +33,8 @@ const ExportPdfButton: React.FC<ExportPdfButtonProps> = ({
       tripId={tripId}
       className={className}
       onExport={handleExport}
+      open={open}
+      onOpenChange={onOpenChange}
     />
   );
 };

--- a/src/components/trip/PdfExportDialog.tsx
+++ b/src/components/trip/PdfExportDialog.tsx
@@ -20,14 +20,21 @@ interface PdfExportDialogProps {
   tripId: string;
   className?: string;
   onExport: (options: PdfExportOptions) => Promise<void>;
+  /** Controlled open state, so the dialog can also be launched from an overflow menu. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const PdfExportDialog: React.FC<PdfExportDialogProps> = ({
   tripId,
   className,
   onExport,
+  open,
+  onOpenChange,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = open ?? internalOpen;
+  const setIsOpen = onOpenChange ?? setInternalOpen;
   const [isLoading, setIsLoading] = useState(false);
   const [options, setOptions] = useState<PdfExportOptions>({
     showImages: true,
@@ -53,8 +60,8 @@ const PdfExportDialog: React.FC<PdfExportDialogProps> = ({
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className={className}>
-          <FileDown className="mr-1 sm:mr-2 h-3.5 w-3.5 sm:h-4 sm:w-4" />
-          <span className="hidden sm:inline">Export PDF</span>
+          <FileDown className="mr-2 h-4 w-4" />
+          Export PDF
         </Button>
       </DialogTrigger>
       

--- a/src/components/trip/TimelineView.tsx
+++ b/src/components/trip/TimelineView.tsx
@@ -5,7 +5,13 @@ import { supabase } from '@/integrations/supabase/client';
 import TimelineContent from './timeline/TimelineContent';
 import ExportPdfButton from './ExportPdfButton';
 import { Button } from '@/components/ui/button';
-import { CalendarDays, ListTree, CalendarPlus } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { CalendarDays, ListTree, CalendarPlus, FileDown, MoreHorizontal } from 'lucide-react';
 import CalendarSyncSheet from './calendar/CalendarSyncSheet';
 import { toast } from 'sonner';
 import { loadGoogleMapsAPI } from '@/utils/googleMapsLoader';
@@ -53,6 +59,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
   const { transportationData, refreshTransportation } = useTransportationEvents(tripId);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSyncSheetOpen, setIsSyncSheetOpen] = useState(false);
+  const [isPdfExportOpen, setIsPdfExportOpen] = useState(false);
   const [itineraryView, setItineraryView] = useState<'timeline' | 'calendar'>('timeline');
 
   // Fetch weather for the trip destination (only for current/upcoming trips)
@@ -209,32 +216,64 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
             </h2>
             <ViewingStatusAvatars tripId={tripId} />
           </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <div className="inline-flex rounded-md border border-border bg-card p-0.5 mr-1">
+          <div className="flex w-full items-center gap-2 sm:w-auto">
+            <fieldset className="grid flex-1 min-w-0 grid-cols-2 rounded-md border border-border bg-card p-0.5 sm:inline-flex sm:flex-none">
+              <legend className="sr-only">Itinerary view</legend>
               <button
                 type="button"
                 aria-pressed={itineraryView === 'timeline'}
                 onClick={() => setItineraryView('timeline')}
-                className={`flex items-center gap-1 px-2.5 py-1 text-sm rounded-[0.4rem] transition-colors ${itineraryView === 'timeline' ? 'bg-sunset-500 text-white' : 'text-muted-foreground hover:text-foreground'}`}
+                className={`flex min-h-[44px] items-center justify-center gap-1.5 px-3 text-sm rounded-[0.4rem] transition-colors sm:min-h-0 sm:py-1 ${itineraryView === 'timeline' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
               >
-                <ListTree className="h-3.5 w-3.5" /><span className="hidden sm:inline">Timeline</span>
+                <ListTree className="h-3.5 w-3.5" />Timeline
               </button>
               <button
                 type="button"
                 aria-pressed={itineraryView === 'calendar'}
                 onClick={() => setItineraryView('calendar')}
-                className={`flex items-center gap-1 px-2.5 py-1 text-sm rounded-[0.4rem] transition-colors ${itineraryView === 'calendar' ? 'bg-sunset-500 text-white' : 'text-muted-foreground hover:text-foreground'}`}
+                className={`flex min-h-[44px] items-center justify-center gap-1.5 px-3 text-sm rounded-[0.4rem] transition-colors sm:min-h-0 sm:py-1 ${itineraryView === 'calendar' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
               >
-                <CalendarDays className="h-3.5 w-3.5" /><span className="hidden sm:inline">Calendar</span>
+                <CalendarDays className="h-3.5 w-3.5" />Calendar
               </button>
-            </div>
+            </fieldset>
+            {/* Desktop: rare actions stay as labeled buttons. */}
             {canEdit && (
-              <Button variant="outline" size="sm" onClick={() => setIsSyncSheetOpen(true)}>
-                <CalendarPlus className="mr-1 sm:mr-2 h-3.5 w-3.5 sm:h-4 sm:w-4" />
-                <span className="hidden sm:inline">Add to calendar</span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="hidden sm:inline-flex"
+                onClick={() => setIsSyncSheetOpen(true)}
+              >
+                <CalendarPlus className="mr-2 h-4 w-4" />
+                Add to calendar
               </Button>
             )}
-            <ExportPdfButton tripId={tripId} className="" />
+            <ExportPdfButton
+              tripId={tripId}
+              className="hidden sm:inline-flex"
+              open={isPdfExportOpen}
+              onOpenChange={setIsPdfExportOpen}
+            />
+            {/* Mobile: rare actions fold into an overflow menu with full labels. */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="icon" className="h-11 w-11 sm:hidden" aria-label="More actions">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {canEdit && (
+                  <DropdownMenuItem onSelect={() => setIsSyncSheetOpen(true)}>
+                    <CalendarPlus className="mr-2 h-4 w-4" />
+                    Add to calendar
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem onSelect={() => setIsPdfExportOpen(true)}>
+                  <FileDown className="mr-2 h-4 w-4" />
+                  Export PDF
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </header>
 

--- a/src/components/trip/calendar/AddEntityPicker.tsx
+++ b/src/components/trip/calendar/AddEntityPicker.tsx
@@ -26,9 +26,9 @@ const AddEntityPicker: React.FC<AddEntityPickerProps> = ({ open, onOpenChange, o
             key={type}
             type="button"
             onClick={() => onPick(type)}
-            className="flex flex-col items-center gap-2 rounded-card border border-border bg-card p-4 hover:border-sunset-400 transition-colors"
+            className="flex flex-col items-center gap-2 rounded-card border border-border bg-card p-4 hover:bg-accent transition-colors"
           >
-            <Icon className="h-5 w-5 text-sunset-500" />
+            <Icon className="h-5 w-5 text-primary" />
             <span className="text-sm font-medium">{label}</span>
           </button>
         ))}

--- a/src/components/trip/calendar/CalendarToolbar.test.tsx
+++ b/src/components/trip/calendar/CalendarToolbar.test.tsx
@@ -1,15 +1,44 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import CalendarToolbar from './CalendarToolbar';
 
-vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }));
+const mobile = vi.hoisted(() => ({ value: false }));
+vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => mobile.value }));
 
 describe('CalendarToolbar (desktop)', () => {
+  beforeEach(() => { mobile.value = false; });
+
   it('renders the title and switches views', () => {
     const onViewChange = vi.fn();
     render(<CalendarToolbar title="Jun 30 - Jul 6" activeView="timeGridWeek" onViewChange={onViewChange} onPrev={() => {}} onNext={() => {}} onToday={() => {}} />);
     expect(screen.getByText('Jun 30 - Jul 6')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Month' }));
     expect(onViewChange).toHaveBeenCalledWith('dayGridMonth');
+  });
+
+  it('renders the day-window toggle when provided and hides it when null', () => {
+    const onToggle = vi.fn();
+    const { rerender } = render(<CalendarToolbar title="Jun 30" activeView="timeGridWeek" onViewChange={() => {}} onPrev={() => {}} onNext={() => {}} onToday={() => {}} dayWindow={{ expanded: false, onToggle }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Show full day' }));
+    expect(onToggle).toHaveBeenCalled();
+    rerender(<CalendarToolbar title="Jun 30" activeView="timeGridWeek" onViewChange={() => {}} onPrev={() => {}} onNext={() => {}} onToday={() => {}} dayWindow={null} />);
+    expect(screen.queryByRole('button', { name: 'Show full day' })).not.toBeInTheDocument();
+  });
+
+  it('marks the active view with aria-pressed', () => {
+    render(<CalendarToolbar title="Jun 30 - Jul 6" activeView="timeGridWeek" onViewChange={() => {}} onPrev={() => {}} onNext={() => {}} onToday={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Week' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Month' })).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+
+describe('CalendarToolbar (mobile)', () => {
+  beforeEach(() => { mobile.value = true; });
+
+  it('maps the Day segment to the list view', () => {
+    const onViewChange = vi.fn();
+    render(<CalendarToolbar title="Jun 30" activeView="timeGridThreeDay" onViewChange={onViewChange} onPrev={() => {}} onNext={() => {}} onToday={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Day' }));
+    expect(onViewChange).toHaveBeenCalledWith('listDay');
   });
 });

--- a/src/components/trip/calendar/CalendarToolbar.tsx
+++ b/src/components/trip/calendar/CalendarToolbar.tsx
@@ -12,6 +12,8 @@ interface CalendarToolbarProps {
   onPrev: () => void;
   onNext: () => void;
   onToday: () => void;
+  /** Early-morning day-window toggle; null hides it (month/list views, or nothing collapsed). */
+  dayWindow?: { expanded: boolean; onToggle: () => void } | null;
 }
 
 const DESKTOP_VIEWS: { label: string; view: CalendarViewName }[] = [
@@ -28,39 +30,41 @@ const MOBILE_VIEWS: { label: string; view: CalendarViewName }[] = [
   { label: 'Month', view: 'dayGridMonth' },
 ];
 
-const CalendarToolbar: React.FC<CalendarToolbarProps> = ({ title, activeView, onViewChange, onPrev, onNext, onToday }) => {
+const CalendarToolbar: React.FC<CalendarToolbarProps> = ({ title, activeView, onViewChange, onPrev, onNext, onToday, dayWindow }) => {
   const isMobile = useIsMobile();
+  const views = isMobile ? MOBILE_VIEWS : DESKTOP_VIEWS;
   return (
-    <div className="flex items-center justify-between gap-2 flex-wrap">
-      <div className="flex items-center gap-1">
-        <Button variant="ghost" size="icon" aria-label="Previous" onClick={onPrev}><ChevronLeft className="h-4 w-4" /></Button>
-        <Button variant="ghost" size="sm" onClick={onToday}>Today</Button>
-        <Button variant="ghost" size="icon" aria-label="Next" onClick={onNext}><ChevronRight className="h-4 w-4" /></Button>
+    <div className="flex items-center gap-2 flex-wrap">
+      <div className="flex min-w-0 flex-1 items-center gap-1">
+        <Button variant="ghost" size="icon" className="h-11 w-11 sm:h-10 sm:w-10" aria-label="Previous" onClick={onPrev}><ChevronLeft className="h-4 w-4" /></Button>
+        <Button variant="ghost" size="sm" className="min-h-[44px] sm:min-h-0" onClick={onToday}>Today</Button>
+        <Button variant="ghost" size="icon" className="h-11 w-11 sm:h-10 sm:w-10" aria-label="Next" onClick={onNext}><ChevronRight className="h-4 w-4" /></Button>
         <h3 className="font-display text-lg tracking-tight text-foreground ml-1 truncate">{title}</h3>
       </div>
-      {isMobile ? (
-        <select
-          className="h-9 rounded-md border border-input bg-background px-2 text-sm"
-          aria-label="Calendar view"
-          value={activeView}
-          onChange={(e) => onViewChange(e.target.value as CalendarViewName)}
+      {dayWindow && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="min-h-[44px] px-2 text-xs text-muted-foreground sm:min-h-0 sm:h-7"
+          onClick={dayWindow.onToggle}
         >
-          {MOBILE_VIEWS.map((v) => <option key={v.view} value={v.view}>{v.label}</option>)}
-        </select>
-      ) : (
-        <div className="inline-flex rounded-md border border-border bg-card p-0.5">
-          {DESKTOP_VIEWS.map((v) => (
-            <button
-              key={v.view}
-              type="button"
-              onClick={() => onViewChange(v.view)}
-              className={`px-3 py-1 text-sm rounded-[0.4rem] transition-colors ${activeView === v.view ? 'bg-sunset-500 text-white' : 'text-muted-foreground hover:text-foreground'}`}
-            >
-              {v.label}
-            </button>
-          ))}
-        </div>
+          {dayWindow.expanded ? 'Hide early morning' : 'Show full day'}
+        </Button>
       )}
+      <fieldset className="grid w-full min-w-0 grid-cols-4 rounded-md border border-border bg-card p-0.5 sm:inline-flex sm:w-auto">
+        <legend className="sr-only">Calendar view</legend>
+        {views.map((v) => (
+          <button
+            key={v.view}
+            type="button"
+            aria-pressed={activeView === v.view}
+            onClick={() => onViewChange(v.view)}
+            className={`min-h-[44px] px-3 text-sm rounded-[0.4rem] transition-colors sm:min-h-0 sm:py-1 ${activeView === v.view ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            {v.label}
+          </button>
+        ))}
+      </fieldset>
     </div>
   );
 };

--- a/src/components/trip/calendar/TripCalendarView.tsx
+++ b/src/components/trip/calendar/TripCalendarView.tsx
@@ -17,7 +17,6 @@ import AddEntityPicker from './AddEntityPicker';
 import { buildDropPatch, isDateWithinTripRange, type CalendarEntityType } from './eventMapping';
 import { computeSlotMinTime, DEFAULT_SLOT_MIN_TIME } from './slotWindow';
 import { applyDropPatch } from './calendarMutations';
-import { Button } from '@/components/ui/button';
 import ActivityDialog from '@/components/trip/day/activities/ActivityDialog';
 import AccommodationDialog from '@/components/trip/accommodation/AccommodationDialog';
 import TransportationDialog from '@/components/trip/transportation/TransportationDialog';
@@ -139,23 +138,19 @@ const TripCalendarView: React.FC<TripCalendarViewProps> = ({ tripId, tripDates, 
 
   return (
     <div className="wl-calendar space-y-3">
-      <CalendarToolbar title={title} activeView={activeView} onViewChange={changeView} onPrev={() => api()?.prev()} onNext={() => api()?.next()} onToday={() => api()?.today()} />
+      <CalendarToolbar
+        title={title}
+        activeView={activeView}
+        onViewChange={changeView}
+        onPrev={() => api()?.prev()}
+        onNext={() => api()?.next()}
+        onToday={() => api()?.today()}
+        dayWindow={showDayWindowToggle ? { expanded: showFullDay, onToggle: () => setShowFullDay((v) => !v) } : null}
+      />
       {isEmpty && (
         <div className="rounded-card border border-dashed border-border bg-card/60 p-10 text-center">
           <p className="font-display text-xl text-foreground">Your itinerary is empty</p>
           <p className="mt-1 text-sm text-muted-foreground">Tap a day to add your first stop.</p>
-        </div>
-      )}
-      {showDayWindowToggle && (
-        <div className="-mb-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-xs text-muted-foreground"
-            onClick={() => setShowFullDay((v) => !v)}
-          >
-            {showFullDay ? 'Hide early morning' : 'Show full day'}
-          </Button>
         </div>
       )}
       <div className={isEmpty ? 'opacity-40' : ''}>


### PR DESCRIPTION
## Summary
- Restore visible labels on the mobile timeline header: the Timeline/Calendar segmented toggle keeps its text (previously three unlabeled, accessibility-invisible icons), and the rare actions (Add to calendar, Export PDF) fold into a labeled overflow menu on one shared row; desktop keeps inline labeled buttons
- Cut mobile chrome above the calendar from ~300px to ~185px: overflow menu saves the actions row, and the "Show full day" toggle moves into the calendar toolbar's nav row
- One segmented view switcher at both breakpoints (replaces the mobile native select), with aria-pressed states and the mobile Day → list view mapping preserved
- 44px minimum touch targets on all mobile controls (`min-h-[44px] sm:min-h-0`)
- Active segments use Roasted Bronze (`bg-primary`) instead of sunset orange, per the design system's One Citrus Peel Rule; AddEntityPicker accents move to primary/accent tokens
- PdfExportDialog gains optional controlled `open`/`onOpenChange` so the overflow menu and desktop trigger share one dialog instance
- Segmented controls are native `<fieldset>`s with `sr-only` legends (SonarQube S6819)

## Test plan
- [x] `npx vitest run src/components/trip/calendar` — 9 files, 55 tests pass (new coverage: day-window toggle render/hide/callback, aria-pressed active state, mobile Day → listDay mapping)
- [x] `tsc -p tsconfig.app.json` — no errors in touched files
- [ ] Visual pass at 375px and 1280px on the trip timeline page (calendar + timeline views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)