### PR TITLE
Add guide page, trip copying, and discovery hints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ const Budget = lazy(() => import("./pages/Budget"));
 const Settings = lazy(() => import("./pages/Settings"));
 const LLMTraining = lazy(() => import("./pages/LLMTraining"));
 const Explore = lazy(() => import("./pages/Explore"));
+const Guide = lazy(() => import("./pages/Guide"));
 const Admin = lazy(() => import("./pages/Admin"));
 const InviteRedeem = lazy(() => import("./pages/InviteRedeem"));
 const OauthConsent = lazy(() => import("./pages/OauthConsent"));
@@ -84,6 +85,7 @@ const App = () => {
                   <Route path="/auth/forgot-password" element={<ForgotPassword />} />
                   <Route path="/auth/update-password" element={<UpdatePassword />} />
                   <Route path="/explore" element={<Explore />} />
+                  <Route path="/guide" element={<Guide />} />
                   <Route path="/explore/:slug/*" element={<TripDetails />} />
                   <Route path="/terms" element={<TermsOfService />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,7 +6,7 @@ import NavigationLinks from "./navigation/NavigationLinks";
 import NavigationAuth from "./navigation/NavigationAuth";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
-import { Menu, Compass, FolderOpen } from "lucide-react";
+import { Menu, Compass, FolderOpen, BookOpen } from "lucide-react";
 import { useLocation } from "react-router-dom";
 
 interface NavigationProps {
@@ -63,6 +63,13 @@ const Navigation = ({ mobileMenuTrigger }: NavigationProps) => {
                   >
                     <FolderOpen className="h-5 w-5" />
                     <span className="font-medium">My Trips</span>
+                  </button>
+                  <button
+                    onClick={() => handleMobileNavigation('/guide')}
+                    className="flex items-center gap-3 px-4 py-3 text-left text-sand-700 hover:bg-sand-50 rounded-lg transition-colors"
+                  >
+                    <BookOpen className="h-5 w-5" />
+                    <span className="font-medium">How it works</span>
                   </button>
                 </div>
               </SheetContent>

--- a/src/components/discovery/DiscoverHint.test.tsx
+++ b/src/components/discovery/DiscoverHint.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DiscoverHint from './DiscoverHint';
+
+const rpc = vi.fn().mockResolvedValue({ error: null });
+const maybeSingle = vi.fn().mockResolvedValue({ data: { discovery_state: {} }, error: null });
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: () => maybeSingle() }),
+      }),
+    }),
+  },
+}));
+
+let mockSession: { user: { id: string } } | null = { user: { id: 'user-1' } };
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ session: mockSession }),
+}));
+
+const renderHint = (props: Partial<React.ComponentProps<typeof DiscoverHint>> = {}) =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <DiscoverHint hint="map-view" {...props}>
+        See your days on a map.
+      </DiscoverHint>
+    </QueryClientProvider>,
+  );
+
+describe('DiscoverHint', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockSession = { user: { id: 'user-1' } };
+    rpc.mockClear();
+    maybeSingle.mockResolvedValue({ data: { discovery_state: {} }, error: null });
+  });
+
+  it('shows an unseen hint', () => {
+    renderHint();
+    expect(screen.getByText('See your days on a map.')).toBeInTheDocument();
+  });
+
+  it('stays hidden while its trigger condition is false', () => {
+    renderHint({ when: false });
+    expect(screen.queryByText('See your days on a map.')).not.toBeInTheDocument();
+  });
+
+  it('does not show to anonymous visitors — there is nowhere to remember a dismissal', () => {
+    mockSession = null;
+    renderHint();
+    expect(screen.queryByText('See your days on a map.')).not.toBeInTheDocument();
+  });
+
+  it('dismisses, remembers locally, and records the dismissal server-side', () => {
+    renderHint();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss tip/i }));
+
+    expect(screen.queryByText('See your days on a map.')).not.toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem('wl.discovery')!)).toEqual({ 'map-view': true });
+    expect(rpc).toHaveBeenCalledWith('mark_discovery_seen', { discovery_key: 'map-view' });
+  });
+
+  it('does not return once already dismissed on this device', () => {
+    window.localStorage.setItem('wl.discovery', JSON.stringify({ 'map-view': true }));
+    renderHint();
+    expect(screen.queryByText('See your days on a map.')).not.toBeInTheDocument();
+  });
+
+  it('running the action also marks the hint seen', () => {
+    const onAction = vi.fn();
+    renderHint({ actionLabel: 'Show me', onAction });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show me' }));
+
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(JSON.parse(window.localStorage.getItem('wl.discovery')!)).toEqual({ 'map-view': true });
+  });
+
+  it('keeps other hints untouched when one is dismissed', () => {
+    window.localStorage.setItem('wl.discovery', JSON.stringify({ 'doc-import': true }));
+    renderHint();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss tip/i }));
+
+    expect(JSON.parse(window.localStorage.getItem('wl.discovery')!)).toEqual({
+      'doc-import': true,
+      'map-view': true,
+    });
+  });
+});

