### PR TITLE
Fix cold-start auth race in trip access checks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import { AuthProvider } from "@/contexts/AuthContext";
+import AuthCacheSync from "@/components/AuthCacheSync";
 import { ConsentProvider } from "@/contexts/ConsentContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import AppLayout from "@/components/layout/AppLayout";
@@ -67,6 +68,7 @@ const App = () => {
         <PostHogConsentSync />
         <GoogleAnalyticsConsentSync />
         <AuthProvider>
+          <AuthCacheSync />
           <TooltipProvider>
             <Toaster />
             <Sonner />

--- a/src/components/AuthCacheSync.test.tsx
+++ b/src/components/AuthCacheSync.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+let mockAuth: { user: { id: string } | null; profileLoaded: boolean };
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}));
+
+import AuthCacheSync from './AuthCacheSync';
+
+const TRIP_KEY = ['trip', 'a4268df2-d4a5-44f6-b23b-87cf6e96aee2'];
+
+function renderWith(queryClient: QueryClient) {
+  const tree = () => (
+    <QueryClientProvider client={queryClient}>
+      <AuthCacheSync />
+    </QueryClientProvider>
+  );
+  const utils = render(tree());
+  return { ...utils, refresh: () => utils.rerender(tree()) };
+}
+
+describe('AuthCacheSync', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockAuth = { user: null, profileLoaded: true };
+  });
+
+  it('drops what an anonymous visitor cached once they sign in', () => {
+    // RLS hid the trip from the logged-out reader, so `null` is cached under a
+    // key the signed-in owner will read from next.
+    queryClient.setQueryData(TRIP_KEY, null);
+    const { refresh } = renderWith(queryClient);
+
+    mockAuth = { user: { id: 'owner-1' }, profileLoaded: true };
+    refresh();
+
+    expect(queryClient.getQueryData(TRIP_KEY)).toBeUndefined();
+  });
+
+  it('drops the previous user rows on sign-out', () => {
+    mockAuth = { user: { id: 'owner-1' }, profileLoaded: true };
+    const { refresh } = renderWith(queryClient);
+    queryClient.setQueryData(TRIP_KEY, { destination: 'Vienna' });
+
+    mockAuth = { user: null, profileLoaded: true };
+    refresh();
+
+    expect(queryClient.getQueryData(TRIP_KEY)).toBeUndefined();
+  });
+
+  it('keeps the cache when the same user stays signed in', () => {
+    mockAuth = { user: { id: 'owner-1' }, profileLoaded: true };
+    const { refresh } = renderWith(queryClient);
+    queryClient.setQueryData(TRIP_KEY, { destination: 'Vienna' });
+
+    refresh();
+
+    expect(queryClient.getQueryData(TRIP_KEY)).toEqual({ destination: 'Vienna' });
+  });
+
+  it('does not treat unresolved auth as a signed-out identity', () => {
+    // A restoring session reads as user: null. Clearing on that, then again
+    // when the session lands, would throw away every in-flight page load.
+    mockAuth = { user: null, profileLoaded: false };
+    const { refresh } = renderWith(queryClient);
+    queryClient.setQueryData(TRIP_KEY, { destination: 'Vienna' });
+
+    mockAuth = { user: { id: 'owner-1' }, profileLoaded: true };
+    refresh();
+
+    expect(queryClient.getQueryData(TRIP_KEY)).toEqual({ destination: 'Vienna' });
+  });
+});

--- a/src/components/AuthCacheSync.tsx
+++ b/src/components/AuthCacheSync.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * Drops cached server state when the signed-in identity changes.
+ *
+ * Every query here is answered through RLS, so one key returns different rows —
+ * or none at all — depending on who is asking. Someone following a trip email
+ * while logged out caches an empty trip under `['trip', id]`; signing in and
+ * coming back would otherwise replay that empty answer for the rest of its
+ * five-minute staleTime and dead-end on "could not be found", even though the
+ * visitor now has access. Signing out matters for the same reason in reverse:
+ * the next person on this browser must not read the previous one's rows.
+ *
+ * Renders nothing.
+ */
+const AuthCacheSync = () => {
+  const { user, profileLoaded } = useAuth();
+  const queryClient = useQueryClient();
+  // undefined = no identity observed yet, distinct from null = signed out.
+  const lastIdentity = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    // Wait for auth to settle, or the first pass would read as "signed out".
+    if (!profileLoaded) return;
+
+    const identity = user?.id ?? null;
+    const previous = lastIdentity.current;
+    lastIdentity.current = identity;
+
+    // First observation establishes the baseline; nothing cached before it
+    // belongs to anyone else.
+    if (previous === undefined || previous === identity) return;
+
+    queryClient.clear();
+  }, [profileLoaded, user?.id, queryClient]);
+
+  return null;
+};
+
+export default AuthCacheSync;

