### PR TITLE
fix(booking): unclip Expedia widget on mobile and unbreak advisor CTA when logged out

### DIFF
--- a/src/components/trip/BookingView.test.tsx
+++ b/src/components/trip/BookingView.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BookingView from './BookingView';
+
+const auth = vi.hoisted(() => ({ user: null as { id: string } | null }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: auth.user }) }));
+
+const toast = vi.hoisted(() => vi.fn());
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast }) }));
+
+vi.mock('@/lib/expedia', () => ({
+  EXPEDIA_FALLBACK_URL: 'https://expedia.com/affiliates/wanderluxe_travel/wanderluxe',
+  EXPEDIA_WIDGET_CAMREF: 'test-camref',
+  mountExpediaWidget: vi.fn(() => () => {}),
+  trackExpediaClick: vi.fn(),
+}));
+
+describe('BookingView', () => {
+  let openSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    auth.user = null;
+    toast.mockClear();
+    openSpy = vi.fn();
+    vi.stubGlobal('open', openSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (window as { gtag?: unknown }).gtag;
+  });
+
+  const clickContact = () => {
+    fireEvent.click(screen.getByRole('button', { name: /contact kevin on fora travel/i }));
+  };
+
+  it('opens the Fora Travel profile when logged out', () => {
+    render(<BookingView tripId="trip-1" />);
+    clickContact();
+    expect(openSpy).toHaveBeenCalledWith('https://www.foratravel.com/advisor/kevin-lowe', '_blank');
+    expect(toast).toHaveBeenCalled();
+  });
+
+  it('opens the Fora Travel profile when gtag is unavailable', () => {
+    auth.user = { id: 'user-1' };
+    render(<BookingView tripId="trip-1" />);
+    clickContact();
+    expect(openSpy).toHaveBeenCalledWith('https://www.foratravel.com/advisor/kevin-lowe', '_blank');
+  });
+
+  it('fires the advisor_contact analytics event when logged in', () => {
+    auth.user = { id: 'user-1' };
+    const gtag = vi.fn();
+    (window as { gtag?: unknown }).gtag = gtag;
+    render(<BookingView tripId="trip-1" />);
+    clickContact();
+    expect(gtag).toHaveBeenCalledWith('event', 'advisor_contact', expect.objectContaining({ event_label: 'trip-1' }));
+    expect(openSpy).toHaveBeenCalledWith('https://www.foratravel.com/advisor/kevin-lowe', '_blank');
+  });
+
+  it('keeps both booking cards shrinkable inside the grid (min-w-0)', () => {
+    const { container } = render(<BookingView tripId="trip-1" />);
+    const grid = container.querySelector('.grid');
+    expect(grid).not.toBeNull();
+    const cards = Array.from(grid!.children);
+    expect(cards).toHaveLength(2);
+    for (const card of cards) {
+      expect(card.className).toContain('min-w-0');
+    }
+  });
+});

--- a/src/components/trip/BookingView.tsx
+++ b/src/components/trip/BookingView.tsx
@@ -70,25 +70,21 @@ const BookingView: React.FC<BookingViewProps> = ({ tripId }) => {
   };
 
   const handleContactClick = () => {
-    try {
-      if (user && tripId) {
-        window.gtag('event', 'advisor_contact', {
-          event_category: 'Booking',
-          event_label: tripId,
-          user_id: user.id,
-          value: 1,
-        });
-
-        window.open('https://www.foratravel.com/advisor/kevin-lowe', '_blank');
-
-        toast({
-          title: "Redirecting to Fora Travel",
-          description: "Opening Kevin's profile page for booking assistance",
-        });
-      }
-    } catch (error) {
-      console.error('Error tracking advisor contact:', error);
+    if (user && tripId) {
+      window.gtag?.('event', 'advisor_contact', {
+        event_category: 'Booking',
+        event_label: tripId,
+        user_id: user.id,
+        value: 1,
+      });
     }
+
+    window.open('https://www.foratravel.com/advisor/kevin-lowe', '_blank');
+
+    toast({
+      title: "Redirecting to Fora Travel",
+      description: "Opening Kevin's profile page for booking assistance",
+    });
   };
 
   return (
@@ -104,7 +100,8 @@ const BookingView: React.FC<BookingViewProps> = ({ tripId }) => {
 
       <div className="grid gap-4 sm:gap-6 lg:grid-cols-2">
       {/* Primary: Expedia self-serve booking */}
-      <Card className="flex flex-col p-5 sm:p-6">
+      {/* min-w-0: without it the advisor card's chip rail inflates the shared grid track past the viewport on mobile */}
+      <Card className="flex min-w-0 flex-col p-5 sm:p-6">
         <div className="mb-4 flex items-baseline justify-between gap-3">
           <h3 className="text-lg sm:text-xl font-semibold tracking-tight text-foreground">
             Search Expedia
@@ -146,7 +143,7 @@ const BookingView: React.FC<BookingViewProps> = ({ tripId }) => {
       </Card>
 
       {/* Secondary: Human travel advisor */}
-      <Card className="flex flex-col p-5 sm:p-6">
+      <Card className="flex min-w-0 flex-col p-5 sm:p-6">
         <div className="mb-5 flex items-baseline justify-between gap-3">
           <h3 className="text-lg sm:text-xl font-semibold tracking-tight text-foreground">
             Or speak with an advisor


### PR DESCRIPTION
## Summary
- Add `min-w-0` to the two Booking-tab cards: the advisor card's expertise chip rail propagated its ~407px intrinsic width through the grid items (default `min-width: auto`), inflating the shared grid track past the viewport on phones and clipping the right side of the Expedia widget.
- Make the "Contact Kevin on Fora Travel" button's `window.open` + toast unconditional: they were inside an `if (user && tripId)` guard meant for analytics, so the CTA silently no-oped for logged-out visitors on public trips. An unguarded `window.gtag` call before `window.open` also killed the button for logged-in users without gtag (ad blockers); analytics now uses `window.gtag?.()` and stays gated on `user`.

## Testing
- New `BookingView.test.tsx` (4 tests, written red→green): logged-out open, gtag-unavailable open, analytics event pin, `min-w-0` regression pin.
- Full suite green (450 tests / 43 files); eslint clean; no new `tsc -p tsconfig.app.json` errors.
- Verified live in the browser at 390px (cards fit, widget fully visible, chip rail scrolls) and 1280px (two-column layout unchanged); confirmed the CTA opens the Fora profile in a new tab with the toast while logged out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)