--- a/src/components/discovery/DiscoverHint.tsx
+++ b/src/components/discovery/DiscoverHint.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { Lightbulb, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useFirstRun, type DiscoveryKey } from '@/hooks/useFirstRun';
+
+interface DiscoverHintProps {
+  /** Which one-time hint this is. See DiscoveryKey for the full set. */
+  hint: DiscoveryKey;
+  /** Gate on the trigger condition — the hint only fires once this is true. */
+  when?: boolean;
+  /** One plain sentence. Say what the user can do, not what the feature is called. */
+  children: React.ReactNode;
+  /** Optional call to action. Firing it also marks the hint seen. */
+  actionLabel?: string;
+  onAction?: () => void;
+  className?: string;
+}
+
+/**
+ * A single dismissible line that appears once, beside the feature it describes.
+ *
+ * Deliberately not a tour: it renders in place at the moment the capability
+ * became relevant, and never returns once acknowledged.
+ */
+export function DiscoverHint({
+  hint,
+  when = true,
+  children,
+  actionLabel,
+  onAction,
+  className,
+}: DiscoverHintProps) {
+  const { isUnseen, dismiss } = useFirstRun(hint, when);
+  const prefersReducedMotion = useReducedMotion();
+
+  if (!isUnseen) return null;
+
+  const handleAction = () => {
+    dismiss();
+    onAction?.();
+  };
+
+  return (
+    <motion.div
+      role="status"
+      initial={prefersReducedMotion ? false : { opacity: 0, y: -4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+      className={cn(
+        'flex items-start gap-3 rounded-lg border border-sunset-200 bg-sunset-50 px-3 py-2.5',
+        className
+      )}
+    >
+      <Lightbulb
+        className="mt-0.5 h-4 w-4 shrink-0 text-sunset-600"
+        strokeWidth={1.75}
+        aria-hidden="true"
+      />
+
+      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-sm leading-snug text-foreground">{children}</span>
+        {actionLabel && onAction && (
+          <button
+            type="button"
+            onClick={handleAction}
+            className="rounded text-sm font-medium text-sunset-600 underline underline-offset-2 transition-colors hover:text-sunset-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sunset-400"
+          >
+            {actionLabel}
+          </button>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss tip"
+        className="-my-2.5 -mr-2 flex h-11 w-11 shrink-0 items-center justify-center rounded text-sunset-600 transition-colors hover:text-sunset-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sunset-400"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </motion.div>
+  );
+}
+
+export default DiscoverHint;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,7 +4,8 @@ import { NavLink } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   Menu, Calendar, CalendarDays, Building, Car, MapPin, UtensilsCrossed,
-  Sparkles, BarChart2, Package, Settings, ArrowLeft, Users, Download, Link2, ShieldCheck, Trash2
+  Sparkles, BarChart2, Package, Settings, ArrowLeft, Users, Download, Link2, ShieldCheck, Trash2,
+  BookOpen
 } from "lucide-react";
 import { usePWAInstall } from "@/hooks/usePWAInstall";
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
@@ -262,6 +263,19 @@ const Sidebar = React.forwardRef<SidebarHandle, SidebarProps>(({ tripId, tripPat
       </ScrollArea>
 
       <div className="p-4 border-t border-sand-200 space-y-3">
+        {/* Permanent reference. Reachable from every trip, on both breakpoints,
+            because "how do I do X again?" arrives while you're mid-trip. */}
+        <NavLink to="/guide" onClick={() => setIsOpen(false)}>
+          <Button
+            className="w-full justify-start text-sand-600 hover:text-earth-600 hover:bg-sand-50"
+            variant="ghost"
+            size="sm"
+          >
+            <BookOpen className="mr-2 h-4 w-4" />
+            How it works
+          </Button>
+        </NavLink>
+
         {/* Mobile-only Admin Portal - Shows only on mobile for admins */}
         {isAdmin && (
           <div className="md:hidden">

--- a/src/components/navigation/NavigationLinks.tsx
+++ b/src/components/navigation/NavigationLinks.tsx
@@ -11,12 +11,16 @@ const NavigationLinks = () => {
       navigate("/explore");
     } else if (path === "My Trips") {
       navigate("/my-trips");
+    } else if (path === "Guide") {
+      navigate("/guide");
     } else if (path === "Admin") {
       navigate("/admin");
     }
   };
 
-  const navItems = isAdmin ? ["Explore", "My Trips", "Admin"] : ["Explore", "My Trips"];
+  const navItems = isAdmin
+    ? ["Explore", "My Trips", "Guide", "Admin"]
+    : ["Explore", "My Trips", "Guide"];
 
   return (
     <motion.div className="hidden space-x-8 md:flex">

--- a/src/components/trip/CopyTripButton.tsx
+++ b/src/components/trip/CopyTripButton.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { Copy, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/contexts/AuthContext';
+import { copyPublicTrip, daysBetweenIso, shiftIsoDate } from '@/services/copyTripService';
+import { formatDateRange } from '@/utils/dateUtils';
+
+interface CopyTripButtonProps {
+  tripId: string;
+  destination: string;
+  arrivalDate: string | null;
+  departureDate: string | null;
+  className?: string;
+}
+
+/** Today as `YYYY-MM-DD` in the viewer's own timezone. */
+function todayIso(): string {
+  const now = new Date();
+  const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 10);
+}
+
+/**
+ * Turns a showcase itinerary into a starting point.
+ *
+ * A finished trip teaches more about what the app can do than any amount of
+ * explanation — but only if you can actually pick it up and change it.
+ */
+export function CopyTripButton({
+  tripId,
+  destination,
+  arrivalDate,
+  departureDate,
+  className,
+}: CopyTripButtonProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { session } = useAuth();
+
+  const [open, setOpen] = useState(false);
+  const [isCopying, setIsCopying] = useState(false);
+
+  // Default to a month out: far enough to be a real plan, near enough to feel
+  // like one you're actually making.
+  const [startDate, setStartDate] = useState(() => shiftIsoDate(todayIso(), 30));
+
+  const preview = useMemo(() => {
+    if (!arrivalDate || !departureDate || !startDate) return null;
+    const shift = daysBetweenIso(arrivalDate, startDate);
+    return formatDateRange(startDate, shiftIsoDate(departureDate, shift));
+  }, [arrivalDate, departureDate, startDate]);
+
+  const handleOpen = () => {
+    if (!session) {
+      // Come back to this trip after signing in, so the intent isn't lost.
+      // `pendingRedirect` is the convention Auth.tsx already reads.
+      sessionStorage.setItem('pendingRedirect', window.location.pathname);
+      navigate('/auth');
+      return;
+    }
+    setOpen(true);
+  };
+
+  const handleCopy = async () => {
+    setIsCopying(true);
+    try {
+      const newTripId = await copyPublicTrip(tripId, startDate || undefined);
+      await queryClient.invalidateQueries({ queryKey: ['my-trips'] });
+      toast.success(`${destination} is now in My Trips — edit it however you like.`);
+      setOpen(false);
+      navigate(`/trip/${newTripId}/timeline`);
+    } catch (error) {
+      console.error('Failed to copy trip:', error);
+      toast.error(
+        error instanceof Error ? error.message : "That copy didn't go through. Please try again."
+      );
+    } finally {
+      setIsCopying(false);
+    }
+  };
+
+  return (
+    <>
+      <Button variant="sunset" size="lg" onClick={handleOpen} className={className}>
+        <Copy className="mr-2 h-4 w-4" aria-hidden="true" />
+        Make this trip mine
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-[440px]">
+          <DialogHeader>
+            <DialogTitle className="font-display text-2xl">
+              Copy this {destination} trip
+            </DialogTitle>
+            <DialogDescription className="text-base">
+              You'll get your own copy — every day, hotel, activity and reservation —
+              to change however you like. The original stays as it is.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="py-2">
+            <Label htmlFor="copy-start-date" className="text-base">
+              When are you going?
+            </Label>
+            <input
+              id="copy-start-date"
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="mt-2 h-11 w-full rounded-md border border-border bg-background px-3 text-base text-foreground focus:border-earth-500 focus:outline-none focus:ring-2 focus:ring-earth-500/30"
+            />
+            {preview && (
+              <p className="mt-3 text-sm text-muted-foreground">
+                Your trip will run <span className="font-medium text-foreground">{preview}</span>.
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={isCopying}>
+              Cancel
+            </Button>
+            <Button variant="sunset" onClick={handleCopy} disabled={isCopying || !startDate}>
+              {isCopying ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  Copying…
+                </>
+              ) : (
+                'Copy to my trips'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default CopyTripButton;

--- a/src/components/trip/TimelineView.test.tsx
+++ b/src/components/trip/TimelineView.test.tsx
@@ -20,6 +20,15 @@ vi.mock('./timeline/TimelineContent', () => ({
   default: () => <div data-testid="timeline-content" />,
 }));
 vi.mock('./timeline/ViewingStatusAvatars', () => ({ default: () => null }));
+vi.mock('@/hooks/useTravelers', () => ({
+  useTravelers: () => ({ travelers: [], isLoading: false }),
+}));
+// Hints default to already-seen here so the dock/view assertions below aren't
+// perturbed by an extra banner. Hint behaviour is covered by DiscoverHint.test.tsx.
+vi.mock('@/hooks/useFirstRun', () => ({
+  useFirstRun: () => ({ isUnseen: false, dismiss: vi.fn() }),
+  default: () => ({ isUnseen: false, dismiss: vi.fn() }),
+}));
 vi.mock('./ExportPdfButton', () => ({ default: () => null }));
 vi.mock('./calendar/CalendarSyncSheet', () => ({ default: () => null }));
 vi.mock('./calendar/TripCalendarView', () => ({

--- a/src/components/trip/TimelineView.tsx
+++ b/src/components/trip/TimelineView.tsx
@@ -5,14 +5,8 @@ import { supabase } from '@/integrations/supabase/client';
 import TimelineContent from './timeline/TimelineContent';
 import ExportPdfButton from './ExportPdfButton';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 // Aliased: a bare `Map` import shadows the global Map constructor used below.
-import { CalendarDays, ListTree, CalendarPlus, FileDown, MoreHorizontal, Map as MapIcon } from 'lucide-react';
+import { CalendarDays, ListTree, CalendarPlus, FileDown, Map as MapIcon } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import CalendarSyncSheet from './calendar/CalendarSyncSheet';
 import { toast } from 'sonner';
@@ -22,6 +16,9 @@ import { AIAssistantPanel } from './ai-assistant';
 import AssistantDock from './ai-assistant/AssistantDock';
 import { useWeather } from '@/hooks/useWeather';
 import ViewingStatusAvatars from './timeline/ViewingStatusAvatars';
+import DiscoverHint from '@/components/discovery/DiscoverHint';
+import { useFirstRun } from '@/hooks/useFirstRun';
+import { useTravelers } from '@/hooks/useTravelers';
 
 const TripCalendarView = lazy(() => import('./calendar/TripCalendarView'));
 const TripMapView = lazy(() => import('./map/TripMapView'));
@@ -90,6 +87,28 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
     },
     [setSearchParams],
   );
+
+  // Deep links from the guide ("Show me") land with the feature already open.
+  // The param is consumed and stripped so a refresh or a back-nav doesn't
+  // reopen a dialog the user has already closed.
+  useEffect(() => {
+    const sync = searchParams.get('sync');
+    const exportParam = searchParams.get('export');
+    if (!sync && !exportParam) return;
+
+    if (sync === '1') setIsSyncSheetOpen(true);
+    if (exportParam === 'pdf') setIsPdfExportOpen(true);
+
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        params.delete('sync');
+        params.delete('export');
+        return params;
+      },
+      { replace: true }
+    );
+  }, [searchParams, setSearchParams]);
 
   // Once opened, the map stays mounted and is hidden with CSS instead: Dynamic
   // Maps bills per map instantiation, and this also preserves camera state.
@@ -230,9 +249,34 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
       created_at: event.created_at || new Date().toISOString(),
     })) || [];
 
+  // ---- Discovery hints -------------------------------------------------
+  // Three capabilities that exist but never announce themselves. Each fires
+  // once, at the first moment it becomes relevant. Only ever one at a time —
+  // stacked hints read as clutter and get dismissed as a batch.
+  const { travelers } = useTravelers(tripId);
 
+  const itemCount =
+    (days?.reduce((sum, day) => sum + (day.activities?.length ?? 0), 0) ?? 0) +
+    processedHotelStays.length +
+    (transportationData?.length ?? 0);
 
+  const hasTransportation = (transportationData?.length ?? 0) > 0;
+  const isSharedTrip = (travelers?.length ?? 0) > 1;
 
+  // Pick the first hint that is both relevant and still unseen, so dismissing
+  // one lets the next take its place rather than silencing the whole chain.
+  const onTimeline = itineraryView === 'timeline';
+  const mapHint = useFirstRun('map-view', onTimeline && itemCount >= 3);
+  const calendarHint = useFirstRun('calendar-sync', onTimeline && canEdit && hasTransportation);
+  const collabHint = useFirstRun('live-collab', onTimeline && isSharedTrip);
+
+  const activeHint = mapHint.isUnseen
+    ? 'map-view'
+    : calendarHint.isUnseen
+      ? 'calendar-sync'
+      : collabHint.isUnseen
+        ? 'live-collab'
+        : null;
 
   return (
     <div className="relative lg:flex lg:gap-6">
@@ -301,28 +345,55 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tripId, tripDates: initialT
               open={isPdfExportOpen}
               onOpenChange={setIsPdfExportOpen}
             />
-            {/* Mobile: rare actions fold into an overflow menu with full labels. */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="icon" className="h-11 w-11 sm:hidden" aria-label="More actions">
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {canEdit && (
-                  <DropdownMenuItem onSelect={() => setIsSyncSheetOpen(true)}>
-                    <CalendarPlus className="mr-2 h-4 w-4" />
-                    Add to calendar
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onSelect={() => setIsPdfExportOpen(true)}>
-                  <FileDown className="mr-2 h-4 w-4" />
-                  Export PDF
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+          </div>
+
+          {/* Mobile: the same two actions as labelled buttons rather than an
+              unlabelled overflow icon — nobody taps a menu they can't read. */}
+          <div className="flex w-full gap-2 sm:hidden">
+            {canEdit && (
+              <Button
+                variant="outline"
+                className="h-11 flex-1"
+                onClick={() => setIsSyncSheetOpen(true)}
+              >
+                <CalendarPlus className="mr-2 h-4 w-4" />
+                Add to calendar
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              className="h-11 flex-1"
+              onClick={() => setIsPdfExportOpen(true)}
+            >
+              <FileDown className="mr-2 h-4 w-4" />
+              Export PDF
+            </Button>
           </div>
         </header>
+
+        {activeHint === 'map-view' && (
+          <DiscoverHint
+            hint="map-view"
+            actionLabel="Show me"
+            onAction={() => setItineraryView('map')}
+          >
+            Your days are filling up — see them laid out on a map, in the order you'll walk them.
+          </DiscoverHint>
+        )}
+        {activeHint === 'calendar-sync' && (
+          <DiscoverHint
+            hint="calendar-sync"
+            actionLabel="Set it up"
+            onAction={() => setIsSyncSheetOpen(true)}
+          >
+            You can subscribe to this itinerary in your phone's calendar — it updates itself as the trip changes.
+          </DiscoverHint>
+        )}
+        {activeHint === 'live-collab' && (
+          <DiscoverHint hint="live-collab">
+            Everyone on this trip sees your changes as you make them. The faces above show who's looking right now.
+          </DiscoverHint>
+        )}
 
         {canEdit && (
           <CalendarSyncSheet tripId={tripId} open={isSyncSheetOpen} onOpenChange={setIsSyncSheetOpen} />

--- a/src/components/trip/ai-assistant/AIAssistantPanel.test.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.test.tsx
@@ -43,6 +43,9 @@ vi.mock('./UsageMeter', () => ({ default: () => null }));
 vi.mock('./PaywallModal', () => ({ default: () => null }));
 vi.mock('./ItemStepperDialog', () => ({ default: () => null }));
 vi.mock('./PromptChips', () => ({ default: () => null }));
+// Stubbed like the other children: the real one reaches the Supabase client,
+// which validates env at import time. Covered by DiscoverHint.test.tsx.
+vi.mock('@/components/discovery/DiscoverHint', () => ({ default: () => null }));
 
 const renderPanel = (props: { onCollapse?: () => void } = {}) => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -10,6 +10,7 @@ import { addPlaceCardItem, undoPlaceCardItem } from '@/services/placeCardAddServ
 import ChatMessageList from './ChatMessageList';
 import ChatInput from './ChatInput';
 import PromptChips from './PromptChips';
+import DiscoverHint from '@/components/discovery/DiscoverHint';
 import UsageMeter from './UsageMeter';
 import PaywallModal from './PaywallModal';
 import ItemStepperDialog from './ItemStepperDialog';
@@ -348,6 +349,12 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
               usage={usage}
               onUpgradeClick={() => setShowPaywall(true)}
             />
+
+            {/* First-run: the attach control is the least obvious thing in the app */}
+            <DiscoverHint hint="doc-import" className="mx-4 mb-2">
+              Have a booking confirmation? Attach the PDF or a photo with{' '}
+              <span className="font-medium">+</span> and I'll read the details straight into your trip.
+            </DiscoverHint>
 
             {/* Input */}
             <ChatInput

--- a/src/components/trip/ai-assistant/ChatFileAttachment.tsx
+++ b/src/components/trip/ai-assistant/ChatFileAttachment.tsx
@@ -227,6 +227,7 @@ const ChatFileAttachmentComponent: React.FC<ChatFileAttachmentProps> = ({
             disabled && 'opacity-50 cursor-not-allowed'
           )}
           title="Attach image or PDF (booking confirmation, screenshot, etc.)"
+          aria-label="Attach a booking confirmation image or PDF"
         >
           <Plus className="w-5 h-5" />
         </Button>

--- a/src/components/trip/hero/DefaultHeroCard.tsx
+++ b/src/components/trip/hero/DefaultHeroCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Plus } from 'lucide-react';
+import { Compass, Plus } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 
 interface DefaultHeroCardProps {
@@ -45,15 +46,26 @@ export function DefaultHeroCard({
           Plan a trip and we'll help shape the days, the bookings, and the budget.
         </p>
 
-        <Button
-          size="lg"
-          onClick={onCreateTrip}
-          variant="sunset"
-          className="font-semibold"
-        >
-          <Plus className="h-5 w-5 mr-2" />
-          Plan a trip
-        </Button>
+        <div className="flex flex-col items-center gap-3 sm:flex-row">
+          <Button
+            size="lg"
+            onClick={onCreateTrip}
+            variant="sunset"
+            className="font-semibold"
+          >
+            <Plus className="h-5 w-5 mr-2" />
+            Plan a trip
+          </Button>
+
+          {/* Starting from a finished itinerary shows what the app can do far
+              faster than starting from an empty one. */}
+          <Button size="lg" variant="outline" asChild>
+            <Link to="/explore">
+              <Compass className="h-5 w-5 mr-2" aria-hidden="true" />
+              Start from an example
+            </Link>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/useFirstRun.ts
+++ b/src/hooks/useFirstRun.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * One-time discovery hints.
+ *
+ * Every key here names a capability that exists but does not announce itself.
+ * A hint fires once, beside the thing it describes, at the first moment the
+ * user is in a position to want it — not on first login, when there is nothing
+ * for the information to attach to.
+ */
+export type DiscoveryKey =
+  | 'map-view'
+  | 'calendar-sync'
+  | 'doc-import'
+  | 'live-collab';
+
+const STORAGE_KEY = 'wl.discovery';
+const QUERY_KEY = ['discovery-state'] as const;
+
+type DiscoveryState = Partial<Record<DiscoveryKey, boolean>>;
+
+/**
+ * localStorage mirror. Read synchronously on first render so a hint the user
+ * already dismissed never flashes back while the profile query is in flight.
+ */
+function readLocal(): DiscoveryState {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as DiscoveryState) : {};
+  } catch {
+    // Private mode, quota, or hand-edited garbage — hints are not worth throwing over.
+    return {};
+  }
+}
+
+function writeLocal(next: DiscoveryState) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    /* no-op */
+  }
+}
+
+/**
+ * Server-side state, shared by every hint on the page through one query key.
+ * Fails soft: if the column or RPC isn't there yet, hints fall back to the
+ * local mirror rather than erroring out of the surrounding component.
+ */
+function useDiscoveryState() {
+  const { session } = useAuth();
+  const userId = session?.user?.id;
+
+  return useQuery({
+    queryKey: QUERY_KEY,
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<DiscoveryState> => {
+      // `discovery_state` and `mark_discovery_seen` land in the generated types
+      // only after 20260819000000_profile_discovery_state.sql is applied and
+      // types are regenerated. Go around the typed builder until then.
+      const from = supabase.from as unknown as (table: string) => {
+        select: (cols: string) => {
+          eq: (col: string, val: string) => {
+            maybeSingle: () => Promise<{
+              data: { discovery_state?: DiscoveryState } | null;
+              error: { message: string } | null;
+            }>;
+          };
+        };
+      };
+
+      const { data, error } = await from('profiles')
+        .select('discovery_state')
+        .eq('id', userId)
+        .maybeSingle();
+
+      if (error) {
+        console.warn('discovery_state unavailable, using local only:', error.message);
+        return {};
+      }
+      return data?.discovery_state ?? {};
+    },
+  });
+}
+
+interface FirstRun {
+  /** True when this hint has never been seen and there is a user to remember it for. */
+  isUnseen: boolean;
+  /** Mark seen. Idempotent, and safe to call from a render-time effect. */
+  dismiss: () => void;
+}
+
+/**
+ * `active` gates the hint on the trigger condition (e.g. the trip has enough
+ * items to be worth mapping). Passing it in rather than checking outside keeps
+ * the "seen" bookkeeping in one place.
+ */
+export function useFirstRun(key: DiscoveryKey, active: boolean = true): FirstRun {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+  const { data: remote } = useDiscoveryState();
+
+  const [local, setLocal] = useState<DiscoveryState>(readLocal);
+
+  // Seen anywhere is seen everywhere: a user who dismissed on their phone
+  // should not meet the same hint again on a laptop, and vice versa.
+  const seen = Boolean(local[key] || remote?.[key]);
+
+  // Fold the server's record back into the local mirror so a fresh device
+  // stops re-checking after the first load.
+  useEffect(() => {
+    if (remote?.[key] && !local[key]) {
+      const next = { ...readLocal(), [key]: true };
+      writeLocal(next);
+      setLocal(next);
+    }
+  }, [remote, key, local]);
+
+  const dismiss = useCallback(() => {
+    const next = { ...readLocal(), [key]: true };
+    writeLocal(next);
+    setLocal(next);
+
+    queryClient.setQueryData<DiscoveryState>(QUERY_KEY, (prev) => ({ ...prev, [key]: true }));
+
+    if (!session?.user) return;
+    // Fire and forget: the local mirror already closed the hint, so a failed
+    // write costs one repeat on another device, not a broken interaction.
+    void (supabase.rpc as unknown as (
+      fn: string,
+      args: Record<string, unknown>
+    ) => Promise<{ error: { message: string } | null }>)('mark_discovery_seen', {
+      discovery_key: key,
+    }).then(({ error }) => {
+      if (error) console.warn('Could not persist discovery hint:', error.message);
+    });
+  }, [key, queryClient, session]);
+
+  const isUnseen = useMemo(
+    // Anonymous visitors on public trips get no hints — there is nowhere to
+    // remember the dismissal, so it would nag on every page load.
+    () => Boolean(session?.user) && active && !seen,
+    [session, active, seen]
+  );
+
+  return { isUnseen, dismiss };
+}
+
+export default useFirstRun;

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -1,0 +1,306 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  ArrowRight,
+  BarChart2,
+  Building,
+  CalendarDays,
+  CalendarPlus,
+  Cloud,
+  Compass,
+  FileDown,
+  ListTree,
+  Map as MapIcon,
+  MessageCircle,
+  Plug,
+  ScanLine,
+  Users,
+} from 'lucide-react';
+import SEO from '@/components/SEO';
+import { Button } from '@/components/ui/button';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * The permanent answer to "what can this thing actually do?".
+ *
+ * Deliberately a page rather than a first-run tour: it is here for the person
+ * coming back after six months, and for anyone who would rather look something
+ * up than be walked through it. Every entry says what you can do in plain
+ * words, and — where it can — takes you there with the feature already open.
+ */
+
+interface Capability {
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  title: string;
+  body: string;
+  /** Path built from the user's most recent trip, when there is one. */
+  to?: (tripPath: string | null) => string | null;
+  actionLabel?: string;
+}
+
+interface Section {
+  heading: string;
+  intro: string;
+  items: Capability[];
+}
+
+const SECTIONS: Section[] = [
+  {
+    heading: 'Building the itinerary',
+    intro: 'Everything on a trip hangs off its days. Add things to a day and the rest follows.',
+    items: [
+      {
+        icon: ListTree,
+        title: 'Plan day by day',
+        body: 'Add hotels, flights, activities and restaurant bookings to each day of your trip. Drag things around to reorder them. Everyone on the trip sees the same plan.',
+        to: (p) => (p ? `${p}/timeline` : '/create-trip'),
+        actionLabel: 'Show me',
+      },
+      {
+        icon: ScanLine,
+        title: 'Let it read your confirmations',
+        body: "Attach a booking confirmation — a PDF or a photo of one — and the assistant pulls out the dates, times, addresses and confirmation numbers, then adds them to the right day. It handles most flight, hotel and restaurant confirmations.",
+        to: (p) => (p ? `${p}/chat` : null),
+        actionLabel: 'Try it',
+      },
+      {
+        icon: MessageCircle,
+        title: 'Ask for ideas',
+        body: 'The assistant knows where and when you are going. Ask it what to do on a free afternoon, where to eat near your hotel, or how to get between two places. It can add anything it suggests straight to your itinerary.',
+        to: (p) => (p ? `${p}/chat` : null),
+        actionLabel: 'Open the assistant',
+      },
+    ],
+  },
+  {
+    heading: 'Seeing it your way',
+    intro: 'The same trip, shown three different ways. Switch between them at the top of the itinerary.',
+    items: [
+      {
+        icon: MapIcon,
+        title: 'See your days on a map',
+        body: "Every place you've added, plotted in the order you'll visit it. Useful for spotting the day where you've accidentally booked lunch an hour from your morning.",
+        to: (p) => (p ? `${p}/timeline?view=map` : null),
+        actionLabel: 'Show me',
+      },
+      {
+        icon: CalendarDays,
+        title: 'See it as a calendar',
+        body: 'A time-grid view of the whole trip, so you can see the gaps and the clashes. Drag anything to move it; times stay exactly as written, wherever you are in the world.',
+        to: (p) => (p ? `${p}/timeline?view=calendar` : null),
+        actionLabel: 'Show me',
+      },
+      {
+        icon: Cloud,
+        title: 'Weather and local times',
+        body: 'Each day shows the forecast for where you are. Anything in a different time zone — a flight landing in another country — carries a small label so the time on screen is never ambiguous.',
+      },
+    ],
+  },
+  {
+    heading: 'Going with other people',
+    intro: 'Trips are rarely solo. Everything here is built for more than one person.',
+    items: [
+      {
+        icon: Users,
+        title: 'Share the trip',
+        body: "Invite people by email or send them a link. You choose whether they can just look or also make changes. Edits appear on everyone's screen as they happen — no refreshing, no version confusion.",
+        to: (p) => (p ? `${p}/timeline` : null),
+        actionLabel: 'Open a trip',
+      },
+      {
+        icon: BarChart2,
+        title: 'Keep track of what it costs',
+        body: 'Log expenses against the trip in whatever currency you paid in, and see the total converted into yours. Bookings you add to the itinerary carry their cost through automatically.',
+        to: (p) => (p ? `${p}/budget` : null),
+        actionLabel: 'Show me',
+      },
+      {
+        icon: Building,
+        title: 'Book what you still need',
+        body: 'Search stays and flights without leaving the trip, or hand the whole thing to a human travel advisor if you would rather someone else made the calls.',
+        to: (p) => (p ? `${p}/booking` : null),
+        actionLabel: 'Show me',
+      },
+    ],
+  },
+  {
+    heading: 'Taking it with you',
+    intro: 'The plan is not much use if it only exists inside this app.',
+    items: [
+      {
+        icon: CalendarPlus,
+        title: 'Put it in your phone calendar',
+        body: 'Subscribe once and the whole itinerary appears in Apple Calendar, Google Calendar or Outlook — and keeps itself up to date as the trip changes. You can turn the link off again at any time.',
+        to: (p) => (p ? `${p}/timeline?sync=1` : null),
+        actionLabel: 'Set it up',
+      },
+      {
+        icon: FileDown,
+        title: 'Print or save a PDF',
+        body: 'A proper typeset itinerary you can print, email, or keep on your phone for the flight when there is no signal. Same layout whether you make it on a phone or a laptop.',
+        to: (p) => (p ? `${p}/timeline?export=pdf` : null),
+        actionLabel: 'Make one',
+      },
+      {
+        icon: Compass,
+        title: 'Install it like an app',
+        body: 'WanderLuxe can be added to your home screen and opens like any other app, with your trips available even on a patchy connection.',
+      },
+    ],
+  },
+  {
+    heading: 'For the curious',
+    intro: 'One thing WanderLuxe does that most travel apps do not.',
+    items: [
+      {
+        icon: Plug,
+        title: 'Plan your trip from Claude or ChatGPT',
+        body: "WanderLuxe runs a connector that lets an AI assistant work on your trips directly — ask Claude to add a dinner reservation on Thursday and it appears here. Add https://wanderluxe.io/mcp as a custom connector in your assistant's settings and sign in with your WanderLuxe account. It can read and change only your own trips.",
+      },
+    ],
+  },
+];
+
+const Guide: React.FC = () => {
+  const navigate = useNavigate();
+  const { session } = useAuth();
+
+  // "Show me" is only honest if it lands on a real trip. Fall back to trip
+  // creation when there is nothing to show yet.
+  const { data: recentTripId } = useQuery({
+    queryKey: ['guide-recent-trip'],
+    enabled: !!session?.user,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('trips')
+        .select('trip_id')
+        .eq('user_id', session!.user.id)
+        .eq('hidden', false)
+        .order('arrival_date', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) return null;
+      return data?.trip_id ?? null;
+    },
+  });
+
+  const tripPath = recentTripId ? `/trip/${recentTripId}` : null;
+
+  return (
+    <>
+      <SEO
+        title="How WanderLuxe works"
+        description="A plain-language guide to everything WanderLuxe can do — planning day by day, maps and calendars, sharing with travel companions, calendar sync, PDF export, and the AI connector."
+        canonicalPath="/guide"
+      />
+
+      <div className="bg-background">
+        <div className="container mx-auto px-4 md:px-6 py-12 md:py-20">
+          <div className="mx-auto max-w-3xl">
+
+            <header className="mb-14">
+              <p className="font-sans text-sm uppercase tracking-[0.18em] text-earth-400 mb-4">
+                Guide
+              </p>
+              <h1 className="font-display text-4xl md:text-5xl text-foreground leading-[1.05]">
+                What WanderLuxe can do.
+              </h1>
+              <p className="mt-5 text-lg leading-relaxed text-muted-foreground">
+                Most of this is one tap away once you know it's there. Nothing here
+                is required — plan a trip however you like and come back when you
+                want more.
+              </p>
+              {!session && (
+                <div className="mt-8">
+                  <Button size="lg" variant="sunset" onClick={() => navigate('/auth')}>
+                    Create a free account
+                  </Button>
+                </div>
+              )}
+            </header>
+
+            <div className="space-y-16">
+              {SECTIONS.map((section) => (
+                <section key={section.heading} aria-labelledby={`s-${section.heading}`}>
+                  <div className="border-t border-border pt-6 mb-7">
+                    <h2
+                      id={`s-${section.heading}`}
+                      className="font-display text-2xl md:text-3xl text-foreground leading-snug"
+                    >
+                      {section.heading}
+                    </h2>
+                    <p className="mt-2 text-base text-muted-foreground">{section.intro}</p>
+                  </div>
+
+                  <ul className="space-y-5">
+                    {section.items.map((item) => {
+                      const Icon = item.icon;
+                      const href = item.to?.(tripPath) ?? null;
+
+                      return (
+                        <li
+                          key={item.title}
+                          className="rounded-card border border-border bg-card p-5 md:p-6 shadow-warm-sm"
+                        >
+                          <div className="flex items-start gap-4">
+                            <span
+                              aria-hidden="true"
+                              className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-sand-50 text-earth-500"
+                            >
+                              <Icon className="h-5 w-5" strokeWidth={1.75} />
+                            </span>
+
+                            <div className="min-w-0 flex-1">
+                              <h3 className="font-display text-xl text-foreground leading-snug">
+                                {item.title}
+                              </h3>
+                              <p className="mt-2 text-base leading-relaxed text-muted-foreground">
+                                {item.body}
+                              </p>
+
+                              {href && item.actionLabel && (
+                                <Button
+                                  variant="outline"
+                                  size="lg"
+                                  className="mt-4"
+                                  onClick={() => navigate(href)}
+                                >
+                                  {item.actionLabel}
+                                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                                </Button>
+                              )}
+                            </div>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              ))}
+            </div>
+
+            <div className="mt-16 border-t border-border pt-8">
+              <p className="text-base text-muted-foreground">
+                Still stuck on something?{' '}
+                <a
+                  href="mailto:hello@wanderluxe.io"
+                  className="font-medium text-earth-500 underline underline-offset-4 hover:text-earth-600"
+                >
+                  Send us a note
+                </a>{' '}
+                and a person will read it.
+              </p>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Guide;

--- a/src/pages/TripDetails.tsx
+++ b/src/pages/TripDetails.tsx
@@ -15,6 +15,7 @@ import BudgetView from "../components/trip/BudgetView";
 import BookingView from "../components/trip/BookingView";
 import AIAssistantPanel from "../components/trip/ai-assistant/AIAssistantPanel";
 import AIAssistantDrawer from "../components/trip/ai-assistant/AIAssistantDrawer";
+import CopyTripButton from "@/components/trip/CopyTripButton";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useTripPermissions } from '@/hooks/use-trip-permissions';
 import { Card } from "@/components/ui/card";
@@ -329,7 +330,32 @@ const TripDetails = () => {
                 </ol>
               </nav>
 
-              {!canEdit && (
+              {/* Showcase trips are the app's best demo — make them a starting
+                  point rather than only a display case. */}
+              {isPublicTrip && !canEdit && (
+                <div className="mb-6 rounded-card border border-sunset-200 bg-sunset-50 p-5">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                      <h2 className="font-display text-xl text-foreground leading-snug">
+                        Like this itinerary? Start from it.
+                      </h2>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        Take a copy — every day, hotel and reservation — set your own dates,
+                        and change whatever you like.
+                      </p>
+                    </div>
+                    <CopyTripButton
+                      tripId={tripId}
+                      destination={displayData.destination}
+                      arrivalDate={displayData.arrival_date ?? null}
+                      departureDate={displayData.departure_date ?? null}
+                      className="shrink-0"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {!isPublicTrip && !canEdit && (
                 <div className="mb-6 bg-blue-50 border-l-4 border-blue-500 p-4 rounded-r-lg">
                   <div className="flex items-center">
                     <div className="flex-shrink-0">

--- a/src/services/copyTripService.ts
+++ b/src/services/copyTripService.ts
@@ -1,0 +1,54 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Copies a public showcase trip into the signed-in user's account.
+ *
+ * The whole deep copy (days, stays, activities, dining, transport) happens in
+ * one database transaction via the `copy_public_trip` function — doing it
+ * client-side would mean a dozen round-trips and a half-copied trip whenever
+ * one of them failed.
+ *
+ * @param sourceTripId  The public trip to copy.
+ * @param newArrivalDate  ISO `YYYY-MM-DD`. Every date in the itinerary shifts
+ *   by the same number of days, so the shape of the trip survives. Omit to
+ *   keep the original dates.
+ * @returns The new trip's id.
+ */
+export async function copyPublicTrip(
+  sourceTripId: string,
+  newArrivalDate?: string
+): Promise<string> {
+  // `copy_public_trip` enters the generated types only once the migration is
+  // applied and types are regenerated; cast at the boundary until then.
+  const rpc = supabase.rpc as unknown as (
+    fn: string,
+    args: Record<string, unknown>
+  ) => Promise<{ data: string | null; error: { message: string } | null }>;
+
+  const { data, error } = await rpc('copy_public_trip', {
+    source_trip_id: sourceTripId,
+    new_arrival_date: newArrivalDate ?? null,
+  });
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('The copy did not return a new trip.');
+
+  return data;
+}
+
+/** Shift `isoDate` by `days`, returning `YYYY-MM-DD`. */
+export function shiftIsoDate(isoDate: string, days: number): string {
+  const [y, m, d] = isoDate.split('-').map(Number);
+  // Construct in UTC so the result never slips a day across a DST boundary.
+  const shifted = new Date(Date.UTC(y, m - 1, d + days));
+  return shifted.toISOString().slice(0, 10);
+}
+
+/** Whole days between two ISO dates. Negative when `to` precedes `from`. */
+export function daysBetweenIso(from: string, to: string): number {
+  const [fy, fm, fd] = from.split('-').map(Number);
+  const [ty, tm, td] = to.split('-').map(Number);
+  const a = Date.UTC(fy, fm - 1, fd);
+  const b = Date.UTC(ty, tm - 1, td);
+  return Math.round((b - a) / 86_400_000);
+}

--- a/supabase/migrations/20260819000000_profile_discovery_state.sql
+++ b/supabase/migrations/20260819000000_profile_discovery_state.sql
@@ -1,0 +1,33 @@
+-- First-run discovery hints.
+--
+-- Records which one-time "did you know" hints a user has already seen, so a
+-- hint fires once per person rather than once per device. The client keeps a
+-- localStorage mirror for instant reads (a hint that renders a beat late reads
+-- as a glitch), and treats the two sources as a union: seen anywhere is seen
+-- everywhere.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS discovery_state jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.profiles.discovery_state IS
+  'Map of first-run hint key -> true once the user has seen or acted on that hint.';
+
+-- Merge a single key server-side. Read-modify-write from the client would race
+-- between tabs and clobber keys set elsewhere; `||` on jsonb does not.
+-- SECURITY INVOKER so the existing profiles_update_policy still applies —
+-- the caller can only ever touch their own row, and is_admin stays pinned.
+CREATE OR REPLACE FUNCTION public.mark_discovery_seen(discovery_key text)
+RETURNS void
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  UPDATE public.profiles
+  SET discovery_state = COALESCE(discovery_state, '{}'::jsonb)
+                        || jsonb_build_object(discovery_key, true),
+      updated_at = now()
+  WHERE id = auth.uid();
+$$;
+
+REVOKE ALL ON FUNCTION public.mark_discovery_seen(text) FROM public;
+GRANT EXECUTE ON FUNCTION public.mark_discovery_seen(text) TO authenticated;

--- a/supabase/migrations/20260819000001_copy_public_trip.sql
+++ b/supabase/migrations/20260819000001_copy_public_trip.sql
@@ -1,0 +1,177 @@
+-- Copy a showcase trip into the caller's own account.
+--
+-- A finished, fully-populated itinerary is the best teaching surface the app
+-- has: it demonstrates every feature at once without a word of instruction.
+-- This makes one reachable as a starting point rather than only as a display.
+--
+-- SECURITY DEFINER because the copy writes across six tables in one
+-- transaction; every write is pinned to auth.uid() and the source is required
+-- to be a public trip, so the definer rights cannot be used to read or write
+-- anything the caller could not already see.
+
+CREATE OR REPLACE FUNCTION public.copy_public_trip(
+  source_trip_id uuid,
+  new_arrival_date date DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  caller      uuid := auth.uid();
+  src         public.trips%ROWTYPE;
+  new_trip_id uuid := gen_random_uuid();
+  day_shift   int  := 0;
+BEGIN
+  IF caller IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in to copy a trip'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO src
+  FROM public.trips
+  WHERE trip_id = source_trip_id
+    AND is_public = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'That trip is not available to copy'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Rebase the whole itinerary onto the caller's own start date. Every date in
+  -- the trip moves by the same number of days, so relative structure survives.
+  IF new_arrival_date IS NOT NULL THEN
+    day_shift := new_arrival_date - src.arrival_date;
+  END IF;
+
+  DROP TABLE IF EXISTS _wl_day_map;
+  DROP TABLE IF EXISTS _wl_stay_map;
+  CREATE TEMP TABLE _wl_day_map  (old_id uuid PRIMARY KEY, new_id uuid NOT NULL) ON COMMIT DROP;
+  CREATE TEMP TABLE _wl_stay_map (old_id uuid PRIMARY KEY, new_id uuid NOT NULL) ON COMMIT DROP;
+
+  -- The trip itself. Deliberately not carried over: slug and summary (unique
+  -- to the published showcase), the calendar feed token (a fresh one is minted
+  -- on demand), and is_public (a copy is always private).
+  INSERT INTO public.trips (
+    trip_id, user_id, destination,
+    primary_destination, primary_destination_place_id,
+    arrival_date, departure_date, budget, timezone,
+    cover_image_url, cover_image_position, image_position,
+    cover_image_photographer, cover_image_photographer_username,
+    is_public, hidden, calendar_feed_enabled
+  )
+  VALUES (
+    new_trip_id, caller, src.destination,
+    src.primary_destination, src.primary_destination_place_id,
+    src.arrival_date + day_shift, src.departure_date + day_shift,
+    src.budget, src.timezone,
+    src.cover_image_url, src.cover_image_position, src.image_position,
+    src.cover_image_photographer, src.cover_image_photographer_username,
+    false, false, false
+  );
+
+  -- Days, remembering old -> new so the children can be re-pointed.
+  WITH mapped AS MATERIALIZED (
+    SELECT day_id AS old_id, gen_random_uuid() AS new_id, date, title, description,
+           image_url, image_position
+    FROM public.trip_days
+    WHERE trip_id = source_trip_id
+  ),
+  inserted AS (
+    INSERT INTO public.trip_days (day_id, trip_id, date, title, description, image_url, image_position)
+    SELECT new_id, new_trip_id, date + day_shift, title, description, image_url, image_position
+    FROM mapped
+  )
+  INSERT INTO _wl_day_map (old_id, new_id)
+  SELECT old_id, new_id FROM mapped;
+
+  -- Stays.
+  WITH mapped AS MATERIALIZED (
+    SELECT stay_id AS old_id, gen_random_uuid() AS new_id, title, hotel, hotel_details,
+           hotel_url, hotel_website, hotel_address, hotel_phone, hotel_place_id,
+           hotel_checkin_date, hotel_checkout_date, checkin_time, checkout_time,
+           final_accommodation_day, cost, currency, expense_type, image_url,
+           order_index, description, timezone
+    FROM public.accommodations
+    WHERE trip_id = source_trip_id
+  ),
+  inserted AS (
+    INSERT INTO public.accommodations (
+      stay_id, trip_id, title, hotel, hotel_details, hotel_url, hotel_website,
+      hotel_address, hotel_phone, hotel_place_id,
+      hotel_checkin_date, hotel_checkout_date, checkin_time, checkout_time,
+      final_accommodation_day, cost, currency, expense_type, image_url,
+      order_index, description, timezone
+    )
+    SELECT new_id, new_trip_id, title, hotel, hotel_details, hotel_url, hotel_website,
+           hotel_address, hotel_phone, hotel_place_id,
+           hotel_checkin_date + day_shift, hotel_checkout_date + day_shift,
+           checkin_time, checkout_time,
+           CASE
+             WHEN final_accommodation_day ~ '^\d{4}-\d{2}-\d{2}$'
+               THEN ((final_accommodation_day::date + day_shift)::text)
+             ELSE final_accommodation_day
+           END,
+           cost, currency, expense_type, image_url,
+           order_index, description, timezone
+    FROM mapped
+  )
+  INSERT INTO _wl_stay_map (old_id, new_id)
+  SELECT old_id, new_id FROM mapped;
+
+  -- Which days each stay spans.
+  INSERT INTO public.accommodations_days (id, stay_id, day_id, date)
+  SELECT gen_random_uuid(), sm.new_id, dm.new_id, ad.date + day_shift
+  FROM public.accommodations_days ad
+  JOIN public.accommodations a ON a.stay_id = ad.stay_id
+  JOIN _wl_stay_map sm ON sm.old_id = ad.stay_id
+  JOIN _wl_day_map  dm ON dm.old_id = ad.day_id
+  WHERE a.trip_id = source_trip_id;
+
+  INSERT INTO public.day_activities (
+    id, trip_id, day_id, title, description, start_time, end_time, order_index,
+    cost, currency, timezone,
+    location_address, location_phone, location_place_id, location_rating, location_website
+  )
+  SELECT gen_random_uuid(), new_trip_id, dm.new_id, act.title, act.description,
+         act.start_time, act.end_time, act.order_index,
+         act.cost, act.currency, act.timezone,
+         act.location_address, act.location_phone, act.location_place_id,
+         act.location_rating, act.location_website
+  FROM public.day_activities act
+  JOIN _wl_day_map dm ON dm.old_id = act.day_id
+  WHERE act.trip_id = source_trip_id;
+
+  INSERT INTO public.reservations (
+    id, trip_id, day_id, restaurant_name, reservation_time, number_of_people,
+    address, phone_number, website, place_id, rating, notes, image_url,
+    cost, currency, order_index, timezone
+  )
+  SELECT gen_random_uuid(), new_trip_id, dm.new_id, r.restaurant_name, r.reservation_time,
+         r.number_of_people, r.address, r.phone_number, r.website, r.place_id, r.rating,
+         r.notes, r.image_url, r.cost, r.currency, r.order_index, r.timezone
+  FROM public.reservations r
+  JOIN _wl_day_map dm ON dm.old_id = r.day_id
+  WHERE r.trip_id = source_trip_id;
+
+  -- Transportation hangs off the trip rather than a day. Confirmation numbers
+  -- and live flight status belong to the original traveller, not the copier.
+  INSERT INTO public.transportation (
+    id, trip_id, type, provider, details,
+    departure_location, arrival_location, departure_timezone, arrival_timezone,
+    start_date, end_date, start_time, end_time, cost, currency
+  )
+  SELECT gen_random_uuid(), new_trip_id, t.type, t.provider, t.details,
+         t.departure_location, t.arrival_location, t.departure_timezone, t.arrival_timezone,
+         t.start_date + day_shift, t.end_date + day_shift, t.start_time, t.end_time,
+         t.cost, t.currency
+  FROM public.transportation t
+  WHERE t.trip_id = source_trip_id;
+
+  RETURN new_trip_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.copy_public_trip(uuid, date) FROM public;
+GRANT EXECUTE ON FUNCTION public.copy_public_trip(uuid, date) TO authenticated;


### PR DESCRIPTION
## Summary
Adds a comprehensive guide page explaining WanderLuxe's capabilities, enables users to copy public showcase trips as a starting point, and introduces subtle one-time discovery hints that surface features at the moment they become relevant.

## Key Changes

### Guide Page (`src/pages/Guide.tsx`)
- New `/guide` route with plain-language explanations of all major features
- Organized into 5 sections: building itineraries, viewing options, collaboration, portability, and AI integration
- Each capability includes an icon, description, and contextual "Show me" button that deep-links to the feature with the user's most recent trip (or trip creation if none exists)
- SEO-optimized with canonical path and meta description
- Call-to-action for unauthenticated users to create an account

### Trip Copying (`src/components/trip/CopyTripButton.tsx`, `src/services/copyTripService.ts`)
- New `CopyTripButton` component that appears on public trip detail pages
- Dialog allows users to select their desired arrival date; all dates in the itinerary shift proportionally
- Deep copy via `copy_public_trip()` RPC function that atomically copies trips, days, stays, activities, dining, and transportation across 6 tables in a single transaction
- Utility functions for ISO date arithmetic (`shiftIsoDate`, `daysBetweenIso`)
- Redirects to trip timeline after successful copy

### Discovery Hints System (`src/hooks/useFirstRun.ts`, `src/components/discovery/DiscoverHint.tsx`)
- `useFirstRun` hook manages one-time hints with dual persistence: localStorage (instant reads) + server state (sync across devices)
- `DiscoverHint` component renders a subtle, dismissible inline hint with optional action button
- Four hint types: `map-view`, `calendar-sync`, `doc-import`, `live-collab`
- Hints fire once at the moment they become relevant (e.g., map hint when 3+ items exist)
- Only one hint visible at a time; dismissing one allows the next to surface

### Database Migrations
- `20260819000000_profile_discovery_state.sql`: Adds `discovery_state` jsonb column to profiles table and `mark_discovery_seen()` RPC function
- `20260819000001_copy_public_trip.sql`: Implements `copy_public_trip()` function with full transaction support, date shifting, and security definer pattern

### Integration Points
- `TimelineView.tsx`: Wires up discovery hints for map view, calendar sync, and live collaboration; handles deep-link params (`?sync=1`, `?export=pdf`)
- `DefaultHeroCard.tsx`: Adds "Explore" button linking to `/explore` page as alternative to creating a new trip
- `TripDetails.tsx`: Shows copy button prominently on public trips
- `Sidebar.tsx`, `Navigation.tsx`, `NavigationLinks.tsx`: Add "Guide" link to main navigation
- `App.tsx`: Registers `/guide` route

## Notable Implementation Details

- **Security**: `copy_public_trip()` uses `SECURITY DEFINER` to safely handle multi-table writes while pinning all inserts to `auth.uid()` and requiring source trip to be public
- **Date Shifting**: Preserves relative trip structure by shifting all dates by the same offset, allowing users to rebase showcase trips to their own travel dates
- **Hint Persistence**: LocalStorage provides instant reads (no flash of dismissed hints), while server state syncs across devices; treats both as a union (seen anywhere = seen everywhere)
- **Deep Linking**: Guide's "Show me" buttons construct URLs with the user's most recent trip, falling back to trip creation for new users
- **Accessibility**: Hints use `role="status"` for screen readers; all interactive elements have proper labels and focus states

https://claude.ai/code/session_01MUdrq5PUbmHmBLkCCQ3c2P