--- a/src/components/trip/details/useTripAccessGate.ts
+++ b/src/components/trip/details/useTripAccessGate.ts
@@ -23,8 +23,9 @@ interface TripAccessGateArgs {
  * The trip URL goes into the `pendingRedirect` slot that Auth.tsx already
  * honours for password sign-in, sign-up and Google OAuth.
  *
- * @returns true while the redirect is pending, so the caller can hold a
- * loading state instead of flashing an error on the way out.
+ * @returns true while the answer is still pending — either the redirect is in
+ * flight or auth has not resolved — so the caller can hold a loading state
+ * instead of flashing an error at someone who does have access.
  */
 export function useTripAccessGate({
   onExploreRoute,
@@ -43,6 +44,10 @@ export function useTripAccessGate({
   const accessChecked = !tripLoading && !permissionsLoading;
   const blockedFromTrip = accessChecked && !canView;
   const mustSignIn = !onExploreRoute && isAnonymous && blockedFromTrip;
+  // Nobody is refused while auth is still restoring: a cold page load from an
+  // email link routinely reaches this point before the session is back, and
+  // the visitor is usually the trip owner.
+  const authUnresolved = !onExploreRoute && !profileLoaded && blockedFromTrip;
 
   useEffect(() => {
     if (!mustSignIn) return;
@@ -50,5 +55,5 @@ export function useTripAccessGate({
     navigate('/auth', { replace: true });
   }, [mustSignIn, location.pathname, navigate]);
 
-  return mustSignIn;
+  return mustSignIn || authUnresolved;
 }

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -328,6 +328,112 @@ describe('AuthContext', () => {
     });
   });
 
+  describe('auth settling', () => {
+    // `profileLoaded` is the app's "auth has resolved" signal — the trip pages
+    // wait on it before deciding whether a visitor may see a trip. A logged-out
+    // visitor is a resolved answer, so it has to settle for them too.
+    const SettledConsumer = () => {
+      const { profileLoaded } = useAuth();
+      return <span data-testid="settled">{profileLoaded ? 'settled' : 'pending'}</span>;
+    };
+
+    it('stays settled when INITIAL_SESSION arrives with no session', async () => {
+      let authChangeCallback: (event: string, session: unknown) => void;
+      mockOnAuthStateChange.mockImplementation((callback) => {
+        authChangeCallback = callback;
+        return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+      });
+
+      render(
+        <AuthProvider>
+          <SettledConsumer />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settled')).toHaveTextContent('settled');
+      });
+
+      // The SDK emits INITIAL_SESSION for every anonymous visitor, after
+      // getSession() has already reported the same null session. Reopening the
+      // question here strands the sign-in gate: nothing loads a profile that
+      // does not exist, so it would never settle again.
+      await act(async () => {
+        authChangeCallback!('INITIAL_SESSION', null);
+      });
+
+      expect(screen.getByTestId('settled')).toHaveTextContent('settled');
+    });
+
+    it('stays settled after the user signs out', async () => {
+      let authChangeCallback: (event: string, session: unknown) => void;
+      mockOnAuthStateChange.mockImplementation((callback) => {
+        authChangeCallback = callback;
+        return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+      });
+
+      mockGetSession.mockResolvedValue({
+        data: { session: { user: { id: 'user-123' }, access_token: 'token' } },
+        error: null,
+      });
+
+      render(
+        <AuthProvider>
+          <SettledConsumer />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settled')).toHaveTextContent('settled');
+      });
+
+      await act(async () => {
+        authChangeCallback!('SIGNED_OUT', null);
+      });
+
+      expect(screen.getByTestId('settled')).toHaveTextContent('settled');
+    });
+
+    it('clears the previous profile on sign-out', async () => {
+      let authChangeCallback: (event: string, session: unknown) => void;
+      mockOnAuthStateChange.mockImplementation((callback) => {
+        authChangeCallback = callback;
+        return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+      });
+
+      mockGetSession.mockResolvedValue({
+        data: { session: { user: { id: 'user-123' }, access_token: 'token' } },
+        error: null,
+      });
+
+      mockFrom.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'user-123', subscription_tier: 'premium' },
+          error: null,
+        }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+      });
+
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('tier')).toHaveTextContent('premium');
+      });
+
+      await act(async () => {
+        authChangeCallback!('SIGNED_OUT', null);
+      });
+
+      expect(screen.getByTestId('tier')).toHaveTextContent('free');
+    });
+  });
+
   describe('visibility change', () => {
     it('should call getSession when tab becomes visible', async () => {
       const mockSession = {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -173,7 +173,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setSession(session);
       setUser(session?.user ?? null);
       if (!session?.user) {
-        setProfileLoaded(false);
+        // Signed out is a settled state, not a pending one. The SDK fires
+        // INITIAL_SESSION with a null session for every anonymous visitor —
+        // after getSession() above already reported the same thing — and there
+        // is no profile to load, so nothing would ever flip this back. Marking
+        // it pending strands every gate that waits on `profileLoaded` to learn
+        // the visitor is logged out (see useTripAccessGate).
+        setSubscriptionTier('free');
+        setAvatarUrl(null);
+        setFullName(null);
+        setLastLoginAt(null);
+        setProfileLoaded(true);
         return;
       }
       // TOKEN_REFRESHED fires every time the SDK rotates the access token.
@@ -181,6 +191,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       // on every token refresh, which would hit the DB every ~hour.
       if (event === 'TOKEN_REFRESHED') return;
       const isNewLogin = event === 'SIGNED_IN';
+      if (isNewLogin) {
+        // Hold the flag while the new user's profile loads so the avatar shows
+        // a skeleton rather than flashing initials. Bounded, unlike the
+        // signed-out case above: ensureProfile resolves it on every path.
+        setProfileLoaded(false);
+      }
       identifyUser(session.user.id, {
         email: session.user.email,
         provider: session.user.app_metadata?.provider,

--- a/src/hooks/use-trip-permissions.test.tsx
+++ b/src/hooks/use-trip-permissions.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: mockFrom },
+}));
+
+vi.mock('./useIsAdmin', () => ({
+  useIsAdmin: () => ({ isAdmin: false, isLoading: false, error: null }),
+}));
+
+let mockAuth: { user: { id: string; email: string } | null; profileLoaded: boolean };
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}));
+
+import { useTripPermissions } from './use-trip-permissions';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const TRIP_ID = 'a4268df2-d4a5-44f6-b23b-87cf6e96aee2';
+const OWNER = { id: 'owner-1', email: 'owner@example.com' };
+
+/** trips/trip_shares both read as select → eq(…) → single(). */
+function stubTables(responses: Record<string, { data: unknown; error: unknown }>) {
+  mockFrom.mockImplementation((table: string) => {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      single: () => Promise.resolve(responses[table] ?? { data: null, error: { message: 'no row' } }),
+    };
+    return chain;
+  });
+}
+
+const PRIVATE_TRIP = { data: { user_id: OWNER.id, is_public: false }, error: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth = { user: OWNER, profileLoaded: true };
+  stubTables({ trips: PRIVATE_TRIP });
+});
+
+describe('useTripPermissions — arriving from an email link', () => {
+  it('does not answer while auth is still restoring', async () => {
+    // A cold page load from a reminder email gets here before the session is
+    // back. Answering now would deny the owner their own trip.
+    mockAuth = { user: null, profileLoaded: false };
+
+    const { result } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.canView).toBe(false);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('grants the owner access once auth resolves', async () => {
+    mockAuth = { user: null, profileLoaded: false };
+    const { result, rerender } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // Session restored — the check has to run again, not keep its early answer.
+    mockAuth = { user: OWNER, profileLoaded: true };
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.canView).toBe(true);
+      expect(result.current.isOwner).toBe(true);
+      expect(result.current.canEdit).toBe(true);
+    });
+  });
+
+  it('re-checks when a different user signs in', async () => {
+    const { result, rerender } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await waitFor(() => expect(result.current.isOwner).toBe(true));
+
+    mockAuth = { user: { id: 'stranger-1', email: 'stranger@example.com' }, profileLoaded: true };
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.isOwner).toBe(false);
+      expect(result.current.canView).toBe(false);
+    });
+  });
+
+  it('reports no access for a signed-out visitor to a private trip', async () => {
+    mockAuth = { user: null, profileLoaded: true };
+
+    const { result } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.canView).toBe(false);
+    });
+  });
+
+  it('lets a signed-out visitor read a public trip', async () => {
+    mockAuth = { user: null, profileLoaded: true };
+    stubTables({ trips: { data: { user_id: OWNER.id, is_public: true }, error: null } });
+
+    const { result } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await waitFor(() => {
+      expect(result.current.canView).toBe(true);
+      expect(result.current.canEdit).toBe(false);
+    });
+  });
+
+  it('grants a shared viewer read access once the share is accepted', async () => {
+    mockAuth = { user: { id: 'guest-1', email: 'guest@example.com' }, profileLoaded: true };
+    stubTables({
+      trips: PRIVATE_TRIP,
+      trip_shares: { data: { permission_level: 'read', share_status: 'accepted' }, error: null },
+    });
+
+    const { result } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await waitFor(() => {
+      expect(result.current.canView).toBe(true);
+      expect(result.current.canEdit).toBe(false);
+      expect(result.current.permissionLevel).toBe('read');
+    });
+  });
+
+  it('withholds access on a share the invitee has not accepted', async () => {
+    mockAuth = { user: { id: 'guest-1', email: 'guest@example.com' }, profileLoaded: true };
+    stubTables({
+      trips: PRIVATE_TRIP,
+      trip_shares: { data: { permission_level: 'edit', share_status: 'pending' }, error: null },
+    });
+
+    const { result } = renderHook(() => useTripPermissions(TRIP_ID));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.canView).toBe(false);
+  });
+});

