### PR TITLE
Fix mobile-only gaps in the trip experience

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { Calendar, BarChart2, Users, Plus, MessageCircle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -11,56 +12,51 @@ interface BottomNavigationProps {
   onAIClick: () => void;
 }
 
+/**
+ * Shared styling for the four non-FAB slots. `min-h-[44px]` keeps every target
+ * at the platform-recommended tap size, and `touch-manipulation` drops the 300ms
+ * click delay that mobile Safari still applies to non-optimised targets.
+ */
+const slotClasses =
+  "flex flex-col items-center justify-center h-full min-h-[44px] gap-1 rounded-lg " +
+  "transition-colors touch-manipulation active:bg-sand-100";
+
+const NavIcon = ({ icon: Icon, label, isActive }: { icon: LucideIcon; label: string; isActive?: boolean }) => (
+  <>
+    <Icon className={cn("h-5 w-5", isActive && "stroke-[2.5]")} />
+    <span className={cn("text-[10px] leading-none", isActive && "font-semibold")}>{label}</span>
+  </>
+);
+
+/*
+ * `pb-[env(safe-area-inset-bottom)]` on the bar keeps the labels clear of the iOS
+ * home indicator — without it the bottom row of a notched iPhone sits under the
+ * gesture bar, where taps are swallowed by the system.
+ */
 const BottomNavigation = ({ tripId, tripPath, onQuickAddClick, onPeopleClick, onAIClick }: BottomNavigationProps) => {
   const base = tripPath ?? (tripId ? `/trip/${tripId}` : undefined);
 
-  const timelineItem = {
-    title: "Timeline",
-    icon: Calendar,
-    href: base ? `${base}/timeline` : "/trips",
-  };
-
-  const budgetItem = {
-    title: "Budget",
-    icon: BarChart2,
-    href: base ? `${base}/budget` : "/trips",
-  };
+  const linkClasses = ({ isActive }: { isActive: boolean }) =>
+    cn(slotClasses, isActive ? "text-earth-700" : "text-sand-600 hover:text-earth-600");
 
   return (
-    <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-sand-200 shadow-warm-lg">
+    <nav
+      aria-label="Trip navigation"
+      className={cn(
+        "md:hidden fixed bottom-0 left-0 right-0 z-50",
+        "bg-background border-t border-sand-200 shadow-warm-lg",
+        "pb-[env(safe-area-inset-bottom,0px)]"
+      )}
+    >
       <div className="grid grid-cols-5 h-16 items-center px-2">
         {/* Timeline */}
-        <NavLink
-          to={timelineItem.href}
-          className={({ isActive }) =>
-            cn(
-              "flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors",
-              isActive
-                ? "text-earth-700"
-                : "text-sand-600 hover:text-earth-600"
-            )
-          }
-        >
-          {({ isActive }) => {
-            const Icon = timelineItem.icon;
-            return (
-              <>
-                <Icon className={cn("h-5 w-5", isActive && "stroke-[2.5]")} />
-                <span className={cn("text-[10px]", isActive && "font-semibold")}>
-                  {timelineItem.title}
-                </span>
-              </>
-            );
-          }}
+        <NavLink to={base ? `${base}/timeline` : "/trips"} className={linkClasses}>
+          {({ isActive }) => <NavIcon icon={Calendar} label="Timeline" isActive={isActive} />}
         </NavLink>
 
         {/* Quick Add */}
-        <button
-          onClick={onQuickAddClick}
-          className="flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors text-sand-600 hover:text-earth-600"
-        >
-          <Plus className="h-5 w-5" />
-          <span className="text-[10px]">Add</span>
+        <button type="button" onClick={onQuickAddClick} className={cn(slotClasses, "text-sand-600 hover:text-earth-600")}>
+          <NavIcon icon={Plus} label="Add" />
         </button>
 
         {/* Center FAB - AI Chat */}
@@ -68,45 +64,21 @@ const BottomNavigation = ({ tripId, tripPath, onQuickAddClick, onPeopleClick, on
           <Button
             onClick={onAIClick}
             size="icon"
-            className="h-14 w-14 rounded-full bg-earth-600 hover:bg-earth-700 shadow-warm-lg -mt-8 ring-4 ring-white"
-            aria-label="AI Chat"
+            className="h-14 w-14 rounded-full bg-earth-600 hover:bg-earth-700 active:bg-earth-800 shadow-warm-lg -mt-8 ring-4 ring-white touch-manipulation"
+            aria-label="Open AI assistant"
           >
             <MessageCircle className="h-6 w-6 text-white" />
           </Button>
         </div>
 
         {/* Budget */}
-        <NavLink
-          to={budgetItem.href}
-          className={({ isActive }) =>
-            cn(
-              "flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors",
-              isActive
-                ? "text-earth-700"
-                : "text-sand-600 hover:text-earth-600"
-            )
-          }
-        >
-          {({ isActive }) => {
-            const Icon = budgetItem.icon;
-            return (
-              <>
-                <Icon className={cn("h-5 w-5", isActive && "stroke-[2.5]")} />
-                <span className={cn("text-[10px]", isActive && "font-semibold")}>
-                  {budgetItem.title}
-                </span>
-              </>
-            );
-          }}
+        <NavLink to={base ? `${base}/budget` : "/trips"} className={linkClasses}>
+          {({ isActive }) => <NavIcon icon={BarChart2} label="Budget" isActive={isActive} />}
         </NavLink>
 
         {/* People */}
-        <button
-          onClick={onPeopleClick}
-          className="flex flex-col items-center justify-center h-full space-y-1 rounded-lg transition-colors text-sand-600 hover:text-earth-600"
-        >
-          <Users className="h-5 w-5" />
-          <span className="text-[10px]">People</span>
+        <button type="button" onClick={onPeopleClick} className={cn(slotClasses, "text-sand-600 hover:text-earth-600")}>
+          <NavIcon icon={Users} label="People" />
         </button>
       </div>
     </nav>

--- a/src/components/trip/calendar/CalendarSyncSheet.tsx
+++ b/src/components/trip/calendar/CalendarSyncSheet.tsx
@@ -59,7 +59,7 @@ const CalendarSyncSheet: React.FC<CalendarSyncSheetProps> = ({ tripId, open, onO
             <div>
               <label htmlFor={`calendar-sub-${tripId}`} className="text-xs font-medium text-muted-foreground">Subscribe link</label>
               <div className="mt-1 flex gap-2">
-                <input id={`calendar-sub-${tripId}`} readOnly value={subscribeUrl ?? ''} className="flex-1 rounded-md border border-input bg-muted px-2 py-1.5 text-xs" onFocus={(e) => e.currentTarget.select()} />
+                <input id={`calendar-sub-${tripId}`} readOnly value={subscribeUrl ?? ''} className="flex-1 min-w-0 rounded-md border border-input bg-muted px-2 py-1.5 text-base md:text-xs" onFocus={(e) => e.currentTarget.select()} />
                 <Button variant="outline" size="icon" aria-label="Copy link" onClick={copy}><Copy className="h-4 w-4" /></Button>
               </div>
             </div>

--- a/src/components/trip/day/CompactDayCard.tsx
+++ b/src/components/trip/day/CompactDayCard.tsx
@@ -15,12 +15,15 @@ import {
   DndContext,
   closestCenter,
   DragEndEvent,
-  PointerSensor,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
 import {
   SortableContext,
+  sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 
@@ -110,10 +113,23 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
 
   const queryClient = useQueryClient();
 
-  // DnD sensors
+  // DnD sensors.
+  //
+  // A single PointerSensor cannot serve both input types: the distance
+  // constraint that feels right for a mouse hijacks the first 8px of every
+  // touch drag, so on a phone the gesture either reorders when the user meant
+  // to scroll or does nothing at all. Splitting mouse from touch lets each get
+  // the constraint it needs — drag-after-8px for a mouse, long-press for touch,
+  // which leaves vertical swipes free to scroll the itinerary.
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: { distance: 8 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
     })
   );
 

--- a/src/components/trip/day/components/SortableTimelineRow.tsx
+++ b/src/components/trip/day/components/SortableTimelineRow.tsx
@@ -3,6 +3,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useIsCoarsePointer } from '@/hooks/use-mobile';
 import TimelineRow from './TimelineRow';
 import { TimelineItem } from './timeline-utils';
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
@@ -29,27 +30,46 @@ const SortableTimelineRow: React.FC<Props> = (props) => {
     isDragging,
   } = useSortable({ id: props.item.id });
 
-  const style = {
+  /*
+   * The grip handle is revealed on hover, so on a touch screen it is unreachable
+   * — which left reordering as a desktop-only feature. Touch devices instead get
+   * the whole row as the drag surface, paired with the TouchSensor's long-press
+   * activation: a press-and-hold picks the row up, while a tap still opens it and
+   * a swipe still scrolls.
+   */
+  const isCoarsePointer = useIsCoarsePointer();
+
+  const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
+    /*
+     * Without this, iOS answers the long-press with its own text-selection
+     * callout and magnifier before the drag ever starts. `manipulation` still
+     * permits panning, so the list scrolls normally.
+     */
+    ...(isCoarsePointer
+      ? { touchAction: 'manipulation', WebkitTouchCallout: 'none', WebkitUserSelect: 'none', userSelect: 'none' }
+      : {}),
   };
 
   return (
     <div
       ref={setNodeRef}
       style={style}
+      {...(isCoarsePointer ? listeners : {})}
       className={cn(
         "group relative",
         isDragging && "z-50 opacity-90 shadow-warm-lg rounded-xl"
       )}
     >
-      {/* Drag Handle */}
+      {/* Drag Handle — pointer devices only; touch drags from the row itself. */}
       <div
         {...attributes}
-        {...listeners}
+        {...(isCoarsePointer ? {} : listeners)}
+        aria-label={`Reorder ${props.item.title}`}
         className={cn(
           "absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1 z-20 p-1 rounded cursor-grab active:cursor-grabbing",
-          "hidden sm:block sm:opacity-0 sm:group-hover:opacity-100 transition-opacity",
+          "hidden sm:block sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 transition-opacity",
           "text-earth-400 hover:text-earth-600"
         )}
       >

--- a/src/components/trip/day/components/TimelineRow.tsx
+++ b/src/components/trip/day/components/TimelineRow.tsx
@@ -158,7 +158,7 @@ const TimelineRow: React.FC<Props> = ({
 
           {/* Event Row */}
           <div
-            className="group/row relative flex-1 min-w-0 -mx-2 px-2 py-1.5 sm:py-2 cursor-pointer rounded-md hover:bg-secondary/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            className="group/row relative flex-1 min-w-0 -mx-2 px-2 py-1.5 sm:py-2 cursor-pointer rounded-md hover:bg-secondary/40 active:bg-secondary/60 touch-manipulation transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             role="button"
             tabIndex={0}
             onClick={handleItemClick}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[40px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[40px] w-full rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/hooks/use-mobile.test.tsx
+++ b/src/hooks/use-mobile.test.tsx
@@ -1,0 +1,145 @@
+// Regression cover for the first-render correctness of the viewport hooks.
+//
+// The previous implementation resolved the match in an effect, so the first
+// render always reported "not mobile" regardless of the real viewport. Consumers
+// that branch their layout on it (the map, the calendar toolbar) rendered the
+// desktop tree once on a phone and then swapped.
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useIsMobile } from './use-mobile';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+/** Minimal matchMedia stand-in that can flip a query and notify subscribers. */
+const installMatchMedia = (initial: Record<string, boolean>) => {
+  const state = { ...initial };
+  const listeners = new Map<string, Set<Listener>>();
+
+  const emit = (query: string, matches: boolean) => {
+    state[query] = matches;
+    listeners.get(query)?.forEach((listener) => listener({ matches } as MediaQueryListEvent));
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      get matches() {
+        return state[query] ?? false;
+      },
+      media: query,
+      onchange: null as MediaQueryList['onchange'],
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: (_: string, listener: Listener) => {
+        if (!listeners.has(query)) listeners.set(query, new Set());
+        listeners.get(query)!.add(listener);
+      },
+      removeEventListener: (_: string, listener: Listener) => {
+        listeners.get(query)?.delete(listener);
+      },
+      dispatchEvent: vi.fn(),
+    }),
+  });
+
+  return { emit };
+};
+
+const MOBILE_QUERY = '(max-width: 767px)';
+const COARSE_QUERY = '(pointer: coarse)';
+
+describe('useIsMobile', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    // The hooks memoise one MediaQueryList per query, so each test needs a fresh
+    // module instance to avoid inheriting the previous test's cached list.
+    vi.resetModules();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it('reports mobile on the very first render pass, before any effect runs', async () => {
+    installMatchMedia({ [MOBILE_QUERY]: true });
+    const { useIsMobile: freshUseIsMobile } = await import('./use-mobile');
+
+    // Record every render rather than reading `result.current`: renderHook
+    // flushes effects inside act(), so the settled value would look correct even
+    // under the old effect-based implementation. The bug is the *first* value.
+    const seen: boolean[] = [];
+    renderHook(() => {
+      const value = freshUseIsMobile();
+      seen.push(value);
+      return value;
+    });
+
+    expect(seen[0]).toBe(true);
+    expect(seen).not.toContain(false);
+  });
+
+  it('reports desktop when the viewport is wide', async () => {
+    installMatchMedia({ [MOBILE_QUERY]: false });
+    const { useIsMobile: freshUseIsMobile } = await import('./use-mobile');
+
+    const { result } = renderHook(() => freshUseIsMobile());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('updates when the viewport crosses the breakpoint', async () => {
+    const { emit } = installMatchMedia({ [MOBILE_QUERY]: false });
+    const { useIsMobile: freshUseIsMobile } = await import('./use-mobile');
+
+    const { result } = renderHook(() => freshUseIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => emit(MOBILE_QUERY, true));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('falls back to desktop when matchMedia is unavailable (prerender)', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useIsCoarsePointer', () => {
+  it('tracks pointer coarseness independently of width', async () => {
+    // A touch laptop: wide viewport, coarse pointer. The two hooks must disagree,
+    // which is why interaction models key off this one rather than useIsMobile.
+    installMatchMedia({ [MOBILE_QUERY]: false, [COARSE_QUERY]: true });
+    vi.resetModules();
+    const mod = await import('./use-mobile');
+
+    const { result: coarse } = renderHook(() => mod.useIsCoarsePointer());
+    const { result: mobile } = renderHook(() => mod.useIsMobile());
+
+    expect(coarse.current).toBe(true);
+    expect(mobile.current).toBe(false);
+  });
+
+  it('is false for precise pointers', async () => {
+    installMatchMedia({ [COARSE_QUERY]: false });
+    vi.resetModules();
+    const mod = await import('./use-mobile');
+
+    const { result } = renderHook(() => mod.useIsCoarsePointer());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,19 +1,69 @@
 import * as React from "react"
 
-const MOBILE_BREAKPOINT = 768
+export const MOBILE_BREAKPOINT = 768
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+const COARSE_POINTER_QUERY = "(pointer: coarse)"
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
+const supportsMatchMedia = () =>
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
 
-  return !!isMobile
+const noop = (): void => undefined
+
+/**
+ * One `MediaQueryList` per distinct query, shared by every consumer.
+ *
+ * These hooks are called per timeline row, so a long itinerary would otherwise
+ * open hundreds of identical subscriptions to answer the same question.
+ */
+const queryLists = new Map<string, MediaQueryList>()
+
+const getQueryList = (query: string): MediaQueryList | null => {
+  if (!supportsMatchMedia()) return null
+  let mql = queryLists.get(query)
+  if (!mql) {
+    mql = window.matchMedia(query)
+    queryLists.set(query, mql)
+  }
+  return mql
+}
+
+/**
+ * `useSyncExternalStore` reads the match during render rather than in an effect,
+ * so the first paint is already correct. Deciding this in an effect instead made
+ * every consumer render the desktop branch once on a phone and then swap — a
+ * visible layout jump, and for the map a second billable Dynamic Maps load.
+ */
+const useMediaQuery = (query: string): boolean => {
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void): (() => void) => {
+      const mql = getQueryList(query)
+      if (!mql) return noop
+      mql.addEventListener("change", onStoreChange)
+      return (): void => mql.removeEventListener("change", onStoreChange)
+    },
+    [query]
+  )
+
+  const getSnapshot = React.useCallback(() => getQueryList(query)?.matches ?? false, [query])
+
+  // Prerender (puppeteer) and any non-browser render fall back to the desktop
+  // branch, matching the layout the crawler-facing HTML is generated at.
+  const getServerSnapshot = React.useCallback(() => false, [])
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
+export function useIsMobile(): boolean {
+  return useMediaQuery(MOBILE_QUERY)
+}
+
+/**
+ * True on touch-first devices (phones, tablets). Distinct from `useIsMobile`,
+ * which is about available width — a touch laptop is wide but still coarse, and
+ * a narrow desktop window is narrow but still precise. Use this to pick
+ * interaction models (long-press vs. hover-revealed handles), not layout.
+ */
+export function useIsCoarsePointer(): boolean {
+  return useMediaQuery(COARSE_POINTER_QUERY)
 }

--- a/src/index.css
+++ b/src/index.css
@@ -206,6 +206,14 @@
     height: 100vh;
     height: -webkit-fill-available;
     height: calc(var(--app-height, 1vh) * 100);
+
+    /*
+     * iOS inflates text in landscape unless auto-adjustment is pinned off. The
+     * app already sets its own responsive type scale, so the browser guessing on
+     * top of it only breaks the layout.
+     */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
   }
 
   body {
@@ -213,6 +221,19 @@
     min-height: 100vh;
     min-height: -webkit-fill-available;
     min-height: calc(var(--app-height, 1vh) * 100);
+
+    /*
+     * Suppress the grey flash Safari and Chrome paint over every tapped element;
+     * components express press feedback through their own `active:` styles.
+     */
+    -webkit-tap-highlight-color: transparent;
+
+    /*
+     * Keep rubber-band scrolling inside whichever pane the user is actually in,
+     * so overscrolling a drawer or the chat log does not drag the page behind it.
+     * `contain` rather than `none` — pull-to-refresh stays available.
+     */
+    overscroll-behavior-y: contain;
   }
 
   :root {

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -308,7 +308,8 @@ const TripDetails = () => {
             }}
           >
 
-            <div className="max-w-none mx-auto px-4 pt-6 pb-24 md:pb-8">
+            {/* Bottom padding clears the fixed mobile nav (4rem) plus the iOS home indicator. */}
+            <div className="max-w-none mx-auto px-4 pt-6 pb-[calc(6rem_+_env(safe-area-inset-bottom,0px))] md:pb-8">
               <nav aria-label="Breadcrumb" className="mb-4 text-sm">
                 <ol className="flex items-center gap-1.5 text-earth-500">
                   <li>


### PR DESCRIPTION
The app was built and tuned on desktop, and several interactions either
degraded or disappeared entirely on a phone. Each of these is a
touch-specific failure rather than a styling preference:

Reordering was desktop-only. The itinerary drag handle is revealed on
hover, so on a touch screen it could never be reached — there was no way
to reorder an itinerary from a phone at all. Touch devices now drag from
the row itself via a long press, which also required splitting the single
PointerSensor into a MouseSensor and a TouchSensor: the 8px distance
constraint that suits a mouse swallows the start of every touch drag, so
a swipe meant to scroll would reorder instead. Long-press activation
leaves vertical swipes free to scroll. Suppressing the iOS selection
callout on those rows is what makes the press survive long enough to
become a drag; a KeyboardSensor comes along for free and makes the
existing handle attributes actually functional.

The bottom nav ignored the iOS safe area. With viewport-fit=cover, the
labels of a notched iPhone sat under the home indicator, where the system
swallows the taps. The bar now pads by the inset, and the trip content
above it clears the bar plus the inset rather than a hardcoded 6rem.

Two fields zoomed the page on focus. iOS zooms into any field whose text
is under 16px; the shared Textarea and the calendar subscribe link were
both below it, so tapping them jumped the viewport and left the user
scrolled sideways. Both now use 16px on mobile and their previous size
from md up, matching what Input already did.

Viewport detection was wrong on first render. useIsMobile resolved in an
effect, so it reported desktop for one render on every phone — the map
and calendar toolbar each rendered their desktop branch and then swapped.
It now reads the media query during render via useSyncExternalStore,
sharing one MediaQueryList per query since these hooks are called per
timeline row. Adds useIsCoarsePointer alongside it, because interaction
model and layout width are different questions: a touch laptop is wide
but coarse.

Global touch handling: pin text-size-adjust so iOS stops inflating text
in landscape, drop the grey tap-highlight flash in favour of the
components' own active: states, and contain overscroll so dragging a
drawer past its end no longer scrolls the page behind it.

Verified against the pre-existing baseline: type errors unchanged at 471,
tests 611 passing with the same 10 env-config failures that fail on a
clean checkout, lint clean, production build succeeds and the safe-area
and calc() rules are present in the emitted CSS.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R2sQgMohCsnKoKSWo2r5LL