### PR TITLE
feat(calendar): dense time grid fitting 7am–10pm in a laptop viewport

### DIFF
--- a/src/components/trip/calendar/CalendarEventChip.tsx
+++ b/src/components/trip/calendar/CalendarEventChip.tsx
@@ -10,8 +10,8 @@ const ICONS: Record<CalendarEntityType, React.ComponentType<{ className?: string
   transportation: Plane,
 };
 
-/** Timed timegrid events at least this tall get the stacked (title over time) layout. */
-const STACK_MIN_MINUTES = 45;
+/** Timed timegrid events at least this long get the stacked (title over time) layout — at the dense slot height (~42px/hour) anything shorter can't fit two lines. */
+const STACK_MIN_MINUTES = 60;
 
 const CalendarEventChip: React.FC<{ arg: EventContentArg }> = ({ arg }) => {
   const { entityType, tzBadge } = arg.event.extendedProps as { entityType: CalendarEntityType; tzBadge?: string };
@@ -26,7 +26,7 @@ const CalendarEventChip: React.FC<{ arg: EventContentArg }> = ({ arg }) => {
 
   if (stacked) {
     return (
-      <div className="wl-chip-stacked flex h-full min-w-0 flex-col gap-0.5 px-2 py-1.5" data-entity-type={entityType}>
+      <div className="wl-chip-stacked flex h-full min-w-0 flex-col gap-0.5 px-2 py-1" data-entity-type={entityType}>
         <span className="flex min-w-0 items-center gap-1.5">
           <Icon className="wl-chip-icon h-3 w-3 shrink-0 opacity-70" aria-hidden data-testid={`chip-icon-${entityType}`} />
           <span className="truncate font-sans text-xs font-medium leading-tight">{arg.event.title}</span>

--- a/src/components/trip/calendar/CalendarToolbar.tsx
+++ b/src/components/trip/calendar/CalendarToolbar.tsx
@@ -12,7 +12,7 @@ interface CalendarToolbarProps {
   onPrev: () => void;
   onNext: () => void;
   onToday: () => void;
-  /** Early-morning day-window toggle; null hides it (month/list views, or nothing collapsed). */
+  /** Day-window toggle for the hidden early/late hours; null hides it (month/list views, or nothing collapsed). */
   dayWindow?: { expanded: boolean; onToggle: () => void } | null;
 }
 
@@ -48,7 +48,7 @@ const CalendarToolbar: React.FC<CalendarToolbarProps> = ({ title, activeView, on
           className="min-h-[44px] px-2 text-xs text-muted-foreground sm:min-h-0 sm:h-7"
           onClick={dayWindow.onToggle}
         >
-          {dayWindow.expanded ? 'Hide early morning' : 'Show full day'}
+          {dayWindow.expanded ? 'Hide extra hours' : 'Show full day'}
         </Button>
       )}
       <fieldset className="grid w-full min-w-0 grid-cols-4 rounded-md border border-border bg-card p-0.5 sm:inline-flex sm:w-auto">

--- a/src/components/trip/calendar/TripCalendarView.test.tsx
+++ b/src/components/trip/calendar/TripCalendarView.test.tsx
@@ -74,17 +74,35 @@ describe('TripCalendarView', () => {
     expect(slot(container, '04:00:00')).not.toBeInTheDocument();
   });
 
+  it('ends the time grid at 10pm by default', () => {
+    const { container } = renderCalendar(FUTURE_TRIP);
+    expect(slot(container, '21:30:00')).toBeInTheDocument();
+    expect(slot(container, '22:00:00')).not.toBeInTheDocument();
+  });
+
+  it('raises the grid end to fit an event that runs past 10pm', () => {
+    mockEvents = [LOUVRE, { id: 'reservation:r1', title: 'Late dinner', start: '2030-03-01T21:30:00', end: '2030-03-01T23:00:00', allDay: false, extendedProps: { entityType: 'dining', record: { id: 'r1' } } }];
+    const { container } = renderCalendar(FUTURE_TRIP);
+    expect(slot(container, '22:30:00')).toBeInTheDocument();
+    expect(slot(container, '23:00:00')).not.toBeInTheDocument();
+  });
+
   it('expands to the full 24-hour day and collapses back', () => {
     const { container } = renderCalendar(FUTURE_TRIP);
     fireEvent.click(screen.getByRole('button', { name: 'Show full day' }));
     expect(slot(container, '00:00:00')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Hide early morning' }));
+    expect(slot(container, '23:30:00')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Hide extra hours' }));
     expect(slot(container, '00:00:00')).not.toBeInTheDocument();
+    expect(slot(container, '23:30:00')).not.toBeInTheDocument();
     expect(slot(container, '07:00:00')).toBeInTheDocument();
   });
 
   it('hides the toggle when nothing is collapsed', () => {
-    mockEvents = [{ id: 'activity:a2', title: 'Midnight snack', start: '2030-03-01T00:30:00', allDay: false, extendedProps: { entityType: 'activity', record: { id: 'a2' } } }];
+    mockEvents = [
+      { id: 'activity:a2', title: 'Midnight snack', start: '2030-03-01T00:30:00', allDay: false, extendedProps: { entityType: 'activity', record: { id: 'a2' } } },
+      { id: 'activity:a3', title: 'Stargazing', start: '2030-03-01T23:15:00', allDay: false, extendedProps: { entityType: 'activity', record: { id: 'a3' } } },
+    ];
     renderCalendar(FUTURE_TRIP);
     expect(screen.queryByRole('button', { name: 'Show full day' })).not.toBeInTheDocument();
   });

--- a/src/components/trip/calendar/TripCalendarView.tsx
+++ b/src/components/trip/calendar/TripCalendarView.tsx
@@ -15,7 +15,7 @@ import CalendarToolbar, { type CalendarViewName } from './CalendarToolbar';
 import CalendarEventPeek from './CalendarEventPeek';
 import AddEntityPicker from './AddEntityPicker';
 import { buildDropPatch, isDateWithinTripRange, type CalendarEntityType } from './eventMapping';
-import { computeSlotMinTime, DEFAULT_SLOT_MIN_TIME } from './slotWindow';
+import { computeSlotMinTime, computeSlotMaxTime, DEFAULT_SLOT_MIN_TIME, DEFAULT_SLOT_MAX_TIME } from './slotWindow';
 import { applyDropPatch } from './calendarMutations';
 import ActivityDialog from '@/components/trip/day/activities/ActivityDialog';
 import AccommodationDialog from '@/components/trip/accommodation/AccommodationDialog';
@@ -112,13 +112,19 @@ const TripCalendarView: React.FC<TripCalendarViewProps> = ({ tripId, tripDates, 
   const dialogTripDates = { arrival_date: tripDates.arrival_date ?? '', departure_date: tripDates.departure_date ?? '' };
   const isEmpty = !isLoading && events.length === 0;
 
-  // Grid starts at 7am (earlier if an event demands it); "Show full day" reveals the hidden early hours.
+  // Grid spans 7am–10pm (widened if an event demands it); "Show full day" reveals the hidden hours.
   const collapsedSlotMin = useMemo(
     () => (visibleRange ? computeSlotMinTime(events, visibleRange.start, visibleRange.end) : DEFAULT_SLOT_MIN_TIME),
     [events, visibleRange],
   );
+  const collapsedSlotMax = useMemo(
+    () => (visibleRange ? computeSlotMaxTime(events, visibleRange.start, visibleRange.end) : DEFAULT_SLOT_MAX_TIME),
+    [events, visibleRange],
+  );
   const slotMinTime = showFullDay ? '00:00:00' : collapsedSlotMin;
-  const showDayWindowToggle = activeView.startsWith('timeGrid') && collapsedSlotMin !== '00:00:00';
+  const slotMaxTime = showFullDay ? '24:00:00' : collapsedSlotMax;
+  const showDayWindowToggle = activeView.startsWith('timeGrid')
+    && (collapsedSlotMin !== '00:00:00' || collapsedSlotMax !== '24:00:00');
 
   const closeAndRefresh = () => { setEditing(null); setAdding(null); invalidateAll(); };
 
@@ -172,6 +178,7 @@ const TripCalendarView: React.FC<TripCalendarViewProps> = ({ tripId, tripDates, 
           validRange={validRange}
           events={events}
           slotMinTime={slotMinTime}
+          slotMaxTime={slotMaxTime}
           eventContent={(arg) => <CalendarEventPeek arg={arg} />}
           eventClassNames={(arg) => [`wl-ev-${(arg.event.extendedProps as { entityType?: CalendarEntityType }).entityType ?? 'activity'}`]}
           dayHeaderContent={(arg) =>

--- a/src/components/trip/calendar/calendarTheme.css
+++ b/src/components/trip/calendar/calendarTheme.css
@@ -32,7 +32,9 @@
   color: hsl(var(--muted-foreground));
   font-size: 0.72rem;
 }
-.wl-calendar .fc-timegrid-slot { height: 2.6em; }
+/* Dense rows: 30-min slot ≈ 21px, so the default 7am–10pm window (~625px) fits a laptop viewport.
+   line-height must shrink with it — FC injects an nbsp into empty slots, whose 1.5-line box would floor rows at 24px. */
+.wl-calendar .fc-timegrid-slot { height: 1.3em; line-height: 1.1; }
 /* Half-hour rules fade to a whisper; the hour lines carry the grid. */
 .wl-calendar .fc-timegrid-slot-minor { border-top-color: color-mix(in srgb, hsl(var(--border)) 40%, transparent); }
 

--- a/src/components/trip/calendar/slotWindow.test.ts
+++ b/src/components/trip/calendar/slotWindow.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import type { EventInput } from '@fullcalendar/core';
-import { computeSlotMinTime, DEFAULT_SLOT_MIN_TIME } from './slotWindow';
+import { computeSlotMinTime, computeSlotMaxTime, DEFAULT_SLOT_MIN_TIME, DEFAULT_SLOT_MAX_TIME } from './slotWindow';
 
-function timed(start: string): EventInput {
-  return { id: `activity:${start}`, title: 'x', start, allDay: false };
+function timed(start: string, end?: string): EventInput {
+  return { id: `activity:${start}`, title: 'x', start, end, allDay: false };
 }
 
 function allDay(date: string): EventInput {
@@ -47,5 +47,42 @@ describe('computeSlotMinTime', () => {
   it('skips events whose start is not a datetime string', () => {
     const events: EventInput[] = [{ id: 'x', title: 'x', start: new Date('2030-03-01T05:00:00'), allDay: false }];
     expect(computeSlotMinTime(events, RANGE.start, RANGE.end)).toBe('07:00:00');
+  });
+});
+
+describe('computeSlotMaxTime', () => {
+  it('defaults to 10pm with no events', () => {
+    expect(computeSlotMaxTime([], RANGE.start, RANGE.end)).toBe('22:00:00');
+    expect(DEFAULT_SLOT_MAX_TIME).toBe('22:00:00');
+  });
+
+  it('keeps 10pm when all timed events end at or before 10pm', () => {
+    const events = [timed('2030-03-01T14:30:00', '2030-03-01T16:00:00'), timed('2030-03-02T20:00:00', '2030-03-02T22:00:00')];
+    expect(computeSlotMaxTime(events, RANGE.start, RANGE.end)).toBe('22:00:00');
+  });
+
+  it('raises the end to the ceiling hour of the latest post-10pm event in range', () => {
+    const events = [timed('2030-03-02T21:30:00', '2030-03-02T22:45:00'), timed('2030-03-01T14:30:00', '2030-03-01T16:00:00')];
+    expect(computeSlotMaxTime(events, RANGE.start, RANGE.end)).toBe('23:00:00');
+  });
+
+  it('keeps an endless late event visible via its start hour', () => {
+    const events = [timed('2030-03-01T23:15:00')];
+    expect(computeSlotMaxTime(events, RANGE.start, RANGE.end)).toBe('24:00:00');
+  });
+
+  it('pins the grid to midnight for an event that runs past midnight', () => {
+    const events = [timed('2030-03-01T22:00:00', '2030-03-02T01:00:00')];
+    expect(computeSlotMaxTime(events, RANGE.start, RANGE.end)).toBe('24:00:00');
+  });
+
+  it('ignores post-10pm events outside the visible range', () => {
+    const events = [timed('2030-03-04T22:30:00', '2030-03-04T23:30:00'), timed('2030-02-28T23:00:00', '2030-02-28T23:45:00')];
+    expect(computeSlotMaxTime(events, RANGE.start, RANGE.end)).toBe('22:00:00');
+  });
+
+  it('ignores all-day events', () => {
+    const events = [allDay('2030-03-01'), allDay('2030-03-02')];
+    expect(computeSlotMaxTime(events, RANGE.start, RANGE.end)).toBe('22:00:00');
   });
 });

--- a/src/components/trip/calendar/slotWindow.ts
+++ b/src/components/trip/calendar/slotWindow.ts
@@ -1,7 +1,9 @@
 import type { EventInput } from '@fullcalendar/core';
 
 export const DEFAULT_SLOT_MIN_TIME = '07:00:00';
+export const DEFAULT_SLOT_MAX_TIME = '22:00:00';
 const DEFAULT_START_HOUR = 7;
+const DEFAULT_END_HOUR = 22;
 
 /**
  * Earliest hour the time grid should show: 7am, lowered to the floor hour of
@@ -19,4 +21,34 @@ export function computeSlotMinTime(events: EventInput[], visibleStart: string, v
     if (Number.isInteger(hour) && hour < minHour) minHour = hour;
   }
   return `${String(minHour).padStart(2, '0')}:00:00`;
+}
+
+/** Exclusive grid end hour a timed in-range event needs, or null if it can't affect the window. */
+function requiredEndHour(event: EventInput, visibleStart: string, visibleEnd: string): number | null {
+  if (event.allDay || typeof event.start !== 'string' || event.start.length < 16) return null;
+  const date = event.start.slice(0, 10);
+  if (date < visibleStart || date >= visibleEnd) return null;
+  if (typeof event.end === 'string' && event.end.length >= 16) {
+    if (event.end.slice(0, 10) > date) return 24; // runs past midnight
+    const h = Number(event.end.slice(11, 13));
+    const m = Number(event.end.slice(14, 16));
+    if (Number.isInteger(h)) return Math.min(h + (m > 0 ? 1 : 0), 24);
+  }
+  // An event with no usable end still needs its start hour fully visible.
+  const startHour = Number(event.start.slice(11, 13));
+  return Number.isInteger(startHour) ? startHour + 1 : null;
+}
+
+/**
+ * Latest hour the time grid should show: 10pm, raised to the ceiling hour of
+ * the latest timed event within [visibleStart, visibleEnd) so no event is
+ * ever clipped. An event ending on a later date pins the grid to midnight.
+ */
+export function computeSlotMaxTime(events: EventInput[], visibleStart: string, visibleEnd: string): string {
+  let maxHour = DEFAULT_END_HOUR;
+  for (const event of events) {
+    const endHour = requiredEndHour(event, visibleStart, visibleEnd);
+    if (endHour !== null && endHour > maxHour) maxHour = endHour;
+  }
+  return maxHour === 24 ? '24:00:00' : `${String(maxHour).padStart(2, '0')}:00:00`;
 }


### PR DESCRIPTION
## Summary
- Halve timegrid slot height (2.6em → 1.3em ≈ 21px per 30-min row) so the default day window fits one laptop viewport instead of multiple scrolls; matching `line-height: 1.1` is required because FullCalendar injects an nbsp into empty slot cells whose 1.5-line box otherwise floors rows at 24px
- End the grid at 10pm by default via new `computeSlotMaxTime`, mirroring the existing 7am floor: raised to the ceiling hour of the latest visible event, pinned to midnight for events that run past it, so no event is ever clipped
- "Show full day" toggle now covers hidden hours at both ends (expanded label: "Hide extra hours"); shown whenever either end is collapsed
- Stacked event-chip layout (title over time) threshold moves 45 → 60 min — at the dense row height a 45-min event can't fit two lines

## Verification
- All 72 calendar tests pass (`npx vitest run src/components/trip/calendar`), including new coverage for the 10pm ceiling: late, endless, overnight, out-of-range, and all-day events
- Verified live at 1440×820: day view renders exactly 7am–10pm (624px grid), 3-day/week match, late events extend the grid (Paris 10pm event → 11pm), full-day toggle round-trips
- Lint clean; no new type errors in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)