### PR TITLE
Send signed-out share-link visitors to sign-in, then back to the trip

### DIFF
--- a/src/components/trip/details/useTripAccessGate.ts
+++ b/src/components/trip/details/useTripAccessGate.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface TripAccessGateArgs {
+  /** Explore routes are public browsing and keep their normal not-found page. */
+  onExploreRoute: boolean;
+  tripLoading: boolean;
+  permissionsLoading: boolean;
+  canView: boolean;
+}
+
+/**
+ * Sends a signed-out visitor who cannot read a trip to sign in, and brings
+ * them back to the same URL afterwards.
+ *
+ * Someone following a share link while logged out lands on a trip with
+ * nothing to show: RLS hides private rows from anonymous readers, so the trip
+ * query and the permission check both come back empty. `/trip/:tripId` is
+ * deliberately unprotected so public trips work anonymously, which means
+ * nothing else routes these visitors to sign-in.
+ *
+ * The trip URL goes into the `pendingRedirect` slot that Auth.tsx already
+ * honours for password sign-in, sign-up and Google OAuth.
+ *
+ * @returns true while the redirect is pending, so the caller can hold a
+ * loading state instead of flashing an error on the way out.
+ */
+export function useTripAccessGate({
+  onExploreRoute,
+  tripLoading,
+  permissionsLoading,
+  canView,
+}: TripAccessGateArgs): boolean {
+  const { session, profileLoaded } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // `profileLoaded` flips true for anonymous visitors too, so it means "auth
+  // has settled", not "logged in" — without it a signed-in user whose session
+  // is still hydrating would be bounced to /auth.
+  const isAnonymous = profileLoaded && !session;
+  const accessChecked = !tripLoading && !permissionsLoading;
+  const blockedFromTrip = accessChecked && !canView;
+  const mustSignIn = !onExploreRoute && isAnonymous && blockedFromTrip;
+
+  useEffect(() => {
+    if (!mustSignIn) return;
+    sessionStorage.setItem('pendingRedirect', location.pathname);
+    navigate('/auth', { replace: true });
+  }, [mustSignIn, location.pathname, navigate]);
+
+  return mustSignIn;
+}

