### PR TITLE
Add offline timezone fallback to timezone-proxy function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ All tables have RLS policies: users can only access their own trips or shared tr
 
 #### 17. **Timezone System**
 - Times are floating wall-clock values (`HH:MM`) — **never convert them between zones**. Each trip has a default IANA `timezone`; items carry nullable overrides (`day_activities.timezone`, `reservations.timezone`, `accommodations.timezone`, `transportation.departure_timezone`/`arrival_timezone`); NULL = inherit trip default
-- Resolution: `timezone-proxy` Edge Function (place_id → geometry → Google Time Zone API → IANA id), cached permanently in `timezone_cache`; client side `useResolveTimezone()` + `useTripTimezone()` (lazy self-healing)
+- Resolution: `timezone-proxy` Edge Function (place_id → geometry → Google Time Zone API → IANA id, with an offline boundary-lookup fallback via `tz-lookup` when the Time Zone API is refused/unavailable), cached permanently in `timezone_cache`; client side `useResolveTimezone()` + `useTripTimezone()` (lazy self-healing)
 - UI: searchable IANA `TimezoneSelect` combobox; forms auto-fill the zone from the chosen place; label helpers in `src/utils/timezoneLabel.ts` (`effectiveTz`, `tzAbbrev`) drive badges on timeline rows, calendar chips, PDF times, and iCal summaries
 
 #### 18. **MCP Server**

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,3 +1,9 @@
 project_id = "arnengxblsfnezrqcsxw"
 [functions.generate-trip-content]
 verify_jwt = true
+
+# Gateway JWT verification off, matching the other functions here: the body
+# calls requireAuth() itself, which rejects the anon key that the gateway
+# would otherwise wave through.
+[functions.timezone-proxy]
+verify_jwt = false

--- a/supabase/functions/timezone-proxy/index.ts
+++ b/supabase/functions/timezone-proxy/index.ts
@@ -1,6 +1,17 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import tzLookup from 'https://esm.sh/@photostructure/tz-lookup@11.6.1';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { requireAuth } from '../_shared/auth.ts';
+
+/** Guards the cache against ids Intl (client + PDF formatters) can't resolve. */
+function isUsableZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 Deno.serve(async (req: Request) => {
   const corsHeaders = getCorsHeaders(req.headers.get('origin'));
@@ -49,27 +60,50 @@ Deno.serve(async (req: Request) => {
       `https://maps.googleapis.com/maps/api/place/details/json?place_id=${encodeURIComponent(placeId)}&fields=geometry&key=${googleApiKey}`,
     );
     const details = await detailsRes.json();
+    if (details?.status && details.status !== 'OK') {
+      console.warn(`timezone-proxy: place details ${details.status}: ${details.error_message ?? ''}`);
+    }
     const loc = details?.result?.geometry?.location;
     if (typeof loc?.lat !== 'number' || typeof loc?.lng !== 'number') {
       return respond({ timeZoneId: null });
     }
 
-    // The timestamp only affects DST offsets in the response; timeZoneId itself
-    // is stable, which is what makes the permanent cache safe.
-    const timestamp = Math.floor(Date.now() / 1000);
-    const tzRes = await fetch(
-      `https://maps.googleapis.com/maps/api/timezone/json?location=${loc.lat},${loc.lng}&timestamp=${timestamp}&key=${googleApiKey}`,
-    );
-    const tz = await tzRes.json();
-    if (tz?.status !== 'OK' || typeof tz?.timeZoneId !== 'string') {
-      return respond({ timeZoneId: null });
+    let timeZoneId: string | null = null;
+    try {
+      // The timestamp only affects DST offsets in the response; timeZoneId itself
+      // is stable, which is what makes the permanent cache safe.
+      const timestamp = Math.floor(Date.now() / 1000);
+      const tzRes = await fetch(
+        `https://maps.googleapis.com/maps/api/timezone/json?location=${loc.lat},${loc.lng}&timestamp=${timestamp}&key=${googleApiKey}`,
+      );
+      const tz = await tzRes.json();
+      if (tz?.status === 'OK' && typeof tz?.timeZoneId === 'string') {
+        timeZoneId = tz.timeZoneId;
+      } else {
+        console.warn(`timezone-proxy: Time Zone API ${tz?.status ?? 'no status'}: ${tz?.errorMessage ?? ''} — falling back to offline lookup`);
+      }
+    } catch (e) {
+      console.warn('timezone-proxy: Time Zone API fetch failed — falling back to offline lookup:', e instanceof Error ? e.message : e);
     }
 
+    // The Time Zone API is a separate Google Cloud enablement from the Places
+    // APIs, so a key that resolves geometry can still be refused here. Boundary
+    // lookup by coordinates keeps resolution working independent of key config.
+    if (!timeZoneId) {
+      try {
+        timeZoneId = tzLookup(loc.lat, loc.lng);
+      } catch {
+        // out-of-range coordinates — leave unresolved
+      }
+    }
+
+    if (!timeZoneId || !isUsableZone(timeZoneId)) return respond({ timeZoneId: null });
+
     await supabase.from('timezone_cache').upsert(
-      { place_id: placeId, timezone_id: tz.timeZoneId, fetched_at: new Date().toISOString() },
+      { place_id: placeId, timezone_id: timeZoneId, fetched_at: new Date().toISOString() },
       { onConflict: 'place_id' },
     );
-    return respond({ timeZoneId: tz.timeZoneId });
+    return respond({ timeZoneId });
   } catch (e) {
     console.error('timezone-proxy resolution error:', e instanceof Error ? e.message : e);
     return respond({ timeZoneId: null });


### PR DESCRIPTION
## Summary
Enhanced the `timezone-proxy` Edge Function with a resilient fallback mechanism for timezone resolution. When the Google Time Zone API is unavailable or refuses the request (e.g., due to separate Cloud enablement requirements), the function now falls back to offline boundary-based lookup via the `tz-lookup` library.

## Key Changes
- **Added `tz-lookup` dependency** (`@photostructure/tz-lookup@11.6.1`) for offline coordinate-to-timezone resolution
- **Implemented `isUsableZone()` validator** to guard the cache against timezone IDs that the Intl API (used by PDF formatters and client-side code) cannot resolve
- **Wrapped Time Zone API call in try-catch** with graceful fallback:
  - Attempts Google Time Zone API first (preferred for accuracy)
  - Falls back to offline `tzLookup()` if API fails, returns non-OK status, or throws
  - Validates final result with `isUsableZone()` before caching
- **Enhanced error logging** with warnings for API failures and fallback triggers, improving observability
- **Updated `config.toml`** to disable gateway JWT verification for `timezone-proxy` (matching other functions; the function calls `requireAuth()` internally)
- **Updated CLAUDE.md** to document the new fallback behavior in the Timezone System section

## Implementation Details
- The offline lookup is coordinate-based (latitude/longitude from Google Places geometry), so it works independently of Time Zone API key configuration
- Boundary lookup may fail for out-of-range coordinates; these are caught and left unresolved (returns `null`)
- The `isUsableZone()` check ensures cached values are compatible with Intl formatters used downstream in PDF export and client-side timezone handling
- Maintains permanent cache safety since timezone IDs are stable regardless of lookup method

https://claude.ai/code/session_01HmN2AXdXKJbnvm1aVeUDDH