### PR TITLE
Fix reservation dialog silently blocking Save on empty notes

### DIFF
--- a/src/components/trip/dining/RestaurantReservationForm.test.tsx
+++ b/src/components/trip/dining/RestaurantReservationForm.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RestaurantReservationForm from './RestaurantReservationForm';
+import { reservationFormSchema } from './reservationFormSchema';
+
+// A trip_days lookup runs on submit; keep the chain permissive so both the
+// one-eq and two-eq call sites resolve.
+vi.mock('@/integrations/supabase/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.single = () => Promise.resolve({ data: { day_id: 'day-1', date: '2026-07-01' }, error: null });
+  return { supabase: { from: () => chain } };
+});
+
+vi.mock('@/utils/googleMapsLoader', () => ({
+  loadGoogleMapsAPI: () => Promise.resolve(),
+  getPlaceDetails: () => Promise.resolve(null),
+  getPhotoUrl: () => null,
+}));
+
+vi.mock('@/services/travelers', () => ({
+  getJunctionTravelerIds: () => Promise.resolve({ data: [] }),
+  setJunctionTravelers: () => Promise.resolve(),
+}));
+
+vi.mock('@/hooks/useTripTimezone', () => ({ useTripTimezone: () => ({ tripTimezone: null }) }));
+vi.mock('@/hooks/useResolveTimezone', () => ({ useResolveTimezone: () => ({ timeZoneId: null }) }));
+
+vi.mock('./RestaurantSearchInput', () => ({
+  default: ({ value, onChange }: { value?: string; onChange: (v: string) => void }) => (
+    <input aria-label="Restaurant Name" value={value ?? ''} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+vi.mock('../travelers/TravelersTagMultiSelect', () => ({ default: () => null }));
+vi.mock('../budget/CurrencySelector', () => ({ default: () => null }));
+vi.mock('../_shared/TimezoneSelect', () => ({ default: () => null }));
+
+/** Mirrors a saved row: Postgres stores NULL for anything left blank. */
+const savedReservation = {
+  id: 'res-1',
+  trip_id: 'trip-1',
+  day_id: 'day-1',
+  order_index: 0,
+  restaurant_name: 'Septime',
+  reservation_time: '19:30:00',
+  notes: null,
+  address: null,
+  phone_number: null,
+  website: null,
+  place_id: null,
+  currency: null,
+  cost: null,
+  number_of_people: null,
+  rating: null,
+  timezone: null,
+};
+
+const renderForm = (onSubmit: ReturnType<typeof vi.fn>) =>
+  render(
+    <RestaurantReservationForm
+      onSubmit={onSubmit}
+      defaultValues={savedReservation}
+      tripId="trip-1"
+      tripArrivalDate="2026-07-01"
+      tripDepartureDate="2026-07-05"
+    />,
+  );
+
+describe('RestaurantReservationForm', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('saves a reservation whose notes are empty', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm(onSubmit);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ restaurant_name: 'Septime', notes: '' });
+  });
+
+  it('keeps notes the user typed', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm(onSubmit);
+
+    await userEvent.type(screen.getByLabelText('Notes'), 'Window table');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ notes: 'Window table' });
+  });
+
+  it('accepts a null notes value from the database', () => {
+    const parsed = reservationFormSchema.safeParse({
+      restaurant_name: 'Septime',
+      reservation_date: '2026-07-01',
+      reservation_time: '19:30:00',
+      notes: null,
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/components/trip/dining/RestaurantReservationForm.tsx
+++ b/src/components/trip/dining/RestaurantReservationForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import DOMPurify from 'dompurify';
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import * as z from "zod";
+import { reservationFormSchema, type ReservationFormValues } from './reservationFormSchema';
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -35,13 +35,6 @@ import {
 } from "@/utils/googleMapsLoader";
 
 /* ------------------------------ helpers ------------------------------ */
-const toNullableNumber = (val: unknown) => {
-  if (val === '' || val === null || typeof val === 'undefined') return undefined;
-  if (typeof val === 'number' && !Number.isNaN(val)) return val;
-  const num = Number(val);
-  return Number.isNaN(num) ? undefined : num;
-};
-
 /** Prefer our proxy photo URL; fall back to direct Google endpoint only if a public key exists. */
 const resolvePhotoUrl = (p: PlacePhotoMeta, maxWidth = 360): string | null => {
   const viaProxy = getPhotoUrl?.(p, maxWidth);
@@ -71,27 +64,7 @@ const resolvePhotoUrl = (p: PlacePhotoMeta, maxWidth = 360): string | null => {
   return null;
 };
 
-// ────────────────────────────────────────────────────────────────────────────────
-// Schema
-// ────────────────────────────────────────────────────────────────────────────────
-const formSchema = z.object({
-  restaurant_name: z.string().min(1, "Restaurant name is required"),
-  reservation_date: z.string().min(1, "Reservation date is required"),
-  reservation_time: z.string().min(1, "Reservation time is required"),
-  address: z.string().optional().nullable(),
-  phone_number: z.string().optional().nullable(),
-  website: z.string().optional().nullable(),
-  number_of_people: z.preprocess(toNullableNumber, z.number().int().positive().optional().nullable()),
-  notes: z.string().optional(),
-  cost: z.preprocess(toNullableNumber, z.number().optional()),
-  currency: z.string().optional().nullable(),
-  place_id: z.string().optional().nullable(),
-  rating: z.preprocess(toNullableNumber, z.number().optional()),
-  travelers: z.array(z.string()).optional(),
-  timezone: z.string().optional().nullable(),
-});
-
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = ReservationFormValues;
 
 interface RestaurantReservationFormProps {
   onSubmit: (data: FormValues & { trip_id: string }) => Promise<void>;
@@ -156,15 +129,18 @@ const RestaurantReservationForm: React.FC<RestaurantReservationFormProps> = ({
   };
 
   const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(reservationFormSchema),
     defaultValues: {
       restaurant_name: '',
-      reservation_time: '',
       number_of_people: undefined,
-      notes: '',
       cost: undefined,
       currency: undefined,
       ...defaultValues,
+      // A saved reservation stores NULL for anything the user left blank. These
+      // back controlled inputs, so normalize before react-hook-form sees them —
+      // a null here fails validation and blocks Save with no visible reason.
+      reservation_time: defaultValues?.reservation_time ?? '',
+      notes: defaultValues?.notes ?? '',
       timezone: defaultValues?.timezone ?? null,
       reservation_date: getPreselectedDate(), // Smart date preselection
     },
@@ -605,8 +581,9 @@ const RestaurantReservationForm: React.FC<RestaurantReservationFormProps> = ({
             <FormItem>
               <FormLabel>Notes</FormLabel>
               <FormControl>
-                <Textarea {...field} className="bg-white" rows={1} />
+                <Textarea {...field} value={field.value ?? ''} className="bg-white" rows={1} />
               </FormControl>
+              <FormMessage />
             </FormItem>
           )}
         />

--- a/src/components/trip/dining/reservationFormSchema.ts
+++ b/src/components/trip/dining/reservationFormSchema.ts
@@ -1,0 +1,31 @@
+import * as z from "zod";
+
+const toNullableNumber = (val: unknown) => {
+  if (val === '' || val === null || typeof val === 'undefined') return undefined;
+  if (typeof val === 'number' && !Number.isNaN(val)) return val;
+  const num = Number(val);
+  return Number.isNaN(num) ? undefined : num;
+};
+
+/**
+ * Optional fields are `.nullable()` because a saved reservation comes straight
+ * from Postgres, where anything the user left blank is NULL.
+ */
+export const reservationFormSchema = z.object({
+  restaurant_name: z.string().min(1, "Restaurant name is required"),
+  reservation_date: z.string().min(1, "Reservation date is required"),
+  reservation_time: z.string().min(1, "Reservation time is required"),
+  address: z.string().optional().nullable(),
+  phone_number: z.string().optional().nullable(),
+  website: z.string().optional().nullable(),
+  number_of_people: z.preprocess(toNullableNumber, z.number().int().positive().optional().nullable()),
+  notes: z.string().optional().nullable(),
+  cost: z.preprocess(toNullableNumber, z.number().optional()),
+  currency: z.string().optional().nullable(),
+  place_id: z.string().optional().nullable(),
+  rating: z.preprocess(toNullableNumber, z.number().optional()),
+  travelers: z.array(z.string()).optional(),
+  timezone: z.string().optional().nullable(),
+});
+
+export type ReservationFormValues = z.infer<typeof reservationFormSchema>;


### PR DESCRIPTION
Editing a saved reservation loaded the row straight from Postgres, where
a blank Notes field is NULL. The form schema declared notes as
`z.string().optional()`, which accepts undefined but rejects null, so
validation failed on a field the user had never touched. The Notes item
had no <FormMessage />, so nothing was rendered — react-hook-form just
moved focus to the textarea and Save did nothing. Typing anything into
Notes made the error go away, which made Notes look required.

- Make notes (and every other blank-able field) nullable in the schema
- Normalize null notes / reservation_time to '' before the form sees them
- Render <FormMessage /> under Notes so a failure here can't be invisible
- Move the schema to its own module so it can be unit-tested without
  tripping the react-refresh/only-export-components lint rule

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017C7WqjAahCL788aPw2cq5m