--- a/src/pages/TripDetails.test.tsx
+++ b/src/pages/TripDetails.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+let mockAuth: { session: unknown; profileLoaded: boolean } = {
+  session: null,
+  profileLoaded: true,
+};
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}));
+
+let mockTripQuery: Record<string, unknown> = {
+  trip: null,
+  tripLoading: false,
+  tripError: null,
+  previousTrip: null,
+};
+vi.mock('@/hooks/useTripQuery', () => ({
+  useTripQuery: () => mockTripQuery,
+  useTripIdBySlug: (slug?: string) => ({
+    tripId: slug ? 'trip-from-slug' : undefined,
+    isLoading: false,
+  }),
+}));
+
+let mockPermissions: Record<string, unknown> = {
+  canView: false,
+  canEdit: false,
+  isOwner: false,
+  permissionLevel: null,
+  isLoading: false,
+};
+vi.mock('@/hooks/use-trip-permissions', () => ({
+  useTripPermissions: () => mockPermissions,
+}));
+
+vi.mock('@/components/trip/details/useTripSubscription', () => ({
+  useTripSubscription: (): void => undefined,
+}));
+
+// Heavy children — irrelevant to routing/guard behaviour, stubbed for speed.
+vi.mock('@/components/trip/HeroSection', () => ({ default: () => <div data-testid="hero" /> }));
+vi.mock('@/components/layout/Sidebar', () => ({ default: () => <div /> }));
+vi.mock('@/components/layout/BottomNavigation', () => ({ default: () => <div /> }));
+vi.mock('@/components/layout/QuickAddSheet', () => ({ default: () => <div /> }));
+vi.mock('@/components/trip/TimelineView', () => ({ default: () => <div data-testid="timeline" /> }));
+vi.mock('@/components/trip/BudgetView', () => ({ default: () => <div /> }));
+vi.mock('@/components/trip/BookingView', () => ({ default: () => <div /> }));
+vi.mock('@/components/trip/ai-assistant/AIAssistantPanel', () => ({ default: () => <div /> }));
+vi.mock('@/components/trip/ai-assistant/AIAssistantDrawer', () => ({ default: () => <div /> }));
+vi.mock('@/components/SEO', () => ({ default: (): null => null, SITE_URL: 'https://wanderluxe.io' }));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const TRIP_ID = 'a4268df2-d4a5-44f6-b23b-87cf6e96aee2';
+
+const A_TRIP = {
+  trip_id: TRIP_ID,
+  destination: 'Gregg in Austria',
+  primary_destination: 'Elmau, Austria',
+  arrival_date: '2026-08-15',
+  departure_date: '2026-08-22',
+  cover_image_url: null as string | null,
+  is_public: false,
+};
+
+let TripDetails: React.ComponentType;
+beforeEach(async () => {
+  const mod = await import('./TripDetails');
+  TripDetails = mod.default;
+});
+
+function renderAt(path: string) {
+  // The skeleton pulls in navigation chrome that reads from React Query.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/trip/:tripId/*" element={<TripDetails />} />
+          <Route path="/explore:slug/*" element={<TripDetails />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('TripDetails — signed-out access to a shared trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockAuth = { session: null, profileLoaded: true };
+    mockTripQuery = { trip: null, tripLoading: false, tripError: null, previousTrip: null };
+    mockPermissions = {
+      canView: false, canEdit: false, isOwner: false, permissionLevel: null, isLoading: false,
+    };
+  });
+
+  it('sends a signed-out visitor to /auth instead of a dead-end error', async () => {
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth', { replace: true });
+    });
+  });
+
+  it('remembers the exact trip URL so sign-in returns the visitor to it', async () => {
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem('pendingRedirect')).toBe(`/trip/${TRIP_ID}/timeline`);
+    });
+  });
+
+  it('never flashes the "could not be found" error on the way to /auth', async () => {
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    expect(screen.queryByText(/could not be found/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/unable to load trip/i)).not.toBeInTheDocument();
+  });
+
+  it('waits for auth to resolve before redirecting, so a signed-in user is not bounced', async () => {
+    // profileLoaded false = AuthContext has not settled yet.
+    mockAuth = { session: null, profileLoaded: false };
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+  });
+
+  it('leaves public trips alone for anonymous visitors', async () => {
+    mockPermissions = { ...mockPermissions, canView: true };
+    mockTripQuery = { ...mockTripQuery, trip: { ...A_TRIP, is_public: true } };
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+  });
+
+  it('does not send explore visitors to sign-in', async () => {
+    renderAt('/explore/vienna-in-spring/timeline');
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+  });
+});
+
+describe('TripDetails — signed-in visitor without access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockAuth = { session: { user: { id: 'u1' } }, profileLoaded: true };
+    // RLS hides the row from someone without access, so the query is empty too —
+    // the access screen must win over the "not found" branch.
+    mockTripQuery = { trip: null, tripLoading: false, tripError: null, previousTrip: null };
+    mockPermissions = {
+      canView: false, canEdit: false, isOwner: false, permissionLevel: null, isLoading: false,
+    };
+  });
+
+  it('shows "Access Restricted" rather than "could not be found"', async () => {
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await waitFor(() => {
+      expect(screen.getByText(/access restricted/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/could not be found/i)).not.toBeInTheDocument();
+  });
+
+  it('does not redirect a signed-in user to /auth', async () => {
+    renderAt(`/trip/${TRIP_ID}/timeline`);
+
+    await waitFor(() => expect(screen.getByText(/access restricted/i)).toBeInTheDocument());
+    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+  });
+});