--- a/src/hooks/use-trip-permissions.tsx
+++ b/src/hooks/use-trip-permissions.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { PermissionLevel } from '@/integrations/supabase/trip_shares_types';
+import { useAuth } from '@/contexts/AuthContext';
 import { useIsAdmin } from './useIsAdmin';
 
 interface TripPermissions {
@@ -11,32 +12,54 @@ interface TripPermissions {
   isLoading: boolean;
 }
 
+const NO_ACCESS: Omit<TripPermissions, 'isLoading'> = {
+  canEdit: false,
+  canView: false,
+  isOwner: false,
+  permissionLevel: null,
+};
+
 /**
  * Hook to check user permissions for a specific trip
+ *
+ * The check re-runs whenever the signed-in user changes. Someone arriving from
+ * a reminder or share email lands on a cold page whose auth state is still
+ * being restored; answering once, early, would deny the owner their own trip
+ * and never correct itself.
+ *
  * @param tripId The ID of the trip to check permissions for
  * @returns Permission information and loading state
  */
 export function useTripPermissions(tripId: string | undefined): TripPermissions {
   const [permissions, setPermissions] = useState<TripPermissions>({
-    canEdit: false,
-    canView: false,
-    isOwner: false,
-    permissionLevel: null,
+    ...NO_ACCESS,
     isLoading: true,
   });
   const { isAdmin } = useIsAdmin();
+  // Identity comes from the auth context rather than a per-mount
+  // supabase.auth.getUser() round trip: that call can fail transiently while a
+  // token is being refreshed, which used to read as "no access" permanently.
+  const { user, profileLoaded } = useAuth();
+  const userId = user?.id;
+  const userEmail = user?.email;
 
   useEffect(() => {
     if (!tripId) {
-      setPermissions({
-        canEdit: false,
-        canView: false,
-        isOwner: false,
-        permissionLevel: null,
-        isLoading: false,
-      });
+      setPermissions({ ...NO_ACCESS, isLoading: false });
       return;
     }
+
+    // Auth has not settled yet, so we cannot tell a logged-out visitor from a
+    // signed-in one. Stay loading; this effect re-runs once it resolves.
+    if (!profileLoaded) {
+      setPermissions({ ...NO_ACCESS, isLoading: true });
+      return;
+    }
+
+    let cancelled = false;
+    const apply = (next: TripPermissions) => {
+      if (!cancelled) setPermissions(next);
+    };
 
     const checkPermissions = async () => {
       try {
@@ -49,21 +72,13 @@ export function useTripPermissions(tripId: string | undefined): TripPermissions 
 
         if (tripError) {
           console.error('Error checking trip data:', tripError);
-          setPermissions({
-            canEdit: false,
-            canView: false,
-            isOwner: false,
-            permissionLevel: null,
-            isLoading: false,
-          });
+          apply({ ...NO_ACCESS, isLoading: false });
           return;
         }
 
-        const { data: { user } } = await supabase.auth.getUser();
-        
         // If trip is public and no user is logged in, allow view-only access
-        if (tripData.is_public && !user) {
-          setPermissions({
+        if (tripData.is_public && !userId) {
+          apply({
             canEdit: false,
             canView: true,
             isOwner: false,
@@ -73,21 +88,15 @@ export function useTripPermissions(tripId: string | undefined): TripPermissions 
           return;
         }
 
-        if (!user) {
-          setPermissions({
-            canEdit: false,
-            canView: false,
-            isOwner: false,
-            permissionLevel: null,
-            isLoading: false,
-          });
+        if (!userId) {
+          apply({ ...NO_ACCESS, isLoading: false });
           return;
         }
 
-        const isOwner = tripData.user_id === user.id;
+        const isOwner = tripData.user_id === userId;
 
         if (isOwner) {
-          setPermissions({
+          apply({
             canEdit: true,
             canView: true,
             isOwner: true,
@@ -99,7 +108,7 @@ export function useTripPermissions(tripId: string | undefined): TripPermissions 
 
         // If trip is public and user is a database-verified admin, grant edit access
         if (tripData.is_public && isAdmin) {
-          setPermissions({
+          apply({
             canEdit: true,
             canView: true,
             isOwner: false,
@@ -111,7 +120,7 @@ export function useTripPermissions(tripId: string | undefined): TripPermissions 
 
         // If trip is public (but user is not admin), allow view-only access
         if (tripData.is_public) {
-          setPermissions({
+          apply({
             canEdit: false,
             canView: true,
             isOwner: false,
@@ -126,35 +135,23 @@ export function useTripPermissions(tripId: string | undefined): TripPermissions 
           .from('trip_shares')
           .select('permission_level, share_status')
           .eq('trip_id', tripId)
-          .eq('shared_with_email', user.email)
+          .eq('shared_with_email', userEmail)
           .single();
 
         if (shareError || !shareData) {
           // User has no access to this trip
-          setPermissions({
-            canEdit: false,
-            canView: false,
-            isOwner: false,
-            permissionLevel: null,
-            isLoading: false,
-          });
+          apply({ ...NO_ACCESS, isLoading: false });
           return;
         }
 
         // Require explicit acceptance for shared trips
         if (shareData.share_status === 'pending') {
-          setPermissions({
-            canEdit: false,
-            canView: false,
-            isOwner: false,
-            permissionLevel: null,
-            isLoading: false,
-          });
+          apply({ ...NO_ACCESS, isLoading: false });
           return;
         }
 
         const permissionLevel = shareData.permission_level as PermissionLevel;
-        setPermissions({
+        apply({
           canEdit: permissionLevel === 'edit',
           canView: true,
           isOwner: false,
@@ -164,18 +161,14 @@ export function useTripPermissions(tripId: string | undefined): TripPermissions 
 
       } catch (error) {
         console.error('Error checking trip permissions:', error);
-        setPermissions({
-          canEdit: false,
-          canView: false,
-          isOwner: false,
-          permissionLevel: null,
-          isLoading: false,
-        });
+        apply({ ...NO_ACCESS, isLoading: false });
       }
     };
 
     checkPermissions();
-  }, [tripId, isAdmin]);
+    // A check started for the previous user must not land after this one.
+    return () => { cancelled = true; };
+  }, [tripId, isAdmin, profileLoaded, userId, userEmail]);
 
   return permissions;
 }

--- a/src/pages/TripDetails.test.tsx
+++ b/src/pages/TripDetails.test.tsx
@@ -88,7 +88,7 @@ function renderAt(path: string) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const tree = () => (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[path]}>
         <Routes>
@@ -98,6 +98,10 @@ function renderAt(path: string) {
       </MemoryRouter>
     </QueryClientProvider>
   );
+  const utils = render(tree());
+  // Re-render the same tree so the component picks up changed mock state —
+  // a fresh element each time, or React bails out on identity.
+  return { ...utils, refresh: () => utils.rerender(tree()) };
 }
 
 describe('TripDetails — signed-out access to a shared trip', () => {
@@ -141,6 +145,34 @@ describe('TripDetails — signed-out access to a shared trip', () => {
     renderAt(TRIP_PATH);
 
     await new Promise((r) => setTimeout(r, 50));
+    expect(mockNavigate).not.toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
+  });
+
+  it('does not accuse a visitor of lacking access while auth is still resolving', async () => {
+    // Following a reminder email loads the page cold: the permission check can
+    // come back empty before the session is restored. Hold, do not refuse.
+    mockAuth = { session: null, profileLoaded: false };
+    renderAt(TRIP_PATH);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText(/access restricted/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/could not be found/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the trip once a late-restored session grants access', async () => {
+    mockAuth = { session: null, profileLoaded: false };
+    const { refresh } = renderAt(TRIP_PATH);
+    expect(screen.queryByTestId('timeline')).not.toBeInTheDocument();
+
+    // Session comes back and the permission check re-runs with it.
+    mockAuth = { session: { user: { id: 'u1' } }, profileLoaded: true };
+    mockPermissions = { ...mockPermissions, canView: true, canEdit: true };
+    mockTripQuery = { ...mockTripQuery, trip: A_TRIP };
+    refresh();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline')).toBeInTheDocument();
+    });
     expect(mockNavigate).not.toHaveBeenCalledWith(AUTH_ROUTE, REPLACE);
   });
 

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -54,9 +54,10 @@ const TripDetails = () => {
   const { trip, tripLoading, tripError, previousTrip } = useTripQuery(tripId);
   useTripSubscription(tripId);
 
-  // Signed-out visitors following a share link are sent to sign in and
-  // returned here afterwards; true while that redirect is pending.
-  const mustSignIn = useTripAccessGate({
+  // Signed-out visitors following a share or reminder link are sent to sign in
+  // and returned here afterwards; true while that redirect is pending, or
+  // while auth is still resolving and access is not yet knowable.
+  const accessPending = useTripAccessGate({
     onExploreRoute,
     tripLoading,
     permissionsLoading,
@@ -134,9 +135,9 @@ const TripDetails = () => {
   }
   if (tripLoading && !previousTrip) return <TripDetailsSkeleton />;
   if (permissionsLoading) return <TripDetailsSkeleton />;
-  // The effect above is navigating to /auth — hold the skeleton rather than
-  // flashing an error on the way out.
-  if (mustSignIn) return <TripDetailsSkeleton />;
+  // Either the gate is navigating to /auth or auth has not resolved yet — hold
+  // the skeleton rather than flashing an error at someone with access.
+  if (accessPending) return <TripDetailsSkeleton />;
   if (tripError) return <TripDetailsError />;
 
   // Checked before the trip data: a viewer without access gets no readable row

--- a/supabase/functions/send-trip-reminders/index.ts
+++ b/supabase/functions/send-trip-reminders/index.ts
@@ -56,6 +56,7 @@ function formatTime(t: string | null): string {
 
 type TripRow = {
   trip_id: string;
+  user_id: string;
   destination: string;
   primary_destination: string | null;
   arrival_date: string;
@@ -84,6 +85,7 @@ type TravelerShare = {
   first_name: string;
   last_name: string | null;
   shared_with_user_id: string;
+  share_status: 'pending' | 'accepted';
 };
 
 function renderHtml(params: {
@@ -331,13 +333,19 @@ Deno.serve(async (req) => {
 
     const { data: trips, error: tripsErr } = await supabase
       .from('trips')
-      .select('trip_id, destination, primary_destination, arrival_date, departure_date')
+      .select('trip_id, user_id, destination, primary_destination, arrival_date, departure_date')
       .eq('arrival_date', targetDate)
       .eq('hidden', false);
 
     if (tripsErr) throw tripsErr;
 
-    const results: Array<{ trip_id: string; sent: number; skipped?: string; error?: string }> = [];
+    const results: Array<{
+      trip_id: string;
+      sent: number;
+      skipped?: string;
+      skipped_pending?: number;
+      error?: string;
+    }> = [];
 
     for (const trip of (trips ?? []) as TripRow[]) {
       try {
@@ -376,7 +384,7 @@ Deno.serve(async (req) => {
             .order('start_time', { ascending: true, nullsFirst: false }),
           supabase
             .from('trip_shares')
-            .select('id, first_name, last_name, shared_with_user_id')
+            .select('id, first_name, last_name, shared_with_user_id, share_status')
             .eq('trip_id', trip.trip_id)
             .not('shared_with_user_id', 'is', null),
         ]);
@@ -434,9 +442,21 @@ Deno.serve(async (req) => {
 
         // Resolve emails for registered travelers via auth admin API.
         let sent = 0;
+        let skippedPending = 0;
         const errors: string[] = [];
         for (const t of travelers) {
           if (!t.shared_with_user_id) continue;
+          // RLS only opens a trip to its owner or to an accepted share, so
+          // mailing this link to someone with a pending invite guarantees them
+          // "Access Restricted". They still appear on the stay lines above —
+          // they are travelling, they just have not taken the invite yet.
+          // The owner is checked against trips.user_id, not their own share
+          // row: that row is written without a status and so reads 'pending'.
+          const isTripOwner = t.shared_with_user_id === trip.user_id;
+          if (!isTripOwner && t.share_status !== 'accepted') {
+            skippedPending++;
+            continue;
+          }
           const { data: userRes, error: userErr } = await supabase.auth.admin.getUserById(t.shared_with_user_id);
           if (userErr || !userRes?.user?.email || !isEmail(userRes.user.email)) {
             errors.push(`no_email:${t.shared_with_user_id}`);
@@ -469,6 +489,7 @@ Deno.serve(async (req) => {
         results.push({
           trip_id: trip.trip_id,
           sent,
+          ...(skippedPending ? { skipped_pending: skippedPending } : {}),
           ...(errors.length ? { error: errors.join('; ') } : {}),
         });
       } catch (e: unknown) {


### PR DESCRIPTION
## Summary

Fixes a critical race condition where users following trip share or reminder email links on a cold page load would be incorrectly denied access to trips they own or have permission to view. The issue occurred because permission checks ran before the auth session was restored, caching a "no access" answer that never corrected itself.

## Key Changes

- **`useTripPermissions` hook**: Now waits for `profileLoaded` from `AuthContext` before checking permissions, ensuring auth has settled. Uses `userId` and `userEmail` from context instead of calling `supabase.auth.getUser()`, which can fail transiently during token refresh. Implements request cancellation to prevent stale permission checks from overwriting newer ones.

- **`AuthContext`**: Clarified `profileLoaded` semantics — it now correctly settles to `true` for signed-out visitors (no profile to load), not `false`. Clears profile data (subscription tier, avatar, name, last login) on sign-out so the next user on the same browser doesn't see the previous user's cached profile.

- **`AuthCacheSync` component** (new): Drops React Query cache when the signed-in identity changes. Prevents RLS-hidden data cached by one user from being replayed to another (e.g., a logged-out visitor caches empty trip data; signing in would otherwise show "not found" for five minutes despite now having access).

- **`TripDetails` page**: Renamed `mustSignIn` to `accessPending` to clarify it now also covers auth resolution time, not just redirect-in-flight. Holds the skeleton UI while auth settles, preventing false "access restricted" errors.

- **`useTripAccessGate` hook**: Updated to account for auth resolution time in addition to redirect pending state.

- **`send-trip-reminders` function**: Added `user_id` to trip query and `share_status` to share query. Skips sending reminder emails to users with pending (unaccepted) shares, since RLS would deny them access anyway, resulting in "Access Restricted" errors.

- **Test coverage**: Added comprehensive tests for `useTripPermissions` covering cold-start scenarios, session restoration, user sign-in/sign-out, public trips, and shared access. Added tests for `AuthContext` auth settling behavior and `AuthCacheSync` cache invalidation.

## Implementation Details

- The hook now uses a `cancelled` flag to prevent race conditions where an older permission check completes after a newer one starts (e.g., user changes while a check is in flight).
- `profileLoaded` is the app's "auth has resolved" signal — it must settle for both signed-in and signed-out states to avoid stranding gates that wait on it.
- RLS ensures queries return different results based on identity, so cache invalidation on identity change is essential for correctness.

https://claude.ai/code/session_01XRn9VWPRuDB9mmsujcUr77