### PR TITLE
fix(nav): add mobile create-trip entry point

### DIFF
--- a/src/components/navigation/NavigationAuth.test.tsx
+++ b/src/components/navigation/NavigationAuth.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NavigationAuth from './NavigationAuth';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }));
+vi.mock('./UserAvatar', () => ({ default: () => <div data-testid="user-avatar" /> }));
+
+const auth = vi.hoisted(() => ({ session: null as object | null }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => auth }));
+
+describe('NavigationAuth (signed in)', () => {
+  beforeEach(() => {
+    auth.session = { user: { id: 'user-1' } };
+    navigate.mockClear();
+  });
+
+  it('renders a mobile create-trip button that navigates to /create-trip', () => {
+    render(<NavigationAuth />);
+    const mobileButton = screen.getByRole('button', { name: 'Create trip' });
+    // Icon button is the mobile counterpart of the labeled desktop button:
+    // shown below md, hidden at md+ where the labeled button takes over.
+    expect(mobileButton.className).toContain('md:hidden');
+    fireEvent.click(mobileButton);
+    expect(navigate).toHaveBeenCalledWith('/create-trip');
+  });
+
+  it('keeps the labeled desktop button hidden below md', () => {
+    render(<NavigationAuth />);
+    const desktopButton = screen.getByRole('button', { name: 'Create Trip' });
+    expect(desktopButton.className).toContain('hidden');
+    expect(desktopButton.className).toContain('md:inline-block');
+  });
+});
+
+describe('NavigationAuth (signed out)', () => {
+  beforeEach(() => {
+    auth.session = null;
+    navigate.mockClear();
+  });
+
+  it('shows no create-trip controls', () => {
+    render(<NavigationAuth />);
+    expect(screen.queryByRole('button', { name: 'Create trip' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create Trip' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/navigation/NavigationAuth.tsx
+++ b/src/components/navigation/NavigationAuth.tsx
@@ -1,6 +1,7 @@
 
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
+import { Plus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import UserAvatar from "./UserAvatar";
 
@@ -12,6 +13,15 @@ const NavigationAuth = () => {
     <motion.div className="flex items-center space-x-4">
       {session ? (
         <>
+          <motion.button
+            onClick={() => navigate("/create-trip")}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            aria-label="Create trip"
+            className="md:hidden flex h-9 w-9 items-center justify-center rounded-full transition-colors bg-earth-500 text-white hover:bg-earth-600"
+          >
+            <Plus className="h-5 w-5" aria-hidden="true" />
+          </motion.button>
           <motion.button
             onClick={() => navigate("/create-trip")}
             whileHover={{ scale: 1.05 }}


### PR DESCRIPTION
## Summary
- On mobile, users with a current or upcoming trip had **no entry point to create a trip**: the nav "Create Trip" button is `hidden md:inline-block` (desktop-only), and the MyTrips hero only shows its create CTA in the no-upcoming-trip `default` state — with an upcoming trip the hero swaps to `NextTripBoardingPass`, which has no create button.
- Adds a compact round `+` icon button (`aria-label="Create trip"`) to `NavigationAuth` that renders only below the `md` breakpoint and navigates to `/create-trip`. The labeled desktop button is unchanged and takes over at `md`+.

## Test plan
- [x] New `NavigationAuth.test.tsx` (written test-first): mobile button exists with `md:hidden` and navigates to `/create-trip`; desktop button keeps `hidden md:inline-block`; signed-out users see neither control
- [x] Full suite green: 482 tests / 48 files
- [x] ESLint clean; no new `tsc` errors in touched files
- [ ] Visual check on a phone: round `+` next to the avatar in the top-right when signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)