### PR TITLE
Refine the shared-trip email

### DIFF
--- a/src/services/tripSharingService.ts
+++ b/src/services/tripSharingService.ts
@@ -102,8 +102,33 @@ export const shareTrip = async (tripId: string, email: string, tripDestination: 
       }
     }
 
-    // Send email notification (best-effort; the share row is already saved)
-    await sendShareNotification(email, user.email || 'A WanderLuxe user', tripDestination, tripId);
+    // Resolve a friendly display name for the sharer so the email reads
+    // "Kevin Lowe shared…" rather than a bare address.
+    const { data: sharerProfile } = await supabase
+      .from('profiles')
+      .select('full_name')
+      .eq('id', user.id)
+      .maybeSingle();
+    const sharedByName =
+      sharerProfile?.full_name?.trim() ||
+      (user.user_metadata?.full_name as string | undefined)?.trim() ||
+      (user.user_metadata?.name as string | undefined)?.trim() ||
+      '';
+
+    // Send email notification (best-effort; the share row is already saved).
+    // `destination` holds the trip's title, `primary_destination` the place.
+    await sendShareNotification({
+      toEmail: email,
+      fromEmail: user.email || 'A WanderLuxe user',
+      tripName: tripData.destination || tripDestination,
+      tripDestination: tripData.primary_destination || tripDestination,
+      tripId,
+      sharedByName,
+      arrivalDate: tripData.arrival_date ?? undefined,
+      departureDate: tripData.departure_date ?? undefined,
+      coverImageUrl: tripData.cover_image_url ?? undefined,
+      permissionLevel,
+    });
 
     // Callers handle their own toast messages
     return true;
@@ -113,15 +138,28 @@ export const shareTrip = async (tripId: string, email: string, tripDestination: 
   }
 };
 
