### PR TITLE
feat(assistant): collapse to floating button + full-width calendar with floating overlay

### DIFF
--- a/docs/superpowers/plans/2026-07-16-trip-assistant-collapse.md
+++ b/docs/superpowers/plans/2026-07-16-trip-assistant-collapse.md
@@ -1,0 +1,599 @@
+# Trip Assistant Collapse & Floating Modes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On desktop, collapsing the Trip Assistant folds it into a floating bottom-right button (timeline reclaims full width), and calendar view always gets full page width with the assistant as a floating overlay panel.
+
+**Architecture:** A new `AssistantDock` positioning shell wraps a single always-mounted `AIAssistantPanel` in `TimelineView` and switches its wrapper between three CSS modes (docked column / fixed overlay / hidden + floating button). The panel is never remounted, so panel-local state (streaming, extracted items) survives collapse/expand and view switches. `AIAssistantPanel`'s broken internal collapse state is removed and replaced by an optional `onCollapse` callback prop.
+
+**Tech Stack:** React 19 + TypeScript, Tailwind CSS, Vitest + @testing-library/react, lucide-react icons, Shadcn/ui Button.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-trip-assistant-collapse-design.md`
+
+## Global Constraints
+
+- Desktop-only feature: every new surface is gated `lg+` (`hidden lg:*`); mobile (`AIAssistantDrawer`, bottom nav) untouched.
+- No persistence: `assistantOpen` is `useState(true)`; nothing is written to localStorage.
+- The `AIAssistantPanel` instance must stay mounted across collapse/expand and timeline↔calendar switches (CSS visibility only, never conditional unmount).
+- Floating button/overlay use `z-40` (above page content, below Radix dialogs at z-50).
+- Design system: `rounded-card`, `shadow-warm-lg`/`shadow-warm-xl`, `bg-earth-500` accent — never plain `shadow-*`.
+- Do NOT set `position` via custom utility classes in `index.css` (source-order gotcha); use Tailwind built-ins (`fixed`, `sticky`) directly.
+- Tests run with `npx vitest run <path>` (bun is not on PATH). Do not gate on `npm run type-check` (verifies nothing) or `tsc -p tsconfig.app.json` (pre-existing ~438-error backlog); just don't add new errors in touched files.
+
+---
+
+### Task 1: `AssistantDock` positioning shell
+
+**Files:**
+- Create: `src/components/trip/ai-assistant/AssistantDock.tsx`
+- Test: `src/components/trip/ai-assistant/AssistantDock.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `AssistantDock` default export, props `{ open: boolean; mode: 'docked' | 'overlay'; onOpen: () => void; children: React.ReactNode }`. Task 3 imports it directly from `./ai-assistant/AssistantDock` (intentionally NOT added to the barrel `index.ts`, so Task 3's test can mock the barrel while keeping the real dock).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/trip/ai-assistant/AssistantDock.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssistantDock from './AssistantDock';
+
+describe('AssistantDock', () => {
+  it('renders children in the docked column when open in docked mode', () => {
+    render(
+      <AssistantDock open mode="docked" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    expect(screen.getByTestId('panel')).toBeInTheDocument();
+    const dock = screen.getByTestId('assistant-dock');
+    expect(dock.className).toContain('lg:w-[42%]');
+    expect(dock.className).not.toContain('fixed');
+    expect(screen.queryByRole('button', { name: /open trip assistant/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a fixed bottom-right overlay when open in overlay mode', () => {
+    render(
+      <AssistantDock open mode="overlay" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    const dock = screen.getByTestId('assistant-dock');
+    expect(dock.className).toContain('fixed');
+    expect(dock.className).toContain('z-40');
+    expect(dock.className).not.toContain('lg:w-[42%]');
+  });
+
+  it('hides the wrapper but keeps children mounted when collapsed, and shows the floating button', () => {
+    const onOpen = vi.fn();
+    render(
+      <AssistantDock open={false} mode="docked" onOpen={onOpen}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    // Children stay mounted (state preservation) — only CSS-hidden.
+    expect(screen.getByTestId('panel')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-dock').className).toBe('hidden');
+    const fab = screen.getByRole('button', { name: /open trip assistant/i });
+    fireEvent.click(fab);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the same child DOM node across collapse/expand and mode switches', () => {
+    const { rerender } = render(
+      <AssistantDock open mode="docked" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    const node = screen.getByTestId('panel');
+    rerender(
+      <AssistantDock open={false} mode="docked" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    rerender(
+      <AssistantDock open mode="overlay" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    expect(screen.getByTestId('panel')).toBe(node);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/trip/ai-assistant/AssistantDock.test.tsx`
+Expected: FAIL — cannot resolve `./AssistantDock`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/trip/ai-assistant/AssistantDock.tsx`:
+
+```tsx
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+
+interface AssistantDockProps {
+  open: boolean;
+  mode: 'docked' | 'overlay';
+  onOpen: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Desktop-only (lg+) positioning shell for the Trip Assistant.
+ * Children stay mounted across collapse/expand and mode switches so
+ * panel-local state (streaming, extracted items) survives — visibility
+ * is CSS-only, never a conditional unmount.
+ */
+const AssistantDock: React.FC<AssistantDockProps> = ({ open, mode, onOpen, children }) => {
+  let wrapperClass = 'hidden';
+  if (open) {
+    wrapperClass =
+      mode === 'docked'
+        ? 'hidden lg:block lg:w-[42%] lg:pr-6 lg:pt-6'
+        : 'hidden lg:block fixed bottom-6 right-6 z-40 w-[400px] max-w-[calc(100vw-3rem)]';
+  }
+
+  return (
+    <>
+      <div className={wrapperClass} data-testid="assistant-dock">
+        {mode === 'docked' ? (
+          <div
+            className="sticky"
+            style={{
+              top: 'calc(var(--app-nav-h, 56px) + 0.5rem)',
+              height: 'calc(100dvh - var(--app-nav-h, 56px) - 1rem)',
+            }}
+          >
+            {children}
+          </div>
+        ) : (
+          <div className="h-[min(70vh,640px)] rounded-card shadow-warm-xl">
+            {children}
+          </div>
+        )}
+      </div>
+
+      {!open && (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label="Open Trip Assistant"
+          className="hidden lg:flex fixed bottom-6 right-6 z-40 h-14 w-14 items-center justify-center rounded-full bg-earth-500 text-background shadow-warm-lg transition-transform hover:scale-105"
+        >
+          <Sparkles className="h-6 w-6" />
+        </button>
+      )}
+    </>
+  );
+};
+
+export default AssistantDock;
+```
+
+Notes for the implementer:
+- The sticky `top`/`height` styles are copied verbatim from the current assistant column in `TimelineView.tsx:309-314`; Task 3 deletes them there.
+- Both mode branches render a `<div>` at the same child position, so React updates the element in place and the `children` subtree (the chat panel) keeps its DOM and state.
+- `max-w-[calc(100vw-3rem)]` keeps the overlay inside the viewport on narrow lg screens.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/trip/ai-assistant/AssistantDock.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/trip/ai-assistant/AssistantDock.tsx src/components/trip/ai-assistant/AssistantDock.test.tsx
+git commit -m "feat(assistant): add AssistantDock positioning shell for desktop collapse/overlay modes"
+```
+
+---
+
+### Task 2: `AIAssistantPanel` — replace dead internal collapse with `onCollapse` prop
+
+**Files:**
+- Modify: `src/components/trip/ai-assistant/AIAssistantPanel.tsx`
+- Test: `src/components/trip/ai-assistant/AIAssistantPanel.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `AIAssistantPanelProps` becomes `{ tripId: string; onCollapse?: () => void }`. With `onCollapse` set, the header renders a chevron button (`aria-label="Collapse assistant"`) that calls it; without it, no collapse button renders (this is the `TripDetails.tsx` Chat-tab case — that file needs NO change). Panel content is always rendered.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/trip/ai-assistant/AIAssistantPanel.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AIAssistantPanel from './AIAssistantPanel';
+
+vi.mock('@/hooks/useAIAssistant', () => ({
+  useAIAssistant: () => ({
+    messages: [],
+    isLoading: false,
+    isStreaming: false,
+    streamingContent: '',
+    error: null,
+    usage: undefined,
+    hasMore: false,
+    isLoadingMore: false,
+    isAnonymous: false,
+    historyLoaded: true,
+    sendMessage: vi.fn(),
+    clearThread: vi.fn(),
+    loadMoreMessages: vi.fn(),
+    loadHistory: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useDocumentExtraction', () => ({
+  useDocumentExtraction: () => ({
+    isExtracting: false,
+    extractDocument: vi.fn(),
+    updateItemStatus: vi.fn(),
+    clearExtraction: vi.fn(),
+  }),
+}));
+
+vi.mock('@/services/bulkImportService', () => ({ bulkImportItems: vi.fn() }));
+vi.mock('@/services/placeCardAddService', () => ({
+  addPlaceCardItem: vi.fn(),
+  undoPlaceCardItem: vi.fn(),
+}));
+
+vi.mock('./ChatMessageList', () => ({ default: () => <div data-testid="message-list" /> }));
+vi.mock('./ChatInput', () => ({ default: () => <div data-testid="chat-input" /> }));
+vi.mock('./UsageMeter', () => ({ default: () => null }));
+vi.mock('./PaywallModal', () => ({ default: () => null }));
+vi.mock('./ItemStepperDialog', () => ({ default: () => null }));
+vi.mock('./PromptChips', () => ({ default: () => null }));
+
+const renderPanel = (props: { onCollapse?: () => void } = {}) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AIAssistantPanel tripId="trip-1" {...props} />
+    </QueryClientProvider>
+  );
+};
+
+describe('AIAssistantPanel collapse button', () => {
+  it('renders the collapse button and calls onCollapse when provided', () => {
+    const onCollapse = vi.fn();
+    renderPanel({ onCollapse });
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse assistant' }));
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no collapse button when onCollapse is absent', () => {
+    renderPanel();
+    expect(screen.queryByRole('button', { name: 'Collapse assistant' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Expand assistant' })).not.toBeInTheDocument();
+  });
+
+  it('always renders the chat content (no internal collapsed state)', () => {
+    renderPanel({ onCollapse: vi.fn() });
+    expect(screen.getByTestId('message-list')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-input')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/trip/ai-assistant/AIAssistantPanel.test.tsx`
+Expected: FAIL — first test fails because clicking the current button toggles internal state instead of calling `onCollapse` (the prop doesn't exist yet; TypeScript will also flag the unknown prop).
+
+- [ ] **Step 3: Modify the panel**
+
+In `src/components/trip/ai-assistant/AIAssistantPanel.tsx`:
+
+3a. Update imports (line 2) — drop `ChevronUp`:
+
+```tsx
+import { Sparkles, ChevronDown } from 'lucide-react';
+```
+
+3b. Update the props interface (lines 18-20):
+
+```tsx
+interface AIAssistantPanelProps {
+  tripId: string;
+  /** Renders a collapse button in the header when provided (desktop dock). */
+  onCollapse?: () => void;
+}
+```
+
+3c. Update the component signature (line 54):
+
+```tsx
+const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse }) => {
+```
+
+3d. Delete the internal collapse state (line 58):
+
+```tsx
+// DELETE this line:
+const [isCollapsed, setIsCollapsed] = useState(false);
+```
+
+3e. Replace the header button (lines 298-311) with a conditional collapse button:
+
+```tsx
+{onCollapse && (
+  <Button
+    variant="ghost"
+    size="icon"
+    onClick={onCollapse}
+    className="h-8 w-8 text-muted-foreground hover:text-foreground"
+    title="Collapse"
+    aria-label="Collapse assistant"
+  >
+    <ChevronDown className="w-4 h-4" />
+  </Button>
+)}
+```
+
+3f. Remove the `{!isCollapsed && (` wrapper around the content (line 315) and its closing `)}` (line 366), keeping the fragment `<>...</>` and everything inside it rendered unconditionally. The surrounding structure becomes:
+
+```tsx
+{/* Content — always rendered; visibility is the dock's job */}
+<>
+  {/* Messages area */}
+  <ChatMessageList
+    ...unchanged props...
+  />
+
+  {/* Error display */}
+  {error && ( ...unchanged... )}
+
+  {/* Usage meter */}
+  <UsageMeter ...unchanged props... />
+
+  {/* Input */}
+  <ChatInput ...unchanged props... />
+</>
+```
+
+(Only the `!isCollapsed &&` condition is removed — all child JSX stays byte-identical. The fragment may also be dropped entirely since it's no longer needed; either is fine.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/trip/ai-assistant/AIAssistantPanel.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Verify no other usages break**
+
+Run: `grep -rn "AIAssistantPanel" src --include="*.tsx" | grep -v ai-assistant/`
+Expected: exactly two consumers — `src/pages/TripDetails.tsx` (Chat tab, no `onCollapse`, now correctly shows no dead button) and `src/components/trip/TimelineView.tsx` (updated in Task 3).
+
+Run: `npx vitest run src/components/trip/ai-assistant`
+Expected: PASS (Task 1 + Task 2 suites).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/trip/ai-assistant/AIAssistantPanel.tsx src/components/trip/ai-assistant/AIAssistantPanel.test.tsx
+git commit -m "feat(assistant): replace dead internal collapse with onCollapse prop"
+```
+
+---
+
+### Task 3: `TimelineView` integration — full-width reflow + floating modes
+
+**Files:**
+- Modify: `src/components/trip/TimelineView.tsx`
+- Test: `src/components/trip/TimelineView.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `AssistantDock` (Task 1) via `import AssistantDock from './ai-assistant/AssistantDock'`; `AIAssistantPanel` with `onCollapse` (Task 2).
+- Produces: user-facing behavior; nothing downstream.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/trip/TimelineView.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TimelineView from './TimelineView';
+
+vi.mock('@/hooks/use-timeline-events', () => ({
+  useTimelineEvents: () => ({ events: [], refreshEvents: vi.fn() }),
+}));
+vi.mock('@/hooks/use-trip-days', () => ({
+  useTripDays: () => ({ days: [], refreshDays: vi.fn() }),
+}));
+vi.mock('@/hooks/use-transportation-events', () => ({
+  useTransportationEvents: () => ({ transportationData: [], refreshTransportation: vi.fn() }),
+}));
+vi.mock('@/hooks/useSessionKeepAlive', () => ({ useSessionKeepAlive: vi.fn() }));
+vi.mock('@/hooks/useWeather', () => ({ useWeather: () => ({ data: undefined }) }));
+vi.mock('@/utils/googleMapsLoader', () => ({ loadGoogleMapsAPI: vi.fn() }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: vi.fn() } }));
+vi.mock('./timeline/TimelineContent', () => ({
+  default: () => <div data-testid="timeline-content" />,
+}));
+vi.mock('./timeline/ViewingStatusAvatars', () => ({ default: () => null }));
+vi.mock('./ExportPdfButton', () => ({ default: () => null }));
+vi.mock('./calendar/CalendarSyncSheet', () => ({ default: () => null }));
+vi.mock('./calendar/TripCalendarView', () => ({
+  default: () => <div data-testid="calendar-view" />,
+}));
+// Stub the panel via the barrel; the real AssistantDock (direct import) stays under test.
+vi.mock('./ai-assistant', () => ({
+  AIAssistantPanel: ({ onCollapse }: { onCollapse?: () => void }) => (
+    <button type="button" onClick={onCollapse}>stub-collapse</button>
+  ),
+}));
+
+const tripDates = { arrival_date: '2026-08-01', departure_date: '2026-08-07' };
+
+const renderView = () =>
+  render(<TimelineView tripId="trip-1" tripDates={tripDates} tripDestination="Kyoto" canEdit />);
+
+describe('TimelineView assistant dock', () => {
+  beforeEach(() => {
+    (window as { gtag?: unknown }).gtag = vi.fn();
+  });
+  afterEach(() => {
+    delete (window as { gtag?: unknown }).gtag;
+  });
+
+  it('defaults to open: docked column next to a 58% timeline, no floating button', () => {
+    renderView();
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-[58%]');
+    expect(screen.getByTestId('assistant-dock').className).toContain('lg:w-[42%]');
+    expect(screen.queryByRole('button', { name: /open trip assistant/i })).not.toBeInTheDocument();
+  });
+
+  it('collapse folds the assistant into a floating button and the timeline goes full width', () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'stub-collapse' }));
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-full');
+    expect(screen.getByTestId('itinerary-column').className).not.toContain('lg:w-[58%]');
+    expect(screen.getByTestId('assistant-dock').className).toBe('hidden');
+    expect(screen.getByRole('button', { name: /open trip assistant/i })).toBeInTheDocument();
+  });
+
+  it('the floating button restores the docked panel', () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'stub-collapse' }));
+    fireEvent.click(screen.getByRole('button', { name: /open trip assistant/i }));
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-[58%]');
+    expect(screen.getByTestId('assistant-dock').className).toContain('lg:w-[42%]');
+  });
+
+  it('calendar view is always full width with the assistant as a fixed overlay', async () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
+    expect(await screen.findByTestId('calendar-view')).toBeInTheDocument();
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-full');
+    const dock = screen.getByTestId('assistant-dock');
+    expect(dock.className).toContain('fixed');
+    expect(dock.className).toContain('z-40');
+  });
+
+  it('open state carries across view switches (open in calendar after collapsing + reopening in timeline)', async () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'stub-collapse' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
+    await screen.findByTestId('calendar-view');
+    // still collapsed after the switch
+    expect(screen.getByTestId('assistant-dock').className).toBe('hidden');
+    fireEvent.click(screen.getByRole('button', { name: /open trip assistant/i }));
+    expect(screen.getByTestId('assistant-dock').className).toContain('fixed');
+  });
+});
+```
+
+Note: the exact name `{ name: 'Calendar' }` targets the view toggle; a regex like `/calendar/i` would also match the "Add to calendar" button and make `getByRole` throw.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/trip/TimelineView.test.tsx`
+Expected: FAIL — `itinerary-column` / `assistant-dock` test ids don't exist yet, and there is no collapse wiring.
+
+- [ ] **Step 3: Modify `TimelineView.tsx`**
+
+3a. Add the import (after the existing `./ai-assistant` import on line 20):
+
+```tsx
+import AssistantDock from './ai-assistant/AssistantDock';
+```
+
+3b. Add state next to `itineraryView` (line 63):
+
+```tsx
+const [itineraryView, setItineraryView] = useState<'timeline' | 'calendar'>('timeline');
+// Desktop assistant visibility. Defaults open on every load (deliberately unpersisted).
+const [assistantOpen, setAssistantOpen] = useState(true);
+```
+
+3c. Replace the main column's opening div (line 211):
+
+```tsx
+{/* Itinerary column: full width below lg; from lg+ 58% beside the docked
+    assistant, full width when it's collapsed or floating over the calendar */}
+<div
+  data-testid="itinerary-column"
+  className={`w-full px-0 sm:px-4 md:px-6 pt-4 md:pt-6 space-y-6 ${
+    itineraryView === 'timeline' && assistantOpen ? 'lg:w-[58%]' : 'lg:w-full'
+  }`}
+>
+```
+
+3d. Replace the assistant column block (lines 307-318) — the old wrapper divs and their sticky styles move into `AssistantDock`:
+
+```tsx
+<AssistantDock
+  open={assistantOpen}
+  mode={itineraryView === 'calendar' ? 'overlay' : 'docked'}
+  onOpen={() => setAssistantOpen(true)}
+>
+  <AIAssistantPanel tripId={tripId} onCollapse={() => setAssistantOpen(false)} />
+</AssistantDock>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/trip/TimelineView.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the surrounding suites**
+
+Run: `npx vitest run src/components/trip`
+Expected: PASS — no regressions in calendar/booking/ai-assistant suites.
+
+- [ ] **Step 6: Lint the touched files**
+
+Run: `npx eslint src/components/trip/TimelineView.tsx src/components/trip/ai-assistant/AssistantDock.tsx src/components/trip/ai-assistant/AIAssistantPanel.tsx`
+Expected: no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/trip/TimelineView.tsx src/components/trip/TimelineView.test.tsx
+git commit -m "feat(assistant): collapse to floating button; full-width calendar with floating overlay panel"
+```
+
+---
+
+### Task 4: Visual verification in the running app
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: the complete feature from Tasks 1-3.
+- Produces: confirmation evidence (screenshots) that the CSS modes render correctly — jsdom cannot verify sticky/fixed layering, stacking contexts, or the warm-shadow styling.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev` (background) and wait for `http://localhost:8080` to respond.
+
+- [ ] **Step 2: Verify desktop behaviors with Playwright MCP (viewport ≥ 1280px)**
+
+On a trip's timeline page, check each of:
+1. Default: timeline + docked assistant side by side (as before).
+2. Click the header chevron → panel disappears, timeline stretches full width, round Sparkles button sits bottom-right.
+3. Click the button → docked panel returns.
+4. Switch to Calendar → calendar spans full width; assistant floats bottom-right above it (open by default if not collapsed), collapse works there too.
+5. Open a Radix dialog (e.g. calendar sync) with the overlay open → dialog renders above the overlay.
+6. Chat tab (`/trip/<id>/…` Chat view): no collapse chevron in the header.
+7. Reload the page → assistant is open again (no persistence).
+
+- [ ] **Step 3: Verify mobile is untouched**
+
+Resize to 390px width: no floating button, no overlay; the bottom-nav AI trigger still opens the full-screen drawer.
+
+- [ ] **Step 4: Screenshot evidence**
+
+Capture: collapsed timeline with floating button; calendar with floating overlay panel. Report both to the user.

--- a/docs/superpowers/specs/2026-07-16-trip-assistant-collapse-design.md
+++ b/docs/superpowers/specs/2026-07-16-trip-assistant-collapse-design.md
@@ -1,0 +1,107 @@
+# Trip Assistant Collapse & Floating Modes (Desktop)
+
+**Date:** 2026-07-16
+**Status:** Approved
+**Branch:** feat/trip-calendar-view (or successor)
+
+## Problem
+
+On desktop (`lg+`), the Trip Assistant renders as a sticky 42% column next to the
+timeline (`src/components/trip/TimelineView.tsx`). Its collapse button
+(`AIAssistantPanel.tsx`, internal `isCollapsed` state) only hides the panel's
+internals — the header box and the 42% column remain, so collapsing accomplishes
+nothing visually and the timeline never reclaims the width.
+
+Additionally, the calendar itinerary view renders inside the 58% timeline column,
+cramping a layout that wants the full page width.
+
+## Decisions (user-confirmed)
+
+1. **Collapse → floating button.** Collapsing the assistant folds it into a
+   floating round button fixed at the bottom-right of the viewport. Clicking the
+   button expands the assistant back to its current-mode surface.
+2. **Calendar view = full width + floating overlay panel.** In calendar view the
+   main column always spans the full width. The open assistant floats above the
+   calendar bottom-right as an Intercom-style overlay panel with the full chat UI
+   (not a slim input bar, not a docked column).
+3. **No persistence.** `assistantOpen` defaults to `true` on every page load.
+   Collapsing lasts only for the current visit; nothing is written to
+   localStorage.
+
+## Design
+
+### State
+
+- `TimelineView` owns `assistantOpen: boolean` (useState, default `true`).
+- One flag carries across itinerary view switches: open in timeline → open
+  (floating) in calendar, collapsed stays collapsed.
+- `AIAssistantPanel`'s internal `isCollapsed` state and its expand/collapse
+  branch are **removed**.
+- `AIAssistantPanel` gains an optional prop `onCollapse?: () => void`:
+  - Provided → header shows the chevron-down button which calls it.
+  - Absent → the header button is not rendered. This applies to the Chat tab in
+    `TripDetails.tsx`, where collapsing is meaningless (fixes the same
+    dead-collapse behavior there).
+
+### Rendering strategy: single mounted panel, CSS-repositioned
+
+The panel holds local state that must survive collapse/expand and view switches:
+in-flight streaming (`useAIAssistant`) and `extractionMessages` (document
+extraction results exist only in component state). Therefore the panel is
+mounted **once** in `TimelineView` inside a single wrapper element whose classes
+switch by mode — never remounted in a different DOM position:
+
+| Mode | Wrapper styling |
+| --- | --- |
+| Timeline + open | Current behavior: `lg:block lg:w-[42%]` column, sticky, `top/height` from `--app-nav-h` (unchanged) |
+| Calendar + open | `fixed` overlay bottom-right: `bottom-6 right-6 w-[400px] h-[min(70vh,640px)] z-40`, same card chrome (`rounded-card shadow-warm-*`) |
+| Collapsed (either view) | Wrapper `hidden`; floating button rendered |
+
+The wrapper stays the same React element so the subtree is preserved.
+The whole feature is `lg+` only — below `lg` the wrapper remains hidden and the
+existing mobile `AIAssistantDrawer` + bottom-nav trigger are untouched.
+
+### Main column width
+
+- Timeline view: `lg:w-[58%]` when `assistantOpen`, `lg:w-full` when collapsed.
+- Calendar view: always `lg:w-full` (assistant never occupies layout space).
+
+### Floating button
+
+- 56px (`h-14 w-14`) round button, Sparkles icon, warm accent background
+  (earth/sunset per design system), `shadow-warm-lg`, subtle hover scale.
+- `fixed bottom-6 right-6 z-40`, `hidden lg:flex` so it never collides with the
+  mobile bottom nav.
+- `aria-label="Open Trip Assistant"`; click sets `assistantOpen = true`.
+- Rendered only when `assistantOpen === false` (both itinerary views).
+
+### Z-index / stacking
+
+Overlay panel and button sit at `z-40` — above page content, below modals and
+dialogs (Radix portals). Verify no clash with the sticky app nav.
+
+## Error handling
+
+No new failure surface: chat/extraction error handling stays inside
+`AIAssistantPanel`. Collapse during streaming is allowed (state survives because
+the panel stays mounted); the mobile drawer's block-close-while-streaming
+behavior is unchanged.
+
+## Testing
+
+Extend existing component tests (Vitest):
+
+- Chevron collapse hides the panel and shows the floating button; clicking the
+  button restores the panel.
+- Timeline column drops the width cap when collapsed.
+- Calendar view renders the main column full width, with the panel as a fixed
+  overlay when open.
+- `AIAssistantPanel` without `onCollapse` renders no header collapse button.
+- Panel-local state survives a collapse/expand cycle (same instance assertion or
+  state-preservation test).
+
+## Out of scope
+
+- Mobile behavior (`AIAssistantDrawer`, bottom nav) — unchanged.
+- Persistence of open state — explicitly rejected.
+- Unread-message badge on the floating button — possible follow-up.

--- a/src/components/trip/TimelineView.test.tsx
+++ b/src/components/trip/TimelineView.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TimelineView from './TimelineView';
+
+vi.mock('@/hooks/use-timeline-events', () => ({
+  useTimelineEvents: () => ({ events: [], refreshEvents: vi.fn() }),
+}));
+vi.mock('@/hooks/use-trip-days', () => ({
+  useTripDays: () => ({ days: [], refreshDays: vi.fn() }),
+}));
+vi.mock('@/hooks/use-transportation-events', () => ({
+  useTransportationEvents: () => ({ transportationData: [], refreshTransportation: vi.fn() }),
+}));
+vi.mock('@/hooks/useSessionKeepAlive', () => ({ useSessionKeepAlive: vi.fn() }));
+vi.mock('@/hooks/useWeather', () => ({ useWeather: () => ({ data: undefined }) }));
+vi.mock('@/utils/googleMapsLoader', () => ({ loadGoogleMapsAPI: vi.fn() }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: vi.fn() } }));
+vi.mock('./timeline/TimelineContent', () => ({
+  default: () => <div data-testid="timeline-content" />,
+}));
+vi.mock('./timeline/ViewingStatusAvatars', () => ({ default: () => null }));
+vi.mock('./ExportPdfButton', () => ({ default: () => null }));
+vi.mock('./calendar/CalendarSyncSheet', () => ({ default: () => null }));
+vi.mock('./calendar/TripCalendarView', () => ({
+  default: () => <div data-testid="calendar-view" />,
+}));
+// Stub the panel via the barrel; the real AssistantDock (direct import) stays under test.
+vi.mock('./ai-assistant', () => ({
+  AIAssistantPanel: ({ onCollapse }: { onCollapse?: () => void }) => (
+    <button type="button" onClick={onCollapse}>stub-collapse</button>
+  ),
+}));
+
+const tripDates = { arrival_date: '2026-08-01', departure_date: '2026-08-07' };
+
+const renderView = () =>
+  render(<TimelineView tripId="trip-1" tripDates={tripDates} tripDestination="Kyoto" canEdit />);
+
+describe('TimelineView assistant dock', () => {
+  beforeEach(() => {
+    (window as { gtag?: unknown }).gtag = vi.fn();
+  });
+  afterEach(() => {
+    delete (window as { gtag?: unknown }).gtag;
+  });
+
+  it('defaults to open: docked column next to a 58% timeline, no floating button', () => {
+    renderView();
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-[58%]');
+    expect(screen.getByTestId('assistant-dock').className).toContain('lg:w-[42%]');
+    expect(screen.queryByRole('button', { name: /open trip assistant/i })).not.toBeInTheDocument();
+  });
+
+  it('collapse folds the assistant into a floating button and the timeline goes full width', () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'stub-collapse' }));
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-full');
+    expect(screen.getByTestId('itinerary-column').className).not.toContain('lg:w-[58%]');
+    expect(screen.getByTestId('assistant-dock').className).toBe('hidden');
+    expect(screen.getByRole('button', { name: /open trip assistant/i })).toBeInTheDocument();
+  });
+
+  it('the floating button restores the docked panel', () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'stub-collapse' }));
+    fireEvent.click(screen.getByRole('button', { name: /open trip assistant/i }));
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-[58%]');
+    expect(screen.getByTestId('assistant-dock').className).toContain('lg:w-[42%]');
+  });
+
+  it('calendar view is always full width with the assistant as a fixed overlay', async () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
+    expect(await screen.findByTestId('calendar-view')).toBeInTheDocument();
+    expect(screen.getByTestId('itinerary-column').className).toContain('lg:w-full');
+    const dock = screen.getByTestId('assistant-dock');
+    expect(dock.className).toContain('fixed');
+    expect(dock.className).toContain('z-40');
+  });
+
+  it('open state carries across view switches (open in calendar after collapsing + reopening in timeline)', async () => {
+    renderView();
+    fireEvent.click(screen.getByRole('button', { name: 'stub-collapse' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
+    await screen.findByTestId('calendar-view');
+    // still collapsed after the switch
+    expect(screen.getByTestId('assistant-dock').className).toBe('hidden');
+    fireEvent.click(screen.getByRole('button', { name: /open trip assistant/i }));
+    expect(screen.getByTestId('assistant-dock').className).toContain('fixed');
+  });
+});

--- a/src/components/trip/TimelineView.tsx
+++ b/src/components/trip/TimelineView.tsx
@@ -18,6 +18,7 @@ import { loadGoogleMapsAPI } from '@/utils/googleMapsLoader';
 import { useTransportationEvents } from '@/hooks/use-transportation-events';
 import { useSessionKeepAlive } from '@/hooks/useSessionKeepAlive';
 import { AIAssistantPanel } from './ai-assistant';
+import AssistantDock from './ai-assistant/AssistantDock';
 import { useWeather } from '@/hooks/useWeather';
 import ViewingStatusAvatars from './timeline/ViewingStatusAvatars';
 
@@ -61,6 +62,8 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
   const [isSyncSheetOpen, setIsSyncSheetOpen] = useState(false);
   const [isPdfExportOpen, setIsPdfExportOpen] = useState(false);
   const [itineraryView, setItineraryView] = useState<'timeline' | 'calendar'>('timeline');
+  // Desktop assistant visibility. Defaults open on every load (deliberately unpersisted).
+  const [assistantOpen, setAssistantOpen] = useState(true);
 
   // Fetch weather for the trip destination (only for current/upcoming trips)
   // Prefer primary_destination if available, fallback to trip name
@@ -207,8 +210,14 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
         <div className="absolute inset-0 bg-background/40 z-20" aria-hidden="true" />
       )}
 
-      {/* Timeline column: full width below lg, 58% from lg+ */}
-      <div className="w-full lg:w-[58%] px-0 sm:px-4 md:px-6 pt-4 md:pt-6 space-y-6">
+      {/* Itinerary column: full width below lg; from lg+ 58% beside the docked
+          assistant, full width when it's collapsed or floating over the calendar */}
+      <div
+        data-testid="itinerary-column"
+        className={`w-full px-0 sm:px-4 md:px-6 pt-4 md:pt-6 space-y-6 ${
+          itineraryView === 'timeline' && assistantOpen ? 'lg:w-[58%]' : 'lg:w-full'
+        }`}
+      >
         <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
           <div className="flex items-center gap-4 min-w-0">
             <h2 className="font-display text-2xl tracking-tight text-foreground shrink-0">
@@ -304,18 +313,13 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
         )}
       </div>
 
-      {/* AI Assistant column: hidden below lg; sticky bottom-anchored from lg+ */}
-      <div className="hidden lg:block lg:w-[42%] lg:pr-6 lg:pt-6">
-        <div
-          className="sticky"
-          style={{
-            top: 'calc(var(--app-nav-h, 56px) + 0.5rem)',
-            height: 'calc(100dvh - var(--app-nav-h, 56px) - 1rem)',
-          }}
-        >
-          <AIAssistantPanel tripId={tripId} />
-        </div>
-      </div>
+      <AssistantDock
+        open={assistantOpen}
+        mode={itineraryView === 'calendar' ? 'overlay' : 'docked'}
+        onOpen={() => setAssistantOpen(true)}
+      >
+        <AIAssistantPanel tripId={tripId} onCollapse={() => setAssistantOpen(false)} />
+      </AssistantDock>
     </div>
   );
 };

--- a/src/components/trip/ai-assistant/AIAssistantPanel.test.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AIAssistantPanel from './AIAssistantPanel';
+
+vi.mock('@/hooks/useAIAssistant', () => ({
+  useAIAssistant: () => ({
+    messages: [],
+    isLoading: false,
+    isStreaming: false,
+    streamingContent: '',
+    error: null,
+    usage: undefined,
+    hasMore: false,
+    isLoadingMore: false,
+    isAnonymous: false,
+    historyLoaded: true,
+    sendMessage: vi.fn(),
+    clearThread: vi.fn(),
+    loadMoreMessages: vi.fn(),
+    loadHistory: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useDocumentExtraction', () => ({
+  useDocumentExtraction: () => ({
+    isExtracting: false,
+    extractDocument: vi.fn(),
+    updateItemStatus: vi.fn(),
+    clearExtraction: vi.fn(),
+  }),
+}));
+
+vi.mock('@/services/bulkImportService', () => ({ bulkImportItems: vi.fn() }));
+vi.mock('@/services/placeCardAddService', () => ({
+  addPlaceCardItem: vi.fn(),
+  undoPlaceCardItem: vi.fn(),
+}));
+
+vi.mock('./ChatMessageList', () => ({ default: () => <div data-testid="message-list" /> }));
+vi.mock('./ChatInput', () => ({ default: () => <div data-testid="chat-input" /> }));
+vi.mock('./UsageMeter', () => ({ default: () => null }));
+vi.mock('./PaywallModal', () => ({ default: () => null }));
+vi.mock('./ItemStepperDialog', () => ({ default: () => null }));
+vi.mock('./PromptChips', () => ({ default: () => null }));
+
+const renderPanel = (props: { onCollapse?: () => void } = {}) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AIAssistantPanel tripId="trip-1" {...props} />
+    </QueryClientProvider>
+  );
+};
+
+describe('AIAssistantPanel collapse button', () => {
+  it('renders the collapse button and calls onCollapse when provided', () => {
+    const onCollapse = vi.fn();
+    renderPanel({ onCollapse });
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse assistant' }));
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no collapse button when onCollapse is absent', () => {
+    renderPanel();
+    expect(screen.queryByRole('button', { name: 'Collapse assistant' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Expand assistant' })).not.toBeInTheDocument();
+  });
+
+  it('always renders the chat content (no internal collapsed state)', () => {
+    renderPanel({ onCollapse: vi.fn() });
+    expect(screen.getByTestId('message-list')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-input')).toBeInTheDocument();
+  });
+});

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
+import { Sparkles, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -17,6 +17,8 @@ import type { AIUsageInfo, AIChatMessage, ChatFileAttachment, ExtractedItem, Pla
 
 interface AIAssistantPanelProps {
   tripId: string;
+  /** Renders a collapse button in the header when provided (desktop dock). */
+  onCollapse?: () => void;
 }
 
 function markItemsCreated(
@@ -51,11 +53,10 @@ function applyItemStatusUpdate(
   });
 }
 
-const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
+const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse }) => {
   const queryClient = useQueryClient();
   const [showPaywall, setShowPaywall] = useState(false);
   const [paywallUsage, setPaywallUsage] = useState<AIUsageInfo | undefined>();
-  const [isCollapsed, setIsCollapsed] = useState(false);
 
   // Extraction state
   const [extractionMessages, setExtractionMessages] = useState<AIChatMessage[]>([]);
@@ -295,26 +296,23 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
             </div>
           </div>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setIsCollapsed(!isCollapsed)}
-            className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            title={isCollapsed ? 'Expand' : 'Collapse'}
-            aria-label={isCollapsed ? 'Expand assistant' : 'Collapse assistant'}
-          >
-            {isCollapsed ? (
-              <ChevronUp className="w-4 h-4" />
-            ) : (
+          {onCollapse && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onCollapse}
+              className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              title="Collapse"
+              aria-label="Collapse assistant"
+            >
               <ChevronDown className="w-4 h-4" />
-            )}
-          </Button>
+            </Button>
+          )}
         </div>
 
-        {/* Collapsible content */}
-        {!isCollapsed && (
-          <>
-            {/* Messages area */}
+        {/* Content — always rendered; visibility is the dock's job */}
+        <>
+          {/* Messages area */}
             <ChatMessageList
               messages={allMessages}
               isLoading={isLoading || isExtracting}
@@ -362,8 +360,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId }) => {
                   : "Ask about your trip or attach a booking..."
               }
             />
-          </>
-        )}
+        </>
       </div>
 
       {/* Paywall modal */}

--- a/src/components/trip/ai-assistant/AssistantDock.test.tsx
+++ b/src/components/trip/ai-assistant/AssistantDock.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssistantDock from './AssistantDock';
+
+describe('AssistantDock', () => {
+  it('renders children in the docked column when open in docked mode', () => {
+    render(
+      <AssistantDock open mode="docked" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    expect(screen.getByTestId('panel')).toBeInTheDocument();
+    const dock = screen.getByTestId('assistant-dock');
+    expect(dock.className).toContain('lg:w-[42%]');
+    expect(dock.className).not.toContain('fixed');
+    expect(screen.queryByRole('button', { name: /open trip assistant/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a fixed bottom-right overlay when open in overlay mode', () => {
+    render(
+      <AssistantDock open mode="overlay" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    const dock = screen.getByTestId('assistant-dock');
+    expect(dock.className).toContain('fixed');
+    expect(dock.className).toContain('z-40');
+    expect(dock.className).not.toContain('lg:w-[42%]');
+  });
+
+  it('hides the wrapper but keeps children mounted when collapsed, and shows the floating button', () => {
+    const onOpen = vi.fn();
+    render(
+      <AssistantDock open={false} mode="docked" onOpen={onOpen}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    // Children stay mounted (state preservation) — only CSS-hidden.
+    expect(screen.getByTestId('panel')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-dock').className).toBe('hidden');
+    const fab = screen.getByRole('button', { name: /open trip assistant/i });
+    fireEvent.click(fab);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the same child DOM node across collapse/expand and mode switches', () => {
+    const { rerender } = render(
+      <AssistantDock open mode="docked" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    const node = screen.getByTestId('panel');
+    rerender(
+      <AssistantDock open={false} mode="docked" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    rerender(
+      <AssistantDock open mode="overlay" onOpen={() => {}}>
+        <div data-testid="panel" />
+      </AssistantDock>
+    );
+    expect(screen.getByTestId('panel')).toBe(node);
+  });
+});

--- a/src/components/trip/ai-assistant/AssistantDock.tsx
+++ b/src/components/trip/ai-assistant/AssistantDock.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+
+interface AssistantDockProps {
+  open: boolean;
+  mode: 'docked' | 'overlay';
+  onOpen: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Desktop-only (lg+) positioning shell for the Trip Assistant.
+ * Children stay mounted across collapse/expand and mode switches so
+ * panel-local state (streaming, extracted items) survives — visibility
+ * is CSS-only, never a conditional unmount.
+ */
+const AssistantDock: React.FC<AssistantDockProps> = ({ open, mode, onOpen, children }) => {
+  let wrapperClass = 'hidden';
+  if (open) {
+    wrapperClass =
+      mode === 'docked'
+        ? 'hidden lg:block lg:w-[42%] lg:pr-6 lg:pt-6'
+        : 'hidden lg:block fixed bottom-6 right-6 z-40 w-[400px] max-w-[calc(100vw-3rem)]';
+  }
+
+  return (
+    <>
+      <div className={wrapperClass} data-testid="assistant-dock">
+        {mode === 'docked' ? (
+          <div
+            className="sticky"
+            style={{
+              top: 'calc(var(--app-nav-h, 56px) + 0.5rem)',
+              height: 'calc(100dvh - var(--app-nav-h, 56px) - 1rem)',
+            }}
+          >
+            {children}
+          </div>
+        ) : (
+          <div className="h-[min(70vh,640px)] rounded-card shadow-warm-xl">
+            {children}
+          </div>
+        )}
+      </div>
+
+      {!open && (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label="Open Trip Assistant"
+          className="hidden lg:flex fixed bottom-6 right-6 z-40 h-14 w-14 items-center justify-center rounded-full bg-earth-500 text-background shadow-warm-lg transition-transform hover:scale-105"
+        >
+          <Sparkles className="h-6 w-6" />
+        </button>
+      )}
+    </>
+  );
+};
+
+export default AssistantDock;

--- a/src/components/trip/calendar/CalendarEventChip.test.tsx
+++ b/src/components/trip/calendar/CalendarEventChip.test.tsx
@@ -21,4 +21,23 @@ describe('CalendarEventChip', () => {
     expect(screen.getByText('Louvre')).toBeInTheDocument();
     expect(screen.getByTestId('chip-icon-activity')).toBeInTheDocument();
   });
+
+  it('stacks title over time for long timegrid events', () => {
+    const arg = {
+      ...makeArg({ end: new Date(2026, 5, 30, 16, 0) }),
+      view: { type: 'timeGridWeek' },
+    } as unknown as import('@fullcalendar/core').EventContentArg;
+    const { container } = render(<CalendarEventChip arg={arg} />);
+    expect(container.firstElementChild).toHaveClass('flex-col');
+    expect(screen.getByText('2:30pm')).toBeInTheDocument();
+  });
+
+  it('keeps the single-row layout for short timegrid events', () => {
+    const arg = {
+      ...makeArg({ end: new Date(2026, 5, 30, 15, 0) }),
+      view: { type: 'timeGridWeek' },
+    } as unknown as import('@fullcalendar/core').EventContentArg;
+    const { container } = render(<CalendarEventChip arg={arg} />);
+    expect(container.firstElementChild).not.toHaveClass('flex-col');
+  });
 });

--- a/src/components/trip/calendar/CalendarEventChip.tsx
+++ b/src/components/trip/calendar/CalendarEventChip.tsx
@@ -10,16 +10,36 @@ const ICONS: Record<CalendarEntityType, React.ComponentType<{ className?: string
   transportation: Plane,
 };
 
+/** Timed timegrid events at least this tall get the stacked (title over time) layout. */
+const STACK_MIN_MINUTES = 45;
+
 const CalendarEventChip: React.FC<{ arg: EventContentArg }> = ({ arg }) => {
   const { entityType, tzBadge } = arg.event.extendedProps as { entityType: CalendarEntityType; tzBadge?: string };
   const Icon = ICONS[entityType] ?? MapPin;
+  const isTimeGrid = Boolean(arg.view?.type?.startsWith('timeGrid'));
+  // Month cells and list rows already show time elsewhere (or are too narrow for it) — title wins.
+  const timeText = isTimeGrid && !arg.event.allDay && arg.timeText ? `${arg.timeText}${tzBadge ? ` ${tzBadge}` : ''}` : '';
+  const minutes = arg.event.start && arg.event.end
+    ? (arg.event.end.getTime() - arg.event.start.getTime()) / 60000
+    : 0;
+  const stacked = isTimeGrid && !arg.event.allDay && minutes >= STACK_MIN_MINUTES;
+
+  if (stacked) {
+    return (
+      <div className="wl-chip-stacked flex h-full min-w-0 flex-col gap-0.5 px-2 py-1.5" data-entity-type={entityType}>
+        <span className="flex min-w-0 items-center gap-1.5">
+          <Icon className="wl-chip-icon h-3 w-3 shrink-0 opacity-70" aria-hidden data-testid={`chip-icon-${entityType}`} />
+          <span className="truncate font-sans text-xs font-medium leading-tight">{arg.event.title}</span>
+        </span>
+        {timeText && <span className="wl-chip-time truncate text-[10px] leading-tight tabular-nums opacity-60">{timeText}</span>}
+      </div>
+    );
+  }
   return (
     <div className="flex items-center gap-1.5 px-1.5 py-0.5 min-w-0" data-entity-type={entityType}>
-      <Icon className="h-3 w-3 shrink-0 opacity-80" aria-hidden data-testid={`chip-icon-${entityType}`} />
-      {!arg.event.allDay && arg.timeText && (
-        <span className="text-[10px] font-medium tabular-nums opacity-70 shrink-0">
-          {arg.timeText}{tzBadge ? ` ${tzBadge}` : ''}
-        </span>
+      <Icon className="wl-chip-icon h-3 w-3 shrink-0 opacity-80" aria-hidden data-testid={`chip-icon-${entityType}`} />
+      {timeText && (
+        <span className="wl-chip-time text-[10px] font-medium tabular-nums opacity-70 shrink-0">{timeText}</span>
       )}
       <span className="truncate font-sans text-xs">{arg.event.title}</span>
     </div>

--- a/src/components/trip/calendar/CalendarEventPeek.tsx
+++ b/src/components/trip/calendar/CalendarEventPeek.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import type { EventContentArg } from '@fullcalendar/core';
+import { Clock, MapPin, Star, Users, Ticket, CalendarRange, Banknote } from 'lucide-react';
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
+import CalendarEventChip from './CalendarEventChip';
+import type { CalendarEntityType } from './eventMapping';
+import { buildPeekFacts, type FactIcon } from './peekFacts';
+
+const TYPE_LABELS: Record<CalendarEntityType, string> = {
+  activity: 'Activity',
+  dining: 'Dining',
+  accommodation: 'Stay',
+  transportation: 'Transport',
+};
+
+const FACT_ICONS: Record<FactIcon, React.ComponentType<{ className?: string }>> = {
+  clock: Clock, pin: MapPin, star: Star, users: Users, ticket: Ticket, dates: CalendarRange, cost: Banknote,
+};
+
+function supportsHover(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+}
+
+/**
+ * Desktop-only hover preview wrapping the event chip. Pure peek: no actions,
+ * clicking the event still opens the edit dialog. Suppressed on touch devices
+ * and while the event is being dragged, resized, or mirrored.
+ */
+const CalendarEventPeek: React.FC<{ arg: EventContentArg }> = ({ arg }) => {
+  const chip = <CalendarEventChip arg={arg} />;
+  if (!supportsHover() || arg.isMirror || arg.isDragging || arg.isResizing) return chip;
+
+  const { entityType, tzBadge } = arg.event.extendedProps as { entityType: CalendarEntityType; tzBadge?: string };
+  const record = (arg.event.extendedProps as { record?: Record<string, unknown> }).record ?? {};
+  const facts = buildPeekFacts(entityType, record, tzBadge);
+
+  return (
+    <HoverCard openDelay={350} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className="h-full min-w-0">{chip}</div>
+      </HoverCardTrigger>
+      {/* Portal so the card escapes FullCalendar's per-event stacking contexts (sibling events would paint over it). */}
+      <HoverCardPrimitive.Portal>
+      <HoverCardContent
+        side="right"
+        align="start"
+        collisionPadding={8}
+        aria-hidden
+        className="w-72 rounded-card border-border bg-background p-4 shadow-warm-lg"
+      >
+        <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">{TYPE_LABELS[entityType] ?? 'Event'}</p>
+        <p className="mt-1 text-sm font-medium leading-snug text-foreground">{arg.event.title}</p>
+        {facts.length > 0 && (
+          <ul className="mt-2.5 space-y-1.5">
+            {facts.map((fact) => {
+              const Icon = FACT_ICONS[fact.icon];
+              return (
+                <li key={`${fact.icon}-${fact.text}`} className="flex items-start gap-2 text-xs leading-snug text-muted-foreground">
+                  <Icon className="mt-0.5 h-3 w-3 shrink-0 opacity-70" aria-hidden />
+                  <span className="min-w-0">{fact.text}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </HoverCardContent>
+      </HoverCardPrimitive.Portal>
+    </HoverCard>
+  );
+};
+
+export default CalendarEventPeek;

--- a/src/components/trip/calendar/TripCalendarView.tsx
+++ b/src/components/trip/calendar/TripCalendarView.tsx
@@ -173,6 +173,15 @@ const TripCalendarView: React.FC<TripCalendarViewProps> = ({ tripId, tripDates, 
           events={events}
           slotMinTime={slotMinTime}
           eventContent={(arg) => <CalendarEventChip arg={arg} />}
+          eventClassNames={(arg) => [`wl-ev-${(arg.event.extendedProps as { entityType?: CalendarEntityType }).entityType ?? 'activity'}`]}
+          dayHeaderContent={(arg) =>
+            arg.view.type.startsWith('timeGrid') ? (
+              <div className="flex flex-col items-center gap-0.5 py-1 font-sans">
+                <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">{format(arg.date, 'EEE')}</span>
+                <span className={`font-display text-xl leading-none ${arg.isToday ? 'text-primary' : 'text-foreground'}`}>{format(arg.date, 'd')}</span>
+              </div>
+            ) : undefined
+          }
           datesSet={(arg) => {
             setTitle(arg.view.title);
             const start = format(arg.start, 'yyyy-MM-dd');

--- a/src/components/trip/calendar/TripCalendarView.tsx
+++ b/src/components/trip/calendar/TripCalendarView.tsx
@@ -12,7 +12,7 @@ import type { Tables } from '@/integrations/supabase/types';
 import { useCalendarEvents } from './useCalendarEvents';
 import { useCalendarRealtime } from './useCalendarRealtime';
 import CalendarToolbar, { type CalendarViewName } from './CalendarToolbar';
-import CalendarEventChip from './CalendarEventChip';
+import CalendarEventPeek from './CalendarEventPeek';
 import AddEntityPicker from './AddEntityPicker';
 import { buildDropPatch, isDateWithinTripRange, type CalendarEntityType } from './eventMapping';
 import { computeSlotMinTime, DEFAULT_SLOT_MIN_TIME } from './slotWindow';
@@ -172,7 +172,7 @@ const TripCalendarView: React.FC<TripCalendarViewProps> = ({ tripId, tripDates, 
           validRange={validRange}
           events={events}
           slotMinTime={slotMinTime}
-          eventContent={(arg) => <CalendarEventChip arg={arg} />}
+          eventContent={(arg) => <CalendarEventPeek arg={arg} />}
           eventClassNames={(arg) => [`wl-ev-${(arg.event.extendedProps as { entityType?: CalendarEntityType }).entityType ?? 'activity'}`]}
           dayHeaderContent={(arg) =>
             arg.view.type.startsWith('timeGrid') ? (

--- a/src/components/trip/calendar/calendarTheme.css
+++ b/src/components/trip/calendar/calendarTheme.css
@@ -5,11 +5,14 @@
   --fc-neutral-bg-color: hsl(var(--muted));
   --fc-today-bg-color: color-mix(in oklch, hsl(var(--sunset-500, 24 95% 53%)) 8%, transparent);
   --fc-now-indicator-color: hsl(24 95% 53%);
+  /* Kill FullCalendar's default blue everywhere; the wl-ev-* tints below paint whole blocks. */
+  --fc-event-bg-color: transparent;
   --fc-event-border-color: transparent;
+  --fc-event-text-color: hsl(var(--foreground));
+  --fc-list-event-hover-bg-color: hsl(var(--muted));
   --fc-small-font-size: 0.72rem;
   font-family: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
 }
-.wl-calendar .fc .fc-col-header-cell-cushion,
 .wl-calendar .fc .fc-list-day-text,
 .wl-calendar .fc .fc-toolbar-title {
   font-family: 'DM Serif Display', ui-serif, Georgia, serif;
@@ -17,21 +20,50 @@
   letter-spacing: -0.01em;
   color: hsl(var(--foreground));
 }
+/* Month view keeps plain weekday labels; timegrid headers are custom-rendered in React. */
+.wl-calendar .fc-dayGridMonth-view .fc-col-header-cell-cushion {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+}
 .wl-calendar .fc .fc-daygrid-day-number,
-.wl-calendar .fc .fc-timegrid-slot-label-cushion {
+.wl-calendar .fc .fc-timegrid-slot-label-cushion,
+.wl-calendar .fc .fc-timegrid-axis-cushion {
   color: hsl(var(--muted-foreground));
   font-size: 0.72rem;
 }
 .wl-calendar .fc-timegrid-slot { height: 2.6em; }
-/* Warm tonal tints per entity type; sunset reserved for selected/focused. */
-.wl-calendar .fc-event { border-radius: 0.375rem; box-shadow: var(--tw-shadow, 0 1px 2px rgba(80, 50, 20, 0.08)); }
-.wl-calendar [data-entity-type="activity"] { background: #EEE7DA; color: hsl(var(--foreground)); }
-.wl-calendar [data-entity-type="dining"] { background: #EDDDC8; color: hsl(var(--foreground)); }
-.wl-calendar [data-entity-type="accommodation"] { background: #EDE8DD; color: hsl(var(--foreground)); }
-.wl-calendar [data-entity-type="transportation"] { background: #FDFCF8; color: hsl(var(--foreground)); border: 1px solid hsl(var(--border)); }
-.wl-calendar .fc-event.fc-event-selected [data-entity-type],
-.wl-calendar .fc-event:focus [data-entity-type] { outline: 2px solid #F97316; outline-offset: 1px; }
+/* Half-hour rules fade to a whisper; the hour lines carry the grid. */
+.wl-calendar .fc-timegrid-slot-minor { border-top-color: color-mix(in srgb, hsl(var(--border)) 40%, transparent); }
+
+/* Event blocks: full warm tonal fill per entity type, hairline family border, flat at rest. */
+.wl-calendar .fc-event {
+  border-radius: 0.375rem;
+  overflow: hidden;
+  color: hsl(var(--foreground));
+}
+.wl-calendar .fc-timegrid-event .fc-event-main { padding: 0; }
+.wl-calendar .fc-event.wl-ev-activity { background: #EEE7DA; border: 1px solid #DCD1BC; }
+.wl-calendar .fc-event.wl-ev-dining { background: #EDDDC8; border: 1px solid #DFC6A4; }
+.wl-calendar .fc-event.wl-ev-accommodation { background: #EDE8DD; border: 1px solid #D9D0BE; }
+.wl-calendar .fc-event.wl-ev-transportation { background: #FDFCF8; border: 1px solid hsl(var(--border)); }
+/* Stacked chips: time aligns under the title text, not the icon. */
+.wl-calendar .wl-chip-stacked .wl-chip-time { padding-left: 1.125rem; }
+/* Week columns are too narrow for icons or the title indent — give the text the full width. */
+.wl-calendar .fc-timeGridWeek-view .fc-timegrid-event .wl-chip-icon { display: none; }
+.wl-calendar .fc-timeGridWeek-view .wl-chip-stacked .wl-chip-time { padding-left: 0; }
+/* Lift only on interaction (flat-by-default); shadows stay bronze. */
+.wl-calendar .fc-event:hover { box-shadow: 0 1px 3px 0 rgba(139, 119, 93, 0.10), 0 1px 2px -1px rgba(139, 119, 93, 0.10); }
+.wl-calendar .fc-event.fc-event-mirror,
+.wl-calendar .fc-event.fc-event-dragging { box-shadow: 0 4px 12px -2px rgba(139, 119, 93, 0.18); }
+.wl-calendar .fc-event:focus-visible,
+.wl-calendar .fc-event.fc-event-selected { outline: 2px solid hsl(var(--primary)); outline-offset: 1px; }
+/* List view keeps its dot; deeper family tones keep the entity type scannable. */
+.wl-calendar .fc-list-event.wl-ev-activity .fc-list-event-dot { border-color: #B7A988; }
+.wl-calendar .fc-list-event.wl-ev-dining .fc-list-event-dot { border-color: #C9975F; }
+.wl-calendar .fc-list-event.wl-ev-accommodation .fc-list-event-dot { border-color: #A99F8C; }
+.wl-calendar .fc-list-event.wl-ev-transportation .fc-list-event-dot { border-color: #8A7F6C; }
 /* Out-of-range day cells (outside the trip dates): de-emphasized and read as non-droppable. */
 .wl-calendar .wl-out-of-range { background: hsl(var(--muted)); opacity: 0.5; }
-/* Month density: warm "+N more" count link instead of default blue; multi-day bars stay visible. */
-.wl-calendar .fc-daygrid-more-link { color: #F97316; font-weight: 500; font-size: 0.7rem; }
+/* Month density: bronze "+N more" link; sunset stays reserved for the now line and today tint. */
+.wl-calendar .fc-daygrid-more-link { color: hsl(var(--primary)); font-weight: 500; font-size: 0.7rem; }

--- a/src/components/trip/calendar/peekFacts.test.ts
+++ b/src/components/trip/calendar/peekFacts.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildPeekFacts } from './peekFacts';
+
+describe('buildPeekFacts', () => {
+  it('builds time, location, rating, and cost rows for an activity', () => {
+    const facts = buildPeekFacts('activity', {
+      start_time: '14:30:00', end_time: '16:00:00',
+      location_address: '12 Rue de Rivoli, Paris',
+      location_rating: 4.7, cost: 60, currency: 'EUR',
+    });
+    expect(facts.map((f) => f.text)).toEqual([
+      '2:30 PM – 4:00 PM',
+      '12 Rue de Rivoli, Paris',
+      '4.7',
+      '€60',
+    ]);
+  });
+
+  it('appends the timezone badge to the time row', () => {
+    const facts = buildPeekFacts('activity', { start_time: '09:00:00' }, 'EEST');
+    expect(facts[0].text).toBe('9:00 AM EEST');
+  });
+
+  it('omits rows with no data — a title-only card is valid', () => {
+    expect(buildPeekFacts('activity', {})).toEqual([]);
+    expect(buildPeekFacts('dining', { restaurant_name: 'Rizes' })).toEqual([]);
+  });
+
+  it('builds party size and reservation time for dining', () => {
+    const facts = buildPeekFacts('dining', {
+      reservation_time: '21:00:00', number_of_people: 6, rating: 4.5,
+    });
+    expect(facts.map((f) => f.text)).toEqual(['9:00 PM', 'Party of 6', '4.5']);
+  });
+
+  it('builds date range and check-in/out times for a stay', () => {
+    const facts = buildPeekFacts('accommodation', {
+      hotel_checkin_date: '2026-08-06', hotel_checkout_date: '2026-08-11',
+      checkin_time: '15:00:00', checkout_time: '11:00:00',
+    });
+    expect(facts.map((f) => f.text)).toEqual([
+      'Aug 6 – Aug 11',
+      'Check-in 3:00 PM · Check-out 11:00 AM',
+    ]);
+  });
+
+  it('combines provider and confirmation number for transport', () => {
+    const facts = buildPeekFacts('transportation', {
+      start_time: '08:15:00', provider: 'Delta', confirmation_number: 'ABC123',
+    });
+    expect(facts.map((f) => f.text)).toEqual(['8:15 AM', 'Delta · ABC123']);
+  });
+});

--- a/src/components/trip/calendar/peekFacts.ts
+++ b/src/components/trip/calendar/peekFacts.ts
@@ -1,0 +1,82 @@
+import { format, parse } from 'date-fns';
+import { formatCostWithCurrency } from '@/utils/costUtils';
+import type { DayActivity, RestaurantReservation, HotelStay, Transportation } from '@/types/trip';
+import type { CalendarEntityType } from './eventMapping';
+
+export type FactIcon = 'clock' | 'pin' | 'star' | 'users' | 'ticket' | 'dates' | 'cost';
+export interface PeekFact { icon: FactIcon; text: string }
+
+/** Format a floating HH:MM(:SS) wall-clock time as h:mm a. Never converts zones. */
+function fmtTime(time: string | null | undefined): string {
+  if (!time) return '';
+  return format(parse(time.slice(0, 5), 'HH:mm', new Date()), 'h:mm a');
+}
+
+function fmtDay(date: string): string {
+  return format(parse(date, 'yyyy-MM-dd', new Date()), 'MMM d');
+}
+
+function timeRange(start: string | null | undefined, end: string | null | undefined, tzBadge?: string): string {
+  if (!start) return '';
+  const range = end ? `${fmtTime(start)} – ${fmtTime(end)}` : fmtTime(start);
+  return tzBadge ? `${range} ${tzBadge}` : range;
+}
+
+function costFact(cost: number | null, currency: string | null | undefined): PeekFact | null {
+  return cost != null ? { icon: 'cost', text: formatCostWithCurrency(cost, currency ?? 'USD') } : null;
+}
+
+function activityFacts(r: DayActivity, tzBadge?: string): (PeekFact | null)[] {
+  return [
+    r.start_time ? { icon: 'clock', text: timeRange(r.start_time, r.end_time, tzBadge) } : null,
+    r.location_address ? { icon: 'pin', text: r.location_address } : null,
+    r.location_rating != null ? { icon: 'star', text: r.location_rating.toFixed(1) } : null,
+    costFact(r.cost, r.currency),
+  ];
+}
+
+function diningFacts(r: RestaurantReservation, tzBadge?: string): (PeekFact | null)[] {
+  return [
+    r.reservation_time ? { icon: 'clock', text: timeRange(r.reservation_time, null, tzBadge) } : null,
+    r.number_of_people ? { icon: 'users', text: `Party of ${r.number_of_people}` } : null,
+    r.address ? { icon: 'pin', text: r.address } : null,
+    r.rating != null ? { icon: 'star', text: r.rating.toFixed(1) } : null,
+    costFact(r.cost, r.currency),
+  ];
+}
+
+function stayFacts(r: HotelStay): (PeekFact | null)[] {
+  const times = [
+    r.checkin_time && `Check-in ${fmtTime(r.checkin_time)}`,
+    r.checkout_time && `Check-out ${fmtTime(r.checkout_time)}`,
+  ].filter(Boolean).join(' · ');
+  return [
+    r.hotel_checkin_date && r.hotel_checkout_date
+      ? { icon: 'dates', text: `${fmtDay(r.hotel_checkin_date)} – ${fmtDay(r.hotel_checkout_date)}` }
+      : null,
+    times ? { icon: 'clock', text: times } : null,
+    r.hotel_address ? { icon: 'pin', text: r.hotel_address } : null,
+    costFact(r.cost, r.currency),
+  ];
+}
+
+function transportFacts(r: Transportation, tzBadge?: string): (PeekFact | null)[] {
+  const booking = [r.provider, r.confirmation_number].filter(Boolean).join(' · ');
+  return [
+    r.start_time ? { icon: 'clock', text: timeRange(r.start_time, r.end_time, tzBadge) } : null,
+    booking ? { icon: 'ticket', text: booking } : null,
+    costFact(r.cost, r.currency),
+  ];
+}
+
+/** Glance essentials per entity type; rows with no data are simply omitted. */
+export function buildPeekFacts(entityType: CalendarEntityType, record: Record<string, unknown>, tzBadge?: string): PeekFact[] {
+  const builders: Record<CalendarEntityType, () => (PeekFact | null)[]> = {
+    activity: () => activityFacts(record as unknown as DayActivity, tzBadge),
+    dining: () => diningFacts(record as unknown as RestaurantReservation, tzBadge),
+    accommodation: () => stayFacts(record as unknown as HotelStay),
+    transportation: () => transportFacts(record as unknown as Transportation, tzBadge),
+  };
+  return (builders[entityType]?.() ?? []).filter(Boolean) as PeekFact[];
+}
+

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -286,8 +286,6 @@ const TripDetails = () => {
             className="relative flex-1 w-full z-10 min-h-screen rounded-t-[28px] bg-sand-50 -mt-6"
             style={{
               boxShadow: '0 -10px 40px -5px rgba(0,0,0,0.10)',
-              backdropFilter: 'blur(2px)',
-              WebkitBackdropFilter: 'blur(2px)',
             }}
           >
 


### PR DESCRIPTION
## Summary

Fixes the desktop Trip Assistant collapse, which previously just emptied the panel while its box and 42% column stayed in place.

- **Collapse now folds the assistant into a floating Sparkles button** fixed at the viewport's bottom-right; the timeline reclaims the full page width. Clicking the button restores the panel.
- **Calendar view always gets the full page width**; the assistant floats above it as a bottom-right overlay panel (~400px × min(70vh, 640px)) with the complete chat UI, collapsible to the same button.
- **State is never persisted** — the assistant defaults to open on every page load, and the open/collapsed state carries across timeline↔calendar switches.
- **Single always-mounted panel**: a new `AssistantDock` shell CSS-switches the panel between docked column, fixed overlay, and hidden, so in-flight streaming and extracted document items survive collapse/expand and view switches (pinned by a DOM-node-identity test).
- The Chat tab's dead collapse chevron is gone (`AIAssistantPanel` now takes an optional `onCollapse` prop; without it, no button renders).
- **Bug fix (found in browser verification):** removed a visually no-op inline `backdrop-filter: blur(2px)` on the TripDetails content wrapper — its opaque background made the blur invisible, but per the CSS spec it created a containing block that anchored the fixed button/overlay to the 8900px page instead of the viewport.

Mobile is untouched (drawer + bottom-nav path unchanged, everything new is `lg+`-gated).

Spec: `docs/superpowers/specs/2026-07-16-trip-assistant-collapse-design.md` · Plan: `docs/superpowers/plans/2026-07-16-trip-assistant-collapse.md`

## Test plan

- [x] 12 new Vitest tests (AssistantDock modes + node identity, panel collapse button, TimelineView width/mode/state wiring); full suite 470/470 green
- [x] Browser verification at 1440×900: docked default, collapse→FAB, restore, calendar overlay, Radix dialog stacks above overlay, reload resets to open
- [x] Mobile 390px: no FAB/overlay; drawer unchanged
- [x] eslint clean on touched files


## Calendar visual overhaul + hover peek card (added 2026-07-16)

- **Killed FullCalendar's default blue.** The warm entity tints were only painted on the inner content chip; the event body underneath still used the library default `#3788d8`. The tints (linen/tea/aged/cream per entity type) now fill the whole block via `eventClassNames`, with hairline family borders, interaction-only bronze shadows, and bronze (not sunset) "+N more" and selection outline.
- **Modern event chips:** timed events ≥45 min stack title over time; Week columns drop the icon/indent so titles stay readable; Month cells show title-first chips; timegrid day headers are small-caps weekday over a serif numeral (bronze on today).
- **Hover peek card (desktop only):** Radix HoverCard on each event with glance essentials — time range with tz badge, address, rating, party size, provider + confirmation, check-in/out, cost. Pure preview (no actions, `aria-hidden`, 350ms delay); clicking still opens the edit dialog. Suppressed on touch and during drag/resize. Portaled to escape FullCalendar's per-event stacking contexts (a sibling event painted over the card in browser testing).

Additional testing: 9 new Vitest tests (chip layouts + peekFacts builder), calendar suite 63/63 green; browser-verified Day/3-Day/Week/Month plus hover on the public Mykonos trip; eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