--- a/src/pages/TripDetails.test.tsx
+++ b/src/pages/TripDetails.test.tsx
@@ -63,6 +63,9 @@ vi.mock('@/components/SEO', () => ({ default: (): null => null, SITE_URL: 'https
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 const TRIP_ID = 'a4268df2-d4a5-44f6-b23b-87cf6e96aee2';
+const TRIP_PATH = `/trip/${TRIP_ID}/timeline`;
+const AUTH_ROUTE = '/auth';
+const REPLACE = { replace: true };
 
 const A_TRIP = {
   trip_id: TRIP_ID,
@@ -109,23 +112,23 @@ describe('TripDetails — signed-out access to a shared trip', () => {
   });
 
   it('sends a signed-out visitor to /auth instead of a dead-end error', async () => {
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/auth', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
     });
   });
 
   it('remembers the exact trip URL so sign-in returns the visitor to it', async () => {
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await waitFor(() => {
-      expect(sessionStorage.getItem('pendingRedirect')).toBe(`/trip/${TRIP_ID}/timeline`);
+      expect(sessionStorage.getItem('pendingRedirect')).toBe(TRIP_PATH);
     });
   });
 
   it('never flashes the "could not be found" error on the way to /auth', async () => {
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
     expect(screen.queryByText(/could not be found/i)).not.toBeInTheDocument();
@@ -135,26 +138,26 @@ describe('TripDetails — signed-out access to a shared trip', () => {
   it('waits for auth to resolve before redirecting, so a signed-in user is not bounced', async () => {
     // profileLoaded false = AuthContext has not settled yet.
     mockAuth = { session: null, profileLoaded: false };
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+    expect(mockNavigate).not.toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
   });
 
   it('leaves public trips alone for anonymous visitors', async () => {
     mockPermissions = { ...mockPermissions, canView: true };
     mockTripQuery = { ...mockTripQuery, trip: { ...A_TRIP, is_public: true } };
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+    expect(mockNavigate).not.toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
   });
 
   it('does not send explore visitors to sign-in', async () => {
     renderAt('/explore/vienna-in-spring/timeline');
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+    expect(mockNavigate).not.toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
   });
 });
 
@@ -172,7 +175,7 @@ describe('TripDetails — signed-in visitor without access', () => {
   });
 
   it('shows "Access Restricted" rather than "could not be found"', async () => {
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await waitFor(() => {
       expect(screen.getByText(/access restricted/i)).toBeInTheDocument();
@@ -181,9 +184,9 @@ describe('TripDetails — signed-in visitor without access', () => {
   });
 
   it('does not redirect a signed-in user to /auth', async () => {
-    renderAt(`/trip/${TRIP_ID}/timeline`);
+    renderAt(TRIP_PATH);
 
     await waitFor(() => expect(screen.getByText(/access restricted/i)).toBeInTheDocument());
-    expect(mockNavigate).not.toHaveBeenCalledWith('/auth', { replace: true });
+    expect(mockNavigate).not.toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
   });
 });

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -7,6 +7,7 @@ import QuickAddSheet from "@/components/layout/QuickAddSheet";
 import { useTripQuery, useTripIdBySlug } from '@/hooks/useTripQuery';
 import { buildOgImageUrl } from '@/utils/tripUrl';
 import { useTripSubscription } from '@/components/trip/details/useTripSubscription';
+import { useTripAccessGate } from '@/components/trip/details/useTripAccessGate';
 import TripDetailsSkeleton from '@/components/trip/details/TripDetailsSkeleton';
 import TripDetailsError from '@/components/trip/details/TripDetailsError';
 import TimelineView from "../components/trip/TimelineView";
@@ -27,7 +28,7 @@ const TripDetails = () => {
   const { tripId: paramsTripId, slug } = useParams<{ tripId?: string; slug?: string }>();
   const location = useLocation();
   const navigate = useNavigate();
-  const { session, profileLoaded } = useAuth();
+  const { session } = useAuth();
 
   const { tripId: tripIdFromSlug, isLoading: slugLookupLoading } = useTripIdBySlug(slug);
   const tripId = paramsTripId ?? tripIdFromSlug ?? undefined;
@@ -53,24 +54,14 @@ const TripDetails = () => {
   const { trip, tripLoading, tripError, previousTrip } = useTripQuery(tripId);
   useTripSubscription(tripId);
 
-  // A signed-out visitor following a share link lands here with nothing to
-  // show — RLS hides private trips from anonymous readers, so both the trip
-  // query and the permission check come back empty. Send them to sign in and
-  // bring them straight back to this URL rather than dead-ending on an error.
-  // `profileLoaded` flips true for anonymous visitors too, so it means "auth
-  // has settled", not "logged in" — without it a signed-in user whose session
-  // is still hydrating would be bounced to /auth.
-  const isAnonymous = profileLoaded && !session;
-  const accessChecked = !tripLoading && !permissionsLoading;
-  const blockedFromTrip = accessChecked && !canView;
-  // Explore routes are public browsing and keep their normal not-found page.
-  const mustSignIn = !onExploreRoute && isAnonymous && blockedFromTrip;
-
-  useEffect(() => {
-    if (!mustSignIn) return;
-    sessionStorage.setItem('pendingRedirect', location.pathname);
-    navigate('/auth', { replace: true });
-  }, [mustSignIn, location.pathname, navigate]);
+  // Signed-out visitors following a share link are sent to sign in and
+  // returned here afterwards; true while that redirect is pending.
+  const mustSignIn = useTripAccessGate({
+    onExploreRoute,
+    tripLoading,
+    permissionsLoading,
+    canView,
+  });
 
   useEffect(() => {
     const tripSlug = (trip as { slug?: string | null })?.slug;

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -27,7 +27,7 @@ const TripDetails = () => {
   const { tripId: paramsTripId, slug } = useParams<{ tripId?: string; slug?: string }>();
   const location = useLocation();
   const navigate = useNavigate();
-  const { session } = useAuth();
+  const { session, profileLoaded } = useAuth();
 
   const { tripId: tripIdFromSlug, isLoading: slugLookupLoading } = useTripIdBySlug(slug);
   const tripId = paramsTripId ?? tripIdFromSlug ?? undefined;
@@ -52,6 +52,27 @@ const TripDetails = () => {
 
   const { trip, tripLoading, tripError, previousTrip } = useTripQuery(tripId);
   useTripSubscription(tripId);
+
+  // A signed-out visitor following a share link lands here with nothing to
+  // show — RLS hides private trips from anonymous readers, so both the trip
+  // query and the permission check come back empty. Send them to sign in and
+  // bring them straight back to this URL rather than dead-ending on an error.
+  // `profileLoaded` guards against redirecting before auth has resolved; it
+  // flips true for anonymous visitors too, so it means "we know for sure".
+  // Explore routes are public browsing and keep their normal not-found page.
+  const mustSignIn =
+    !onExploreRoute &&
+    profileLoaded &&
+    !session &&
+    !tripLoading &&
+    !permissionsLoading &&
+    !canView;
+
+  useEffect(() => {
+    if (!mustSignIn) return;
+    sessionStorage.setItem('pendingRedirect', location.pathname);
+    navigate('/auth', { replace: true });
+  }, [mustSignIn, location.pathname, navigate]);
 
   useEffect(() => {
     const tripSlug = (trip as { slug?: string | null })?.slug;
@@ -124,11 +145,14 @@ const TripDetails = () => {
   }
   if (tripLoading && !previousTrip) return <TripDetailsSkeleton />;
   if (permissionsLoading) return <TripDetailsSkeleton />;
+  // The effect above is navigating to /auth — hold the skeleton rather than
+  // flashing an error on the way out.
+  if (mustSignIn) return <TripDetailsSkeleton />;
   if (tripError) return <TripDetailsError />;
 
-  const displayData = trip || previousTrip;
-  if (!displayData) return <TripDetailsError message="The requested trip could not be found." />;
-
+  // Checked before the trip data: a viewer without access gets no readable row
+  // back either, so testing `displayData` first would mask this with a
+  // misleading "could not be found".
   if (!canView) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-sand-50 via-sand-50 to-earth-50 flex items-center justify-center p-4">
@@ -160,6 +184,9 @@ const TripDetails = () => {
       </div>
     );
   }
+
+  const displayData = trip || previousTrip;
+  if (!displayData) return <TripDetailsError message="The requested trip could not be found." />;
 
   const handleTabChange = (tab: string) => {
     if (onExploreRoute && slug) {

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -57,16 +57,14 @@ const TripDetails = () => {
   // show — RLS hides private trips from anonymous readers, so both the trip
   // query and the permission check come back empty. Send them to sign in and
   // bring them straight back to this URL rather than dead-ending on an error.
-  // `profileLoaded` guards against redirecting before auth has resolved; it
-  // flips true for anonymous visitors too, so it means "we know for sure".
+  // `profileLoaded` flips true for anonymous visitors too, so it means "auth
+  // has settled", not "logged in" — without it a signed-in user whose session
+  // is still hydrating would be bounced to /auth.
+  const isAnonymous = profileLoaded && !session;
+  const accessChecked = !tripLoading && !permissionsLoading;
+  const blockedFromTrip = accessChecked && !canView;
   // Explore routes are public browsing and keep their normal not-found page.
-  const mustSignIn =
-    !onExploreRoute &&
-    profileLoaded &&
-    !session &&
-    !tripLoading &&
-    !permissionsLoading &&
-    !canView;
+  const mustSignIn = !onExploreRoute && isAnonymous && blockedFromTrip;
 
   useEffect(() => {
     if (!mustSignIn) return;


### PR DESCRIPTION
Follow-up to #285 (merged). Frontend only — no edge function redeploy needed.

## The problem

Clicking **View the itinerary** in a share email while signed out dead-ended on "could not be found".

`/trip/:tripId` is deliberately *not* wrapped in `ProtectedRoute` so public trips work anonymously. That means nothing was sending signed-out visitors to `/auth`, and RLS hides the private row from them, so the page fell through to the not-found branch.

## The fix

Redirect them to `/auth`, stashing the trip URL in the existing `pendingRedirect` sessionStorage slot that `Auth.tsx` already honours for password sign-in, sign-up, Google OAuth, and the already-signed-in case. They land back on the trip they clicked. No new redirect machinery — `ProtectedRoute` was already using this exact mechanism; `TripDetails` just wasn't.

Two guards on the redirect:

- **Waits for auth to resolve.** Firing on `!session` alone would bounce a signed-in user whose session hadn't hydrated yet. Gated on `profileLoaded`, which `AuthContext` sets true for anonymous visitors too — so it means "auth has settled", not "logged in".
- **Explore routes excluded.** `/explore/:slug` is public browsing and keeps its normal not-found page.

## Second bug found along the way

The `!canView` **Access Restricted** screen — with its own Sign In button — was **unreachable**. The `!displayData` check sat above it, and since RLS returns no readable row to anyone without access, that branch always won first.

This hit signed-in users too: someone without access to a trip saw "could not be found" instead of being told to contact the owner. Checking `canView` before the trip data makes that existing screen reachable. Same root cause, so it's fixed here — and the tests confirm it, since the two Access Restricted cases also fail against the pre-fix file.

## Tests

8 new tests in `src/pages/TripDetails.test.tsx`, following the conventions in `InviteRedeem.test.tsx`. These are genuine regression tests: **5 fail against the pre-fix file, all 8 pass after.**

Covered: redirect fires; the exact trip URL is remembered; no error flashes on the way out; no redirect while auth is unresolved; public trips untouched; explore untouched; and both signed-in-without-access cases.

## Verification

- `npx vitest run` — 511 passed / 52 files
- `npx eslint` on both changed files — clean
- Zero new type errors against `tsconfig.app.json` (313 pre-existing, unchanged before and after)

One incidental note: `TripCalendarView.test.tsx` was failing locally only because the container had no `.env`. With placeholder env vars it passes (11 tests) — that's why the suite count moved from 50 to 52 files. No committed change relates to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1UhdReQVrD4b5sxeMsEWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1UhdReQVrD4b5sxeMsEWt)_