+export interface ShareNotificationParams {
+  toEmail: string;
+  fromEmail: string;
+  /** The trip's title (`trips.destination`). */
+  tripName: string;
+  /** The place the trip is to (`trips.primary_destination`), when known. */
+  tripDestination: string;
+  tripId: string;
+  /** Sharer's display name; falls back to their email in the email itself. */
+  sharedByName?: string;
+  arrivalDate?: string;
+  departureDate?: string;
+  coverImageUrl?: string;
+  permissionLevel?: PermissionLevel;
+}
+
 /**
  * Send an email notification to a user that a trip has been shared with them
  * Using Supabase Edge Function for email delivery
  */
 export const sendShareNotification = async (
-  toEmail: string,
-  fromEmail: string,
-  tripDestination: string,
-  tripId: string
+  params: ShareNotificationParams
 ): Promise<boolean> => {
   try {
     // Get the Supabase URL and anon key from environment
@@ -140,12 +178,7 @@ export const sendShareNotification = async (
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${supabaseAnonKey}` // Add authorization header
       },
-      body: JSON.stringify({
-        toEmail,
-        fromEmail,
-        tripDestination,
-        tripId
-      })
+      body: JSON.stringify(params)
     });
 
     let result;

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-// /supabase/functions/send-share-trip-email/index.ts
+// /supabase/functions/send-email/index.ts
 // WanderLuxe — Share Trip Email via Mailgun (Supabase Edge Function)
 const DEFAULT_VIEW_URL = "https://wanderluxe.io";
 // Minimal CORS (tighten the origin if you want an allowlist)
@@ -12,16 +12,283 @@ function getCorsHeaders(origin: string | null): Record<string, string> {
 const MAILGUN_API_KEY = Deno.env.get("MAILGUN_API_KEY");
 const MAILGUN_DOMAIN = Deno.env.get("MAILGUN_DOMAIN") || "mail.wanderluxe.io";
 if (!MAILGUN_API_KEY) throw new Error("MAILGUN_API_KEY is not set");
+
+// Brand palette approximations for emails
+const COLORS = {
+  sand50: "#f8f5f0",
+  sand100: "#f3efe8",
+  sand200: "#e9e3da",
+  earth600: "#7c5e45",
+  text: "#2a2521",
+  muted: "#6b655f",
+};
+
+const FONT_SANS = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif";
+const FONT_SERIF = "Georgia,'Times New Roman',Times,serif";
+
 // tiny helpers
-const isEmail = (s)=>/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s) && !/[\r\n]/.test(s);
-const esc = (s)=>s.replace(/[&<>"']/g, (m)=>({
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      '"': "&quot;",
-      "'": "&#39;"
-    })[m]);
-Deno.serve(async (req)=>{
+const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s) && !/[\r\n]/.test(s);
+const esc = (s: string) =>
+  s.replace(/[&<>"']/g, (m) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }[m]!));
+
+// Subject/preheader are plain text — HTML-escaping them would leak "&amp;" into the inbox.
+const stripNewlines = (s: string) => s.replace(/[\r\n]+/g, " ").trim();
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function parseISODate(iso: string): { y: number; m: number; d: number } | null {
+  const [y, m, d] = (iso || "").split("-").map(Number);
+  if (!y || !m || !d || m < 1 || m > 12) return null;
+  return { y, m, d };
+}
+
+/** "Aug 15–22, 2026" · "Aug 28 – Sep 3, 2026" · "Dec 28, 2026 – Jan 3, 2027" */
+function formatDateRange(startIso: string, endIso: string): string {
+  const a = parseISODate(startIso);
+  const b = parseISODate(endIso);
+  if (!a && !b) return "";
+  if (!a || !b) {
+    const o = (a ?? b)!;
+    return `${MONTHS[o.m - 1]} ${o.d}, ${o.y}`;
+  }
+  if (a.y === b.y && a.m === b.m) return `${MONTHS[a.m - 1]} ${a.d}–${b.d}, ${a.y}`;
+  if (a.y === b.y) return `${MONTHS[a.m - 1]} ${a.d} – ${MONTHS[b.m - 1]} ${b.d}, ${a.y}`;
+  return `${MONTHS[a.m - 1]} ${a.d}, ${a.y} – ${MONTHS[b.m - 1]} ${b.d}, ${b.y}`;
+}
+
+function nightsBetween(startIso: string, endIso: string): number | null {
+  const a = parseISODate(startIso);
+  const b = parseISODate(endIso);
+  if (!a || !b) return null;
+  const ms = Date.UTC(b.y, b.m - 1, b.d) - Date.UTC(a.y, a.m - 1, a.d);
+  const nights = Math.round(ms / 86400000);
+  return nights > 0 ? nights : null;
+}
+
+/**
+ * Places from Google often arrive as "6181 Elmau, Austria" — drop a leading
+ * postal code so the email reads like a destination, not an address label.
+ */
+function tidyPlace(place: string): string {
+  return place.replace(/^\s*\d{3,6}\s+(?=\p{L})/u, "").trim();
+}
+
+/** Only https images are embedded; Unsplash URLs get a fixed banner crop. */
+function safeImageUrl(raw: string): string | null {
+  if (!raw) return null;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "https:") return null;
+  if (u.hostname === "images.unsplash.com") {
+    u.searchParams.set("w", "1200");
+    u.searchParams.set("h", "500");
+    u.searchParams.set("fit", "crop");
+    u.searchParams.set("crop", "entropy");
+    u.searchParams.set("q", "75");
+    u.searchParams.set("auto", "format");
+  }
+  return u.toString();
+}
+
+type EmailView = {
+  toEmail: string;
+  sharerLabel: string;      // display name when we have one, else the email
+  sharerEmail: string;
+  tripName: string;
+  place: string;            // "" when absent or same as the trip name
+  dateRange: string;        // "" when dates are missing
+  nights: number | null;
+  canEdit: boolean;
+  coverImageUrl: string | null;
+  viewUrl: string;
+};
+
+function renderHtml(v: EmailView): string {
+  const accessLabel = v.canEdit ? "Can edit" : "View only";
+  const inviteLine = v.canEdit
+    ? `<strong>${esc(v.sharerLabel)}</strong> invited you to view and help plan this trip.`
+    : `<strong>${esc(v.sharerLabel)}</strong> invited you to follow along with this trip.`;
+
+  const metaBits = [
+    v.place ? esc(v.place) : "",
+    v.dateRange ? esc(v.dateRange) : "",
+    v.nights ? `${v.nights} ${v.nights === 1 ? "night" : "nights"}` : "",
+  ].filter(Boolean);
+
+  const preheader = stripNewlines(
+    [
+      `${v.sharerLabel} shared "${v.tripName}"`,
+      [v.place, v.dateRange].filter(Boolean).join(" · "),
+    ].filter(Boolean).join(" — "),
+  );
+
+  const coverBlock = v.coverImageUrl
+    ? `
+                <tr>
+                  <td style="padding:0;line-height:0;font-size:0;">
+                    <img src="${esc(v.coverImageUrl)}" width="600" alt=""
+                         style="display:block;width:100%;max-width:600px;height:auto;border:0;outline:none;text-decoration:none;border-radius:12px 12px 0 0;">
+                  </td>
+                </tr>`
+    : "";
+
+  const metaBlock = metaBits.length
+    ? `
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px 0;">
+                      <tr>
+                        <td class="meta" style="background:${COLORS.sand100};border-radius:8px;padding:12px 16px;font-family:${FONT_SANS};font-size:14px;line-height:1.5;color:${COLORS.muted};">
+                          ${metaBits.join(' <span style="color:#c9c0b4;">·</span> ')}
+                        </td>
+                      </tr>
+                    </table>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="x-apple-disable-message-reformatting">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<!-- Stop iOS/Outlook from auto-linking the addresses below in default blue. -->
+<meta name="format-detection" content="telephone=no,date=no,address=no,email=no">
+<title>${esc(v.tripName)} · WanderLuxe</title>
+<style>
+:root { color-scheme: light dark; supported-color-schemes: light dark; }
+@media (prefers-color-scheme: dark) {
+  body, .bg { background: #141312 !important; }
+  .card { background: #1f1d1b !important; border-color: #332f2b !important; }
+  .meta { background: #262321 !important; color: #bdb6ac !important; }
+  .text { color: #f3f0eb !important; }
+  .heading { color: #f7f4ef !important; }
+  .muted, .footer { color: #a9a29a !important; }
+  .eyebrow, .wordmark { color: #c2a184 !important; }
+  .pill { background: #2f2a26 !important; color: #d8cec2 !important; border-color: #433c35 !important; }
+  .cta { background: #8a6a4e !important; color: #ffffff !important; }
+  .divider { border-color: #332f2b !important; }
+  a.link { color: #c2a184 !important; }
+}
+@media screen and (max-width: 600px) {
+  .container { width: 100% !important; }
+  .px { padding-left: 22px !important; padding-right: 22px !important; }
+  .heading { font-size: 26px !important; }
+}
+a.link { color: ${COLORS.earth600}; }
+/* Addresses shown as plain text, not tappable mailto links. */
+.noline, .noline a { color: inherit !important; text-decoration: none !important; }
+</style>
+</head>
+<body style="margin:0;padding:0;background:${COLORS.sand50};" class="bg">
+  <div style="display:none;font-size:1px;color:${COLORS.sand50};line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">${esc(preheader)}</div>
+  <div style="display:none;max-height:0;overflow:hidden;">&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;</div>
+  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" class="bg" style="background:${COLORS.sand50};">
+    <tr>
+      <td align="center" class="bg" style="padding:24px;background:${COLORS.sand50};">
+        <table role="presentation" width="600" class="container" cellpadding="0" cellspacing="0" style="width:600px;max-width:600px;">
+          <tr>
+            <td style="padding:8px 24px 20px 24px;text-align:center;">
+              <div class="wordmark" style="font-family:${FONT_SERIF};font-size:26px;letter-spacing:.5px;color:${COLORS.earth600};"><strong>WanderLuxe</strong></div>
+            </td>
+          </tr>
+          <tr>
+            <td class="card" style="background:#ffffff;border:1px solid ${COLORS.sand200};border-radius:12px;overflow:hidden;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                ${coverBlock}
+                <tr>
+                  <td class="px" style="padding:28px 32px 32px 32px;font-family:${FONT_SANS};">
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 10px 0;">
+                      <tr>
+                        <td class="eyebrow" style="font-family:${FONT_SANS};font-size:12px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:${COLORS.earth600};padding-right:10px;">
+                          Shared with you
+                        </td>
+                        <td class="pill" style="font-family:${FONT_SANS};font-size:11px;font-weight:600;letter-spacing:.04em;color:${COLORS.muted};background:${COLORS.sand100};border:1px solid ${COLORS.sand200};border-radius:999px;padding:3px 10px;white-space:nowrap;">
+                          ${accessLabel}
+                        </td>
+                      </tr>
+                    </table>
+
+                    <h1 class="heading" style="margin:0 0 6px 0;font-family:${FONT_SERIF};font-size:30px;line-height:1.2;font-weight:normal;color:${COLORS.text};">
+                      ${esc(v.tripName)}
+                    </h1>
+
+                    ${metaBlock}
+
+                    <p class="text" style="margin:0 0 24px 0;font-size:16px;line-height:1.6;color:${COLORS.text};">
+                      ${inviteLine}
+                    </p>
+
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
+                      <tr>
+                        <td align="center" bgcolor="${COLORS.earth600}" style="border-radius:8px;">
+                          <a href="${esc(v.viewUrl)}" target="_blank" class="cta"
+                             style="font-family:${FONT_SANS};display:inline-block;padding:15px 30px;text-decoration:none;color:#ffffff;background:${COLORS.earth600};border-radius:8px;font-weight:600;font-size:16px;line-height:1;">
+                             View the itinerary
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <hr class="divider" style="border:none;border-top:1px solid ${COLORS.sand200};margin:0 0 16px 0;">
+
+                    <p class="muted" style="margin:0 0 10px 0;font-size:13px;line-height:1.6;color:${COLORS.muted};">
+                      Sign in with <span class="noline" style="font-weight:600;color:${COLORS.muted};">${esc(v.toEmail)}</span> to open it. No account yet? Sign up with that address and the trip will be waiting in <em>Shared With Me</em>.
+                    </p>
+                    <p class="muted" style="margin:0;font-size:13px;line-height:1.6;color:${COLORS.muted};">
+                      Button not working? <a class="link" href="${esc(v.viewUrl)}" target="_blank">Open your trip</a>
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="footer" style="text-align:center;padding:20px 24px;color:${COLORS.muted};font-size:12px;line-height:1.6;font-family:${FONT_SANS};">
+              You received this because <span class="noline" style="color:${COLORS.muted};">${esc(v.sharerEmail)}</span> shared a trip with you on WanderLuxe.<br>
+              © ${new Date().getFullYear()} WanderLuxe. All rights reserved.
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+function renderText(v: EmailView): string {
+  const metaBits = [v.place, v.dateRange, v.nights ? `${v.nights} ${v.nights === 1 ? "night" : "nights"}` : ""].filter(Boolean);
+  return [
+    `${v.sharerLabel} shared a trip with you on WanderLuxe.`,
+    ``,
+    v.tripName,
+    ...(metaBits.length ? [metaBits.join(" · ")] : []),
+    `Access: ${v.canEdit ? "Can edit" : "View only"}`,
+    ``,
+    v.canEdit
+      ? `${v.sharerLabel} invited you to view and help plan this trip.`
+      : `${v.sharerLabel} invited you to follow along with this trip.`,
+    ``,
+    `View the itinerary: ${v.viewUrl}`,
+    ``,
+    `Sign in with ${v.toEmail} to open it. No account yet? Sign up with that address and the trip will be waiting in "Shared With Me".`,
+    ``,
+    `Happy travels,`,
+    `The WanderLuxe Team`,
+  ].join("\n");
+}
+
+Deno.serve(async (req) => {
   const corsHeaders = getCorsHeaders(req.headers.get('origin'));
   if (req.method === "OPTIONS") return new Response(null, {
     headers: corsHeaders
@@ -45,113 +312,45 @@ Deno.serve(async (req)=>{
     const tripDestination = (body.tripDestination ?? "").trim();
     const tripName = (body.tripName ?? tripDestination).trim();
     const tripId = (body.tripId ?? "").trim();
+    // Optional enrichment — the email degrades gracefully without any of it.
+    const sharerName = stripNewlines((body.sharedByName ?? "").toString()).slice(0, 80);
+    const arrivalDate = (body.arrivalDate ?? "").toString().trim();
+    const departureDate = (body.departureDate ?? "").toString().trim();
+    const coverImageUrl = safeImageUrl((body.coverImageUrl ?? "").toString().trim());
+    const canEdit = body.permissionLevel !== "read";
+
     if (!isEmail(toEmail) || !isEmail(fromEmail) || !tripDestination) {
       throw new Error("Missing or invalid fields: toEmail, fromEmail, or tripDestination");
     }
+
     // Build the view URL - include tripId if provided for direct navigation
     const viewUrl = tripId
-      ? `${DEFAULT_VIEW_URL}/trip/${tripId}`
+      ? `${DEFAULT_VIEW_URL}/trip/${encodeURIComponent(tripId)}`
       : DEFAULT_VIEW_URL;
-    // Brand palette approximations for emails
-    const colors = {
-      sand50: "#f8f5f0",
-      sand200: "#e9e3da",
-      earth600: "#7c5e45",
-      text: "#2a2521"
+
+    // The trip name and the place are frequently the same string ("Gregg in
+    // Austria"); only show the place when it adds something.
+    const place = tidyPlace(tripDestination);
+    const showPlace = place && place.toLowerCase() !== tripName.toLowerCase() ? place : "";
+
+    const view: EmailView = {
+      toEmail,
+      sharerLabel: sharerName || fromEmail,
+      sharerEmail: fromEmail,
+      tripName,
+      place: showPlace,
+      dateRange: formatDateRange(arrivalDate, departureDate),
+      nights: nightsBetween(arrivalDate, departureDate),
+      canEdit,
+      coverImageUrl,
+      viewUrl,
     };
-    const emailSubject = `${esc(fromEmail)} shared “${esc(tripName)}” with you on WanderLuxe`;
-    const htmlContent = `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="x-apple-disable-message-reformatting">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>WanderLuxe</title>
-<style>
-@media (prefers-color-scheme: dark) {
-  body, .bg, .card { background: #1b1a19 !important; }
-  .text { color: #f3f0eb !important; }
-  .muted { color: #bdb6ac !important; }
-  .cta { background: ${colors.earth600} !important; color: #ffffff !important; }
-  .divider { border-color: #3b3733 !important; }
-}
-@media screen and (max-width: 600px) {
-  .container { width: 100% !important; }
-  .px { padding-left: 20px !important; padding-right: 20px !important; }
-}
-a { color: ${colors.earth600}; }
-</style>
-</head>
-<body style="margin:0;padding:0;background:${colors.sand50};" class="bg">
-  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:${colors.sand50};">
-    <tr>
-      <td align="center" style="padding:24px;">
-        <table role="presentation" width="600" class="container" cellpadding="0" cellspacing="0" style="width:600px;max-width:600px;">
-          <tr>
-            <td style="padding:24px 24px 8px 24px;text-align:center;">
-              <div style="font-family: Georgia, 'Times New Roman', Times, serif;font-size:28px;letter-spacing:.5px;color:${colors.earth600};"><strong>WanderLuxe</strong></div>
-            </td>
-          </tr>
-          <tr>
-            <td class="card" style="background:#ffffff;border:1px solid ${colors.sand200};border-radius:8px;padding:0 0 8px 0;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td class="px" style="padding:24px 32px;">
-                    <p class="text" style="margin:0 0 12px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:16px;line-height:1.6;color:${colors.text};">
-                      Hello!
-                    </p>
-                    <p class="text" style="margin:0 0 12px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:16px;line-height:1.6;color:${colors.text};">
-                      <strong>${esc(fromEmail)}</strong> has shared a trip with you on WanderLuxe:
-                      <strong>“${esc(tripName)}”</strong> (${esc(tripDestination)}).
-                    </p>
-                    <p class="text" style="margin:0 0 24px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:16px;line-height:1.6;color:${colors.text};">
-                      To view this trip, sign in to your WanderLuxe account. If you don’t have one,
-                      create it using <strong>${esc(toEmail)}</strong> and it will appear in <em>Shared With Me</em>.
-                    </p>
-                    <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin:8px auto 24px auto;">
-                      <tr>
-                        <td align="center" bgcolor="${colors.earth600}" style="border-radius:6px;">
-                          <a href="${viewUrl}" target="_blank"
-                             class="cta"
-                             style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;display:inline-block;padding:12px 22px;text-decoration:none;color:#ffffff;background:${colors.earth600};border-radius:6px;font-weight:600;">
-                             View Shared Trip
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
-                    <hr class="divider" style="border:none;border-top:1px solid ${colors.sand200};margin:8px 0 16px 0;">
-                    <p class="muted" style="margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:13px;line-height:1.6;color:#6b655f;">
-                      If the button doesn't work, copy and paste this link:<br>
-                      <a href="${viewUrl}" target="_blank">${viewUrl}</a>
-                    </p>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-          <tr>
-            <td style="text-align:center;padding:16px 24px;color:#6b655f;font-size:12px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
-              © ${new Date().getFullYear()} WanderLuxe. All rights reserved.
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>`;
-    const textContent = [
-      `Hello!`,
-      ``,
-      `${fromEmail} shared a trip with you on WanderLuxe: "${tripName}" (${tripDestination}).`,
-      ``,
-      `To view this trip, sign in to your WanderLuxe account. If you don't have one, create it using ${toEmail} and it will appear in "Shared With Me".`,
-      ``,
-      `Open: ${viewUrl}`,
-      ``,
-      `Happy travels,`,
-      `The WanderLuxe Team`
-    ].join("\n");
+
+    // Subject is plain text — do not HTML-escape it.
+    const emailSubject = stripNewlines(`${view.sharerLabel} shared “${tripName}” with you`);
+    const htmlContent = renderHtml(view);
+    const textContent = renderText(view);
+
     // Build Mailgun form-data
     const formData = new FormData();
     // Keep From aligned with Mailgun domain for SPF/DKIM
@@ -185,7 +384,7 @@ a { color: ${colors.earth600}; }
         "Content-Type": "application/json"
       }
     });
-  } catch (err) {
+  } catch (err: any) {
     console.error("send-share-trip-email error:", err);
     return new Response(JSON.stringify({
       success: false,

--- a/supabase/functions/send-trip-reminders/index.ts
+++ b/supabase/functions/send-trip-reminders/index.ts
@@ -1,8 +1,8 @@
 // deno-lint-ignore-file no-explicit-any
 // WanderLuxe — Trip Reminder Email (Supabase Edge Function)
 // Fires hourly via pg_cron; only emails when it is 20:00 in America/New_York.
-// Sends a single reminder per trip 3 days before start_date to every registered
-// traveler in trip_shares.
+// Sends a single reminder per trip 3 days before arrival_date to every
+// registered traveler in trip_shares.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4';
 
 const DEFAULT_VIEW_URL = 'https://wanderluxe.io';
@@ -58,8 +58,8 @@ type TripRow = {
   trip_id: string;
   destination: string;
   primary_destination: string | null;
-  start_date: string;
-  end_date: string;
+  arrival_date: string;
+  departure_date: string;
 };
 
 type Accommodation = {
@@ -314,7 +314,7 @@ Deno.serve(async (req) => {
       });
     }
 
-    // today in ET, then +3 days as the trip target start_date.
+    // today in ET, then +3 days as the trip target arrival_date.
     const etDateParts = new Intl.DateTimeFormat('en-CA', {
       timeZone: 'America/New_York',
       year: 'numeric',
@@ -331,8 +331,8 @@ Deno.serve(async (req) => {
 
     const { data: trips, error: tripsErr } = await supabase
       .from('trips')
-      .select('trip_id, destination, primary_destination, start_date, end_date')
-      .eq('start_date', targetDate)
+      .select('trip_id, destination, primary_destination, arrival_date, departure_date')
+      .eq('arrival_date', targetDate)
       .eq('hidden', false);
 
     if (tripsErr) throw tripsErr;
@@ -428,7 +428,7 @@ Deno.serve(async (req) => {
         });
 
         const tripLabel = trip.primary_destination || trip.destination;
-        const tripDates = `${formatDate(trip.start_date)} – ${formatDate(trip.end_date)}`;
+        const tripDates = `${formatDate(trip.arrival_date)} – ${formatDate(trip.departure_date)}`;
         const viewUrl = `${DEFAULT_VIEW_URL}/trip/${trip.trip_id}`;
         const subject = `Your trip to ${tripLabel} starts in 3 days`;
 


### PR DESCRIPTION
The share email showed the trip title twice ("Gregg in Austria" (Gregg in
Austria)) because the client never sent tripName, so it fell back to
tripDestination. Meanwhile the trip's place, dates and cover image were
already loaded on the client and thrown away.

Send the data we already have and rebuild the template around it:

- Map destination -> tripName and primary_destination -> place, and only
  render the place when it differs from the title. Fixes the duplication.
- Add cover image banner, date range ("Aug 15-22, 2026"), night count,
  and a view/edit access pill. Every field degrades gracefully.
- Lead with the trip instead of "Hello!"; move the sign-in instructions
  below the CTA as fine print.
- Add a hidden preheader so the inbox preview is controlled.
- Subject now leads with the sharer's display name, and is no longer
  HTML-escaped (trip names containing & rendered as "&amp;").
- Stop iOS/Outlook auto-linking addresses in default blue.
- Fix dark mode: the wrapper table kept its inline sand background, so the
  page stayed light around the card. Card, border and wordmark now adapt.
- Validate cover image URLs (https only) and normalise Unsplash crops.
- Bigger CTA tap target; plain-text part matches the HTML.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G1UhdReQVrD4b5sxeMsEWt