### PR TITLE
Redesign the day timeline and distill the assistant's copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ evals/results/
 
 # TypeScript incremental build info (written by `tsc -b`)
 *.tsbuildinfo
+
+# impeccable design-hook caches
+.impeccable/

--- a/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantDrawer.tsx
@@ -47,9 +47,6 @@ class AIAssistantErrorBoundary extends Component<{ children: ReactNode; onReset:
           <AlertCircle className="w-10 h-10 text-red-400" />
           <div className="space-y-1">
             <h3 className="font-display text-lg leading-tight tracking-tight text-foreground">Something went wrong</h3>
-            <p className="text-sm leading-snug text-muted-foreground">
-              The assistant ran into an unexpected error.
-            </p>
           </div>
           <Button onClick={this.handleReset} variant="outline" size="sm" className="mt-1">
             Try again
@@ -95,8 +92,8 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
       thread_id: '',
       role: 'assistant',
       content: items.length === 1
-        ? "I've prepared this item for you to add to your trip:"
-        : `I've prepared ${items.length} items for you to add to your trip:`,
+        ? "I've prepared this item:"
+        : `I've prepared ${items.length} items:`,
       metadata: {},
       created_at: new Date().toISOString(),
       extractedItems: items,
@@ -225,7 +222,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
           id: `user-extract-${Date.now()}`,
           thread_id: '',
           role: 'user',
-          content: message || 'Please extract items from this document',
+          content: message || 'Extract items from this document',
           metadata: {},
           created_at: new Date().toISOString(),
           attachmentPreviewUrl: attachment.previewUrl,
@@ -244,7 +241,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
             role: 'assistant',
             content: items.length > 0
               ? `I found ${items.length} item${items.length !== 1 ? 's' : ''} in your document.`
-              : "I couldn't find any bookable items in this document.",
+              : "I didn't find any travel details in your document.",
             metadata: {},
             created_at: new Date().toISOString(),
             extractedItems: items,
@@ -370,7 +367,7 @@ const AIAssistantDrawer: React.FC<AIAssistantDrawerProps> = ({
                   isSending={isStreaming || isExtracting}
                   placeholder={
                     isDisabled && usage?.used === usage?.limit
-                      ? "Daily limit reached. Upgrade for unlimited."
+                      ? "Daily limit reached. Upgrade for unlimited messages."
                       : "Ask about your trip..."
                   }
                 />

--- a/src/components/trip/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/trip/ai-assistant/AIAssistantPanel.tsx
@@ -78,8 +78,8 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
       thread_id: '',
       role: 'assistant',
       content: items.length === 1
-        ? "I've prepared this item for you to add to your trip:"
-        : `I've prepared ${items.length} items for you to add to your trip:`,
+        ? "I've prepared this item:"
+        : `I've prepared ${items.length} items:`,
       metadata: {},
       created_at: new Date().toISOString(),
       extractedItems: items,
@@ -136,7 +136,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
           id: `user-extract-${Date.now()}`,
           thread_id: '',
           role: 'user',
-          content: message || 'Please extract items from this document',
+          content: message || 'Extract items from this document',
           metadata: {},
           created_at: new Date().toISOString(),
           attachmentPreviewUrl: attachment.previewUrl,
@@ -156,7 +156,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
             role: 'assistant',
             content: items.length > 0
               ? `I found ${items.length} item${items.length !== 1 ? 's' : ''} in your document.`
-              : "I couldn't find any bookable items in this document.",
+              : "I didn't find any travel details in your document.",
             metadata: {},
             created_at: new Date().toISOString(),
             extractedItems: items,
@@ -293,7 +293,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
             </div>
             <div>
               <h3 className="font-display text-[17px] leading-tight tracking-tight text-foreground">Trip Assistant</h3>
-              <p className="text-[13px] leading-snug text-muted-foreground mt-0.5">Chat, plan, and lift bookings into your trip</p>
+              <p className="text-[13px] leading-snug text-muted-foreground mt-0.5">Private to you, not shared with co-travelers</p>
             </div>
           </div>
 
@@ -352,8 +352,8 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
 
             {/* First-run: the attach control is the least obvious thing in the app */}
             <DiscoverHint hint="doc-import" className="mx-4 mb-2">
-              Have a booking confirmation? Attach the PDF or a photo with{' '}
-              <span className="font-medium">+</span> and I'll read the details straight into your trip.
+              Attach a booking confirmation with <span className="font-medium">+</span> and I'll
+              read it into your trip.
             </DiscoverHint>
 
             {/* Input */}
@@ -364,7 +364,7 @@ const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({ tripId, onCollapse 
               placeholder={
                 isDisabled && usage?.used === usage?.limit
                   ? (isAnonymous ? "Sign up free to keep chatting" : "Daily limit reached. Upgrade for unlimited messages.")
-                  : "Ask about your trip or attach a booking..."
+                  : "Ask about your trip..."
               }
             />
         </>

--- a/src/components/trip/ai-assistant/ChatFileAttachment.tsx
+++ b/src/components/trip/ai-assistant/ChatFileAttachment.tsx
@@ -29,7 +29,7 @@ const ChatFileAttachmentComponent: React.FC<ChatFileAttachmentProps> = ({
 
   const validateFile = useCallback((file: File): string | null => {
     if (!ALLOWED_TYPES.includes(file.type)) {
-      return 'Only JPG, PNG, or PDF files are allowed.';
+      return 'Attach a JPG, PNG, or PDF.';
     }
     if (file.size > MAX_FILE_MB * 1024 * 1024) {
       return `File size must be under ${MAX_FILE_MB}MB.`;
@@ -94,7 +94,7 @@ const ChatFileAttachmentComponent: React.FC<ChatFileAttachmentProps> = ({
         });
       } catch (e) {
         console.error('PDF conversion failed:', e);
-        toast.error('Failed to preview PDF. Please try again.');
+        toast.error('Could not preview that PDF.');
       } finally {
         setIsConverting(false);
       }
@@ -132,30 +132,6 @@ const ChatFileAttachmentComponent: React.FC<ChatFileAttachmentProps> = ({
     e.preventDefault();
     e.stopPropagation();
   }, []);
-
-  const handlePaste = useCallback(async () => {
-    try {
-      if (!navigator.clipboard || !('read' in navigator.clipboard)) {
-        toast.info('Paste not supported. Use the attach button instead.');
-        return;
-      }
-      const items = await navigator.clipboard.read();
-      for (const item of items) {
-        for (const type of item.types) {
-          if (type.startsWith('image/') || type === 'application/pdf') {
-            const blob = await item.getType(type);
-            const ext = type.split('/')[1] || 'png';
-            const pasted = new File([blob], `pasted.${ext}`, { type });
-            processFile(pasted);
-            return;
-          }
-        }
-      }
-      toast.info('No image or PDF found in clipboard.');
-    } catch (e: unknown) {
-      console.error('Clipboard read failed:', e);
-    }
-  }, [processFile]);
 
   // Listen for paste events
   useEffect(() => {

--- a/src/components/trip/ai-assistant/ChatInput.tsx
+++ b/src/components/trip/ai-assistant/ChatInput.tsx
@@ -163,7 +163,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         </Button>
       </div>
       <p className="text-xs text-muted-foreground mt-2 px-1 hidden sm:block">
-        {attachment ? 'Press Enter to extract items from this document' : 'Press Enter to send, Shift+Enter for a new line'}
+        {attachment ? 'Press Enter to extract items' : 'Shift+Enter for a new line'}
       </p>
     </div>
   );

--- a/src/components/trip/ai-assistant/ChatMessageList.tsx
+++ b/src/components/trip/ai-assistant/ChatMessageList.tsx
@@ -265,13 +265,13 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
                 What can I help you plan?
               </h2>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Recommendations, scheduling, packing tips, or paste a confirmation to add it to your trip.
+                Paste a booking confirmation to add it to your trip.
               </p>
             </div>
           </div>
           {emptyStateSlot}
           <p className="text-xs text-muted-foreground/80 max-w-[280px] text-center leading-relaxed">
-            Trip details are shared with Google Gemini to personalize recommendations. Messages are never used to train AI models.
+            Trip details go to Google Gemini for recommendations. Messages are never used to train AI models.
           </p>
         </div>
       </div>
@@ -306,7 +306,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
           {isLoadingMore ? (
             <div className="flex items-center gap-2 text-sand-400 text-xs">
               <Loader2 className="w-3 h-3 animate-spin" />
-              <span>Loading older messages...</span>
+              <span>Loading older chats…</span>
             </div>
           ) : (
             <div className="flex items-center gap-1 text-sand-400 text-xs">

--- a/src/components/trip/ai-assistant/ExtractedItemCard.tsx
+++ b/src/components/trip/ai-assistant/ExtractedItemCard.tsx
@@ -55,7 +55,7 @@ const TRANSPORT_TYPE_LABELS: Record<string, string> = {
   flight: 'Flight',
   train: 'Train',
   ferry: 'Ferry',
-  rental_car: 'Car Rental',
+  rental_car: 'Rental Car',
   car_service: 'Car Service',
   shuttle: 'Shuttle'
 };
@@ -105,7 +105,7 @@ function getReservationSummary(fields: Record<string, unknown>): ItemSummary {
   const time = fields.time as string;
   const partySize = fields.party_size as number;
   const dateStr = date ? formatShortDate(date) : '';
-  const partySizeStr = partySize ? `${partySize} guests` : '';
+  const partySizeStr = partySize ? `${partySize} ${partySize === 1 ? 'guest' : 'guests'}` : '';
 
   return { title: name, subtitle: [dateStr, time, partySizeStr].filter(Boolean).join(' • ') };
 }
@@ -195,11 +195,6 @@ const ExtractedItemCard: React.FC<ExtractedItemCardProps> = ({
             </p>
           )}
 
-          {/* Click to edit hint (when in stepper / edit flow) */}
-          {isClickable && (
-            <p className="mt-1 text-xs text-earth-500">Tap to edit details</p>
-          )}
-
           {/* Warnings */}
           {hasWarnings && !isProcessed && (
             <div className="mt-1.5 flex items-center gap-1 text-xs text-amber-600">
@@ -207,27 +202,11 @@ const ExtractedItemCard: React.FC<ExtractedItemCardProps> = ({
               <span>
                 {item.missingRequired.length > 0
                   ? `Missing: ${item.missingRequired.join(', ')}`
-                  : 'Low confidence - please verify'}
+                  : 'Low confidence, verify'}
               </span>
             </div>
           )}
         </div>
-
-        {/* Confidence indicator */}
-        {!compact && !isProcessed && (
-          <div className="flex-shrink-0">
-            <div
-              className={cn(
-                'text-xs tabular-nums px-1.5 py-0.5 rounded',
-                item.confidence >= 0.9 ? 'bg-green-100 text-green-700' :
-                item.confidence >= 0.7 ? 'bg-sand-100 text-sand-700' :
-                'bg-amber-100 text-amber-700'
-              )}
-            >
-              {Math.round(item.confidence * 100)}%
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/trip/ai-assistant/ExtractionResultMessage.tsx
+++ b/src/components/trip/ai-assistant/ExtractionResultMessage.tsx
@@ -43,7 +43,7 @@ function EmptyState(): React.ReactElement {
         </div>
         <div>
           <p className="text-sm text-foreground">
-            I couldn't find any bookable items in this document.
+            I didn't find any travel details in your document.
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             Try a clearer image, or a confirmation with visible booking details.
@@ -121,8 +121,8 @@ const ExtractionResultMessage: React.FC<ExtractionResultMessageProps> = ({
 
   const summaryParts = buildSummaryParts(itemCounts);
   const headerText = allProcessed
-    ? `Added ${pluralize(createdItems.length, 'item')} to your trip`
-    : `Found ${pluralize(items.length, 'item')} in your document`;
+    ? `Added ${pluralize(createdItems.length, 'item')}`
+    : `Found ${pluralize(items.length, 'item')}`;
 
   return (
     <div className="rounded-2xl bg-sand-50 border border-border rounded-tl-sm overflow-hidden max-w-full">
@@ -182,15 +182,6 @@ const ExtractionResultMessage: React.FC<ExtractionResultMessageProps> = ({
         </div>
       )}
 
-      {/* Success state */}
-      {allProcessed && (
-        <div className="px-4 py-3 border-t border-border bg-green-50">
-          <div className="flex items-center gap-2 text-sm text-green-700">
-            <Check className="w-4 h-4" />
-            <span>All items have been processed</span>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/trip/ai-assistant/ItemStepperDialog.tsx
+++ b/src/components/trip/ai-assistant/ItemStepperDialog.tsx
@@ -276,7 +276,6 @@ const ItemStepperDialog: React.FC<ItemStepperDialogProps> = ({
             <Button
               onClick={handleEditClick}
               className="flex-1"
-              title="Open full form to edit and add"
             >
               <Check className="w-4 h-4 mr-1" />
               Edit & {isLastItem ? 'Finish' : 'Next'}

--- a/src/components/trip/ai-assistant/PaywallModal.tsx
+++ b/src/components/trip/ai-assistant/PaywallModal.tsx
@@ -45,7 +45,7 @@ const PaywallModal: React.FC<PaywallModalProps> = ({ open, onOpenChange, usage, 
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
       if (!token) {
-        toast.error("Please sign in to upgrade");
+        toast.error("Sign in to upgrade");
         return;
       }
 
@@ -85,7 +85,7 @@ const PaywallModal: React.FC<PaywallModalProps> = ({ open, onOpenChange, usage, 
       console.error('Checkout error:', e);
       // Handle network errors specifically
       if (e instanceof TypeError && (e.message.includes('Load failed') || e.message.includes('Failed to fetch'))) {
-        toast.error("Connection error - please check your internet and try again");
+        toast.error("Connection failed. Check your network and try again.");
       } else {
         toast.error(e instanceof Error ? e.message : "Failed to start checkout");
       }
@@ -110,7 +110,7 @@ const PaywallModal: React.FC<PaywallModalProps> = ({ open, onOpenChange, usage, 
             </div>
             <DialogTitle className="font-display text-xl leading-tight tracking-tight">Sign up free to keep chatting</DialogTitle>
             <DialogDescription className="text-sand-600">
-              You've used your {usage?.limit || 5} trial messages. Create a free account to continue.
+              You've used your {usage?.limit || 5} trial messages.
             </DialogDescription>
           </DialogHeader>
 
@@ -128,7 +128,7 @@ const PaywallModal: React.FC<PaywallModalProps> = ({ open, onOpenChange, usage, 
                 </li>
                 <li className="flex items-center gap-2 text-sm text-earth-600">
                   <Check className="w-4 h-4 text-green-600 flex-shrink-0" />
-                  <span>Plan and manage your own trips</span>
+                  <span>Plan your own trips</span>
                 </li>
                 <li className="flex items-center gap-2 text-sm text-earth-600">
                   <Check className="w-4 h-4 text-green-600 flex-shrink-0" />
@@ -169,8 +169,7 @@ const PaywallModal: React.FC<PaywallModalProps> = ({ open, onOpenChange, usage, 
           </div>
           <DialogTitle className="font-display text-xl leading-tight tracking-tight">You've reached today's limit</DialogTitle>
           <DialogDescription className="text-sand-600">
-            Free accounts include 10 Trip Assistant messages per day.
-            Upgrade to Pro for unlimited access across all your trips.
+            Free accounts include 10 messages per day.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/components/trip/ai-assistant/PlaceCard.tsx
+++ b/src/components/trip/ai-assistant/PlaceCard.tsx
@@ -153,7 +153,6 @@ const PlaceCard: React.FC<PlaceCardProps> = ({ card, onAdd, compact = false }) =
               variant="default"
               asChild
               className="h-8 flex-1 min-w-[96px] text-xs"
-              title="Book on Expedia"
             >
               <a
                 href={expediaUrl}

--- a/src/components/trip/ai-assistant/PromptChips.tsx
+++ b/src/components/trip/ai-assistant/PromptChips.tsx
@@ -11,33 +11,27 @@ interface PromptChipsProps {
 
 const DEFAULT_PROMPTS: PromptChip[] = [
   {
-    id: 'optimize',
-    label: 'Optimize schedule',
-    prompt: "Can you help me optimize today's schedule to minimize travel time between activities?",
-    icon: 'calendar'
-  },
-  {
     id: 'restaurants',
     label: 'Restaurant ideas',
-    prompt: 'What are some great restaurant recommendations near my hotel for dinner tonight?',
+    prompt: 'Where should I eat near my hotel tonight?',
     icon: 'utensils'
   },
   {
     id: 'packing',
     label: 'Packing tips',
-    prompt: "What should I pack for this trip based on the destination and activities I've planned?",
+    prompt: "What should I pack based on the activities I've planned?",
     icon: 'backpack'
   },
   {
     id: 'day-trip',
     label: 'Day trip ideas',
-    prompt: 'What are some interesting day trip options from my destination that I could add to my itinerary?',
+    prompt: 'Suggest day trips I could add to this itinerary.',
     icon: 'map'
   },
   {
     id: 'transport',
     label: 'Getting around',
-    prompt: "What's the best way to get around between my planned activities? Should I use public transit, taxi, or walking?",
+    prompt: "What's the best way to get around between my activities?",
     icon: 'car'
   }
 ];

--- a/src/components/trip/ai-assistant/UsageMeter.tsx
+++ b/src/components/trip/ai-assistant/UsageMeter.tsx
@@ -108,7 +108,7 @@ const UsageMeter: React.FC<UsageMeterProps> = ({ usage, onUpgradeClick }) => {
             isExhausted ? 'text-red-600 hover:text-red-700' : 'text-amber-600 hover:text-amber-700'
           )}
         >
-          {isExhausted ? 'Upgrade' : 'Go unlimited'}
+          Upgrade
         </button>
       )}
     </div>

--- a/src/components/trip/day/CompactDayCard.tsx
+++ b/src/components/trip/day/CompactDayCard.tsx
@@ -36,7 +36,7 @@ import LayoverHintRow from './components/LayoverHintRow';
 import NowIndicator from './components/NowIndicator';
 import TimePeriodHeader from './components/TimePeriodHeader';
 import { useDayTimeline } from './components/useDayTimeline';
-import { combineDateAndTime } from './components/timeline-utils';
+import { combineDateAndTime, type TimelineRenderRow } from './components/timeline-utils';
 
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
 import DayActivityManager from './components/DayActivityManager'; // adjust if needed
@@ -182,7 +182,6 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
     allDayHotels,
     rows,
     periodGroups,
-    summary,
     isCheckInDay,
     isCheckOutDay,
     isTravelDay,
@@ -204,8 +203,72 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
   };
 
   const hasContent = rows.length > 0 || allDayHotels.length > 0;
+  // Time-of-day sections only earn their weight once a day is busy enough to
+  // need scanning. Below this, they are chrome around three rows.
+  const PERIOD_SECTION_THRESHOLD = 5;
+  const showPeriodSections = totalEvents >= PERIOD_SECTION_THRESHOLD;
 
   // Toggle period expansion
+  // One dispatcher for both layouts: below the section threshold rows render
+  // flat, above it they render inside time-of-day sections.
+  const renderRow = (row: TimelineRenderRow, i: number, rowCount: number) => {
+
+        // Check if event has passed (for today only)
+        const isItemPast = isTodayFlag && row.kind === 'item' && (() => {
+          const endTime = row.item.endTime || row.item.time;
+          if (!endTime) return false;
+          const eventEnd = combineDateAndTime(normalizedDay, endTime);
+          return eventEnd ? eventEnd < new Date() : false;
+        })();
+
+        return row.kind === 'item' ? (
+          canEdit ? (
+            <SortableTimelineRow
+              key={row.item.id}
+              item={row.item}
+              idx={i}
+              isLast={i >= rowCount - 1}
+              tripId={tripId}
+              isPast={isItemPast || false}
+              onActivityClick={onActivityClick}
+              onHotelClick={onHotelClick}
+              onTransportationClick={onTransportationClick}
+              onReservationClick={onReservationClick}
+            />
+          ) : (
+            <TimelineRow
+              key={row.item.id}
+              item={row.item}
+              idx={i}
+              isLast={i >= rowCount - 1}
+              tripId={tripId}
+              isPast={isItemPast || false}
+              onActivityClick={onActivityClick}
+              onHotelClick={onHotelClick}
+              onTransportationClick={onTransportationClick}
+              onReservationClick={onReservationClick}
+            />
+          )
+        ) : row.kind === 'grouped' ? (
+          <GroupedEventCard
+            key={row.id}
+            items={row.items}
+            groupType={row.groupType}
+            title={row.title}
+            timeRange={row.timeRange}
+            tripId={tripId}
+            onActivityClick={onActivityClick}
+            onHotelClick={onHotelClick}
+            onTransportationClick={onTransportationClick}
+            onReservationClick={onReservationClick}
+          />
+        ) : row.kind === 'now' ? (
+          <NowIndicator key="now-indicator" />
+        ) : row.kind === 'hint' ? (
+          <LayoverHintRow key={row.id} text={row.text} hintType={row.hintType} />
+        ) : null;
+  };
+
   const togglePeriod = (period: string) => {
     setExpandedPeriods(prev => {
       const next = new Set(prev);
@@ -281,7 +344,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
       <Card
         id={`day-${index}`}
         className={cn(
-          "relative overflow-hidden transition-shadow duration-200 bg-card shadow-warm-sm md:hover:shadow-warm border border-border rounded-card",
+          "relative transition-shadow duration-200 bg-card shadow-warm-sm md:hover:shadow-warm border border-border rounded-card",
           isTodayFlag && "border-primary/60 shadow-warm"
         )}
       >
@@ -293,7 +356,6 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
           isTodayFlag={isTodayFlag}
           isCheckInDay={isCheckInDay}
           isCheckOutDay={isCheckOutDay}
-          summary={summary}
           isExpanded={isExpanded}
           onToggle={() => setIsExpanded(!isExpanded)}
           dateISO={date}
@@ -311,9 +373,11 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
               animate={{ height: 'auto', opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
               transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
-              className="border-t border-border overflow-hidden"
+              className="overflow-hidden rounded-b-card border-t border-border"
             >
-              <div className="bg-background px-3 py-4 sm:px-4 sm:py-5 md:px-6 md:py-6">
+              <div className="bg-background">
+                {/* Where you're staying: pinned context strip, not a row */}
+                <AllDayHotelsSection stays={allDayHotels} onHotelClick={onHotelClick} tripId={tripId} />
                 {hasContent ? (
                   <DndContext
                     sensors={sensors}
@@ -324,26 +388,24 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                       items={sortableIds}
                       strategy={verticalListSortingStrategy}
                     >
-                      <div className="space-y-2 sm:space-y-3">
-                        <AllDayHotelsSection stays={allDayHotels} onHotelClick={onHotelClick} tripId={tripId} />
-
-                        <div className="relative space-y-3">
-                          {/* Continuous timeline line - responsive positioning */}
-                          <div className="absolute left-[12px] sm:left-[20px] top-4 bottom-0 w-px bg-border -translate-x-1/2" />
-                          {periodGroups.map((group, groupIdx) => {
+                      <div className="py-2">
+                        <div>
+                          {showPeriodSections ? periodGroups.map((group, groupIdx) => {
                             const isExpanded = isPeriodExpanded(group.period);
                             const eventCount = group.rows.filter(row => row.kind !== 'hint' && row.kind !== 'now').length;
 
                             return (
                               <div key={group.period} className="relative z-10">
                                 {/* Period Header */}
-                                <TimePeriodHeader
+                                <div className="px-3 sm:px-4">
+                                  <TimePeriodHeader
                                   label={group.label}
                                   isFirst={groupIdx === 0}
                                   isExpanded={isExpanded}
                                   onToggle={() => togglePeriod(group.period)}
                                   eventCount={eventCount}
-                                />
+                                  />
+                                </div>
 
                                 {/* Period Events */}
                                 <AnimatePresence>
@@ -353,74 +415,19 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                                       animate={{ height: 'auto', opacity: 1 }}
                                       exit={{ height: 0, opacity: 0 }}
                                       transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
-                                      className="overflow-hidden space-y-3"
+                                      className="overflow-hidden"
                                     >
-                                      {group.rows.map((row, i) => {
-                                        // Check if event has passed (for today only)
-                                        const isItemPast = isTodayFlag && row.kind === 'item' && (() => {
-                                          const endTime = row.item.endTime || row.item.time;
-                                          if (!endTime) return false;
-                                          const eventEnd = combineDateAndTime(normalizedDay, endTime);
-                                          return eventEnd ? eventEnd < new Date() : false;
-                                        })();
-
-                                        return row.kind === 'item' ? (
-                                          canEdit ? (
-                                            <SortableTimelineRow
-                                              key={row.item.id}
-                                              item={row.item}
-                                              idx={i}
-                                              isLast={i >= group.rows.length - 1}
-                                              tripId={tripId}
-                                              isPast={isItemPast || false}
-                                              onActivityClick={onActivityClick}
-                                              onHotelClick={onHotelClick}
-                                              onTransportationClick={onTransportationClick}
-                                              onReservationClick={onReservationClick}
-                                            />
-                                          ) : (
-                                            <TimelineRow
-                                              key={row.item.id}
-                                              item={row.item}
-                                              idx={i}
-                                              isLast={i >= group.rows.length - 1}
-                                              tripId={tripId}
-                                              isPast={isItemPast || false}
-                                              onActivityClick={onActivityClick}
-                                              onHotelClick={onHotelClick}
-                                              onTransportationClick={onTransportationClick}
-                                              onReservationClick={onReservationClick}
-                                            />
-                                          )
-                                        ) : row.kind === 'grouped' ? (
-                                          <GroupedEventCard
-                                            key={row.id}
-                                            items={row.items}
-                                            groupType={row.groupType}
-                                            title={row.title}
-                                            timeRange={row.timeRange}
-                                            tripId={tripId}
-                                            onActivityClick={onActivityClick}
-                                            onHotelClick={onHotelClick}
-                                            onTransportationClick={onTransportationClick}
-                                            onReservationClick={onReservationClick}
-                                          />
-                                        ) : row.kind === 'now' ? (
-                                          <NowIndicator key="now-indicator" />
-                                        ) : row.kind === 'hint' ? (
-                                          <LayoverHintRow key={row.id} text={row.text} hintType={row.hintType} />
-                                        ) : null;
-                                      })}
+                                      {group.rows.map((row, i) => renderRow(row, i, group.rows.length))}
                                     </motion.div>
                                   )}
                                 </AnimatePresence>
                               </div>
                             );
-                          })}
+                          }) : rows.map((row, i) => renderRow(row, i, rows.length))}
                         </div>
 
                         {canEdit && (
-                          <div className="hidden md:flex pt-4 border-t border-border">
+                          <div className="mt-2 hidden border-t border-border px-3 pt-3 md:flex sm:px-4">
                             <DropdownMenu>
                               <DropdownMenuTrigger asChild>
                                 <Button

--- a/src/components/trip/day/components/AllDayHotelsSection.tsx
+++ b/src/components/trip/day/components/AllDayHotelsSection.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Hotel } from 'lucide-react';
+import { Bed } from 'lucide-react';
 import { HotelStay } from '@/types/trip';
-import TravelerAvatars from '../../timeline/TravelerAvatars'; // adjust path if needed
 
 type Props = {
   stays: HotelStay[];
@@ -9,39 +8,28 @@ type Props = {
   tripId: string;
 };
 
-const AllDayHotelsSection: React.FC<Props> = ({ stays, onHotelClick, tripId }) => {
+/**
+ * Where you're sleeping is context for the whole day, not an event competing
+ * with the day's plans. It gets a pinned strip under the header instead of a
+ * timeline row: bed icon and property name only, address on hover.
+ */
+const AllDayHotelsSection: React.FC<Props> = ({ stays, onHotelClick }) => {
   if (stays.length === 0) return null;
+
   return (
-    <div className="pb-2 sm:pb-3">
-      <div className="flex items-center gap-2 mb-1.5">
-        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.16em]">All day</span>
-        <div className="flex-1 h-px bg-border" />
-      </div>
-      <div className="space-y-1">
-        {stays.map(stay => (
-          <div
-            key={`allday-${stay.stay_id}`}
-            className="flex items-center gap-3 cursor-pointer hover:bg-secondary/40 rounded-md p-2 -mx-2 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-            role="button"
-            tabIndex={0}
-            onClick={() => onHotelClick?.(stay)}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onHotelClick?.(stay); } }}
-          >
-            <Hotel className="h-3.5 w-3.5 text-earth-500 flex-shrink-0" strokeWidth={1.5} />
-            <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium text-foreground group-hover:text-primary transition-colors line-clamp-1">
-                Staying at {stay.hotel}
-              </div>
-              {stay.hotel_address && (
-                <div className="text-xs text-muted-foreground line-clamp-1 mt-0.5">{stay.hotel_address}</div>
-              )}
-            </div>
-            <div className="flex-shrink-0">
-              <TravelerAvatars tripId={tripId} eventType="accommodation" eventId={stay.stay_id} maxShow={3} />
-            </div>
-          </div>
-        ))}
-      </div>
+    <div className="divide-y divide-border border-b border-border">
+      {stays.map((stay) => (
+        <button
+          key={`allday-${stay.stay_id}`}
+          type="button"
+          title={stay.hotel_address || undefined}
+          onClick={() => onHotelClick?.(stay)}
+          className="flex h-strip w-full items-center gap-2.5 bg-secondary/50 px-3 text-left transition-colors hover:bg-secondary sm:px-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        >
+          <Bed className="h-3.5 w-3.5 shrink-0 text-earth-500" strokeWidth={1.5} />
+          <span className="min-w-0 flex-1 truncate text-ui-sm text-earth-600">{stay.hotel}</span>
+        </button>
+      ))}
     </div>
   );
 };

--- a/src/components/trip/day/components/DayHeader.tsx
+++ b/src/components/trip/day/components/DayHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Badge } from '@/components/ui/badge';
 import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { DailyForecast, WeatherData } from '@/hooks/useWeather';
 import DayWeatherBadge from '@/components/trip/timeline/DayWeatherBadge';
 
@@ -12,7 +13,6 @@ type Props = {
   isTodayFlag: boolean;
   isCheckInDay: boolean;
   isCheckOutDay: boolean;
-  summary: string;
   isExpanded: boolean;
   onToggle: () => void;
   weather?: DailyForecast;
@@ -22,6 +22,9 @@ type Props = {
   allForecasts?: DailyForecast[];
 };
 
+const chipClass =
+  'text-ui-xs px-2 py-0.5 font-medium uppercase tracking-[0.08em] shrink-0';
+
 const DayHeader: React.FC<Props> = ({
   dayTitle,
   formattedDate,
@@ -29,7 +32,6 @@ const DayHeader: React.FC<Props> = ({
   isTodayFlag,
   isCheckInDay,
   isCheckOutDay,
-  summary,
   isExpanded,
   onToggle,
   weather,
@@ -53,61 +55,62 @@ const DayHeader: React.FC<Props> = ({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full text-left p-4 sm:p-5 md:p-6 cursor-pointer hover:bg-secondary/40 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0"
+      aria-expanded={isExpanded}
+      className={cn(
+        // Sticky so the day you're reading stays named while you scroll it.
+        'sticky top-0 z-20 flex h-daybar w-full items-center gap-3 bg-card px-3 text-left sm:px-4',
+        'cursor-pointer transition-colors duration-200 hover:bg-secondary/40',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+        isExpanded ? 'rounded-t-card' : 'rounded-card',
+      )}
     >
-      <div className="flex items-start sm:items-center justify-between gap-3">
-        <div className="flex flex-col sm:flex-row sm:items-baseline gap-1.5 sm:gap-4 flex-1 min-w-0">
-          <div className="flex flex-col min-w-0">
-            <div className="text-[10px] sm:text-[11px] font-medium text-muted-foreground uppercase tracking-[0.18em] mb-1">
-              Day {index}
-            </div>
-            <span className="text-lg sm:text-xl md:text-2xl font-display font-normal text-foreground leading-tight truncate">
-              {dayTitle}
-              <span className="text-muted-foreground/80">, {formattedDate}</span>
-            </span>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
-              {(weather || (isTodayFlag && currentWeather)) && (
-                <DayWeatherBadge
-                  forecast={weather}
-                  currentWeather={currentWeather}
-                  isToday={isTodayFlag}
-                  location={weatherLocation}
-                  allForecasts={allForecasts}
-                  date={dateISO?.split('T')[0]}
-                />
-              )}
-              {daysUntil && (
-                <Badge variant="outline" className="bg-card border-border text-muted-foreground text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide">
-                  In {daysUntil} {daysUntil === 1 ? 'day' : 'days'}
-                </Badge>
-              )}
-              {isTodayFlag && (
-                <Badge className="bg-primary text-primary-foreground text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-primary">Today</Badge>
-              )}
-              {isCheckInDay && (
-                <Badge className="bg-primary/15 text-primary border-transparent text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-primary/15">Check-in</Badge>
-              )}
-              {isCheckOutDay && (
-                <Badge className="bg-muted text-muted-foreground border-transparent text-[10px] sm:text-xs px-2 py-0.5 font-medium uppercase tracking-wide hover:bg-muted">Check-out</Badge>
-              )}
-              {summary && (
-                <span className="text-[10px] sm:text-xs text-muted-foreground font-medium">{summary}</span>
-              )}
-            </div>
-        </div>
-
-        <span aria-hidden className="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors group-hover:bg-accent flex-shrink-0">
-          <motion.span
-            className="inline-flex"
-            animate={{ rotate: isExpanded ? 180 : 0 }}
-            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
-          >
-            <ChevronDown className="h-4 w-4 sm:h-5 sm:w-5" strokeWidth={1.5} />
-          </motion.span>
+      {/* Name over date, both hard left. The name is the only serif on the timeline. */}
+      <span className="flex min-w-0 shrink flex-col">
+        <span className="truncate text-ui-day font-display font-normal leading-tight text-foreground">
+          {dayTitle}
         </span>
-      </div>
+        <span className="truncate text-ui-sm leading-tight text-earth-500">
+          {formattedDate}
+        </span>
+      </span>
+
+      {/* Status chips, pushed right */}
+      <span className="ml-auto flex items-center gap-1.5 overflow-hidden sm:gap-2">
+        {(weather || (isTodayFlag && currentWeather)) && (
+          <DayWeatherBadge
+            forecast={weather}
+            currentWeather={currentWeather}
+            isToday={isTodayFlag}
+            location={weatherLocation}
+            allForecasts={allForecasts}
+            date={dateISO?.split('T')[0]}
+          />
+        )}
+        {daysUntil && (
+          <Badge variant="outline" className={cn(chipClass, 'hidden bg-card border-border text-earth-500 sm:inline-flex')}>
+            In {daysUntil} {daysUntil === 1 ? 'day' : 'days'}
+          </Badge>
+        )}
+        {isTodayFlag && (
+          <Badge className={cn(chipClass, 'bg-primary text-primary-foreground hover:bg-primary')}>Today</Badge>
+        )}
+        {isCheckInDay && (
+          <Badge className={cn(chipClass, 'hidden border-transparent bg-primary/15 text-primary hover:bg-primary/15 sm:inline-flex')}>Check-in</Badge>
+        )}
+        {isCheckOutDay && (
+          <Badge className={cn(chipClass, 'hidden border-transparent bg-muted text-earth-500 hover:bg-muted sm:inline-flex')}>Check-out</Badge>
+        )}
+      </span>
+
+      <span aria-hidden className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-earth-500">
+        <motion.span
+          className="inline-flex"
+          animate={{ rotate: isExpanded ? 180 : 0 }}
+          transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <ChevronDown className="h-5 w-5" strokeWidth={1.5} />
+        </motion.span>
+      </span>
     </button>
   );
 };

--- a/src/components/trip/day/components/DaySummaryCard.tsx
+++ b/src/components/trip/day/components/DaySummaryCard.tsx
@@ -103,13 +103,13 @@ const DaySummaryCard: React.FC<Props> = ({
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <Wallet className="h-5 w-5 text-earth-600" />
-          <h3 className="font-semibold text-earth-800 text-sm">Daily Breakdown</h3>
+          <h3 className="text-ui-base font-semibold text-foreground">Daily Breakdown</h3>
         </div>
         <div className="text-right">
-          <div className="text-2xl font-bold text-earth-900">
+          <div className="text-ui-lg font-semibold tabular-nums text-foreground">
             {formatCurrencyWithSymbol(total, displayCurrency)}
           </div>
-          <div className="text-xs text-earth-500">
+          <div className="text-ui-sm text-earth-500">
             {hasMixedCurrencies && hasRates && convertedFrom.length > 0
               ? `Includes conversions from ${[...new Set(convertedFrom)].join(', ')}`
               : 'Total spend'}
@@ -122,9 +122,9 @@ const DaySummaryCard: React.FC<Props> = ({
           <div key={cat.category} className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <cat.Icon className="h-3.5 w-3.5 text-earth-500" strokeWidth={1.5} />
-              <span className="text-xs text-earth-700">{cat.category}</span>
+              <span className="text-ui-sm text-earth-500">{cat.category}</span>
             </div>
-            <span className="text-xs font-medium text-foreground tabular-nums">
+            <span className="text-ui-sm font-medium tabular-nums text-foreground">
               {formatCurrencyWithSymbol(cat.amount, cat.currency)}
             </span>
           </div>
@@ -132,7 +132,7 @@ const DaySummaryCard: React.FC<Props> = ({
       </div>
 
       {total > 0 && (
-        <div className="flex items-center gap-1 mt-3 pt-3 border-t border-border text-xs text-earth-600">
+        <div className="flex items-center gap-1 mt-3 pt-3 border-t border-border text-ui-sm text-earth-500">
           <TrendingUp className="h-3 w-3" />
           <span>Track your spending in the Budget tab</span>
         </div>

--- a/src/components/trip/day/components/EventDetailDialog.test.tsx
+++ b/src/components/trip/day/components/EventDetailDialog.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EventDetailDialog, { EventDetail } from './EventDetailDialog';
+import type { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
+
+// Both children reach the Supabase client / Places proxy, which validate env at
+// import time. The dialog's own job is the field mapping, so stub them out.
+vi.mock('../../timeline/TravelerAvatars', () => ({ default: () => <div data-testid="travelers" /> }));
+vi.mock('./HotelPhotoThumb', () => ({ default: () => <div data-testid="photo" /> }));
+
+const renderDialog = (event: EventDetail, canEdit = true) => {
+  const onEdit = vi.fn();
+  render(
+    <EventDetailDialog
+      event={event}
+      open
+      onOpenChange={vi.fn()}
+      tripId="trip-1"
+      canEdit={canEdit}
+      onEdit={onEdit}
+    />,
+  );
+  return { onEdit };
+};
+
+const activity = {
+  id: 'a1',
+  day_id: 'd1',
+  trip_id: 'trip-1',
+  title: 'Half-day private boat',
+  description: 'Colombier Bay, snorkel stop',
+  start_time: '09:30',
+  end_time: '15:00',
+  cost: 2000,
+  currency: 'EUR',
+  order_index: 0,
+  created_at: '',
+  is_paid: true,
+  location_address: '12 Quai General de Gaulle',
+  location_phone: '+590 590 00 00 00',
+  location_rating: 4.8,
+  location_website: 'https://example.com',
+} as DayActivity;
+
+describe('EventDetailDialog', () => {
+  it('shows an activity read-only, with every populated field', () => {
+    renderDialog({ kind: 'activity', data: activity });
+
+    expect(screen.getByText('Half-day private boat')).toBeInTheDocument();
+    expect(screen.getByText('9:30 AM – 3:00 PM')).toBeInTheDocument();
+    expect(screen.getByText('12 Quai General de Gaulle')).toBeInTheDocument();
+    expect(screen.getByText('+590 590 00 00 00')).toBeInTheDocument();
+    expect(screen.getByText('Colombier Bay, snorkel stop')).toBeInTheDocument();
+    // cost carries its paid state on the same line
+    expect(screen.getByText('€2,000 · Paid')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Website/ })).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('omits fields the event does not carry', () => {
+    renderDialog({
+      kind: 'activity',
+      data: { ...activity, location_address: null, location_phone: null, cost: null, description: undefined },
+    });
+
+    expect(screen.queryByText('Address')).not.toBeInTheDocument();
+    expect(screen.queryByText('Phone')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cost')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notes')).not.toBeInTheDocument();
+    // the one it does carry survives
+    expect(screen.getByText('Time')).toBeInTheDocument();
+  });
+
+  it('routes Edit through the callback rather than editing inline', () => {
+    const { onEdit } = renderDialog({ kind: 'activity', data: activity });
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Edit/ }));
+    expect(onEdit).toHaveBeenCalledWith({ kind: 'activity', data: activity });
+  });
+
+  it('hides Edit without permission', () => {
+    renderDialog({ kind: 'activity', data: activity }, false);
+    expect(screen.queryByRole('button', { name: /Edit/ })).not.toBeInTheDocument();
+  });
+
+  it('renders a stay, including both dates and times', () => {
+    renderDialog({
+      kind: 'hotel',
+      data: {
+        stay_id: 's1',
+        trip_id: 'trip-1',
+        hotel: 'Hotel Manapany',
+        hotel_checkin_date: '2026-12-21',
+        hotel_checkout_date: '2026-12-28',
+        checkin_time: '15:00',
+        checkout_time: '11:00',
+        hotel_details: null,
+        hotel_url: null,
+        cost: 8400,
+        currency: 'USD',
+        hotel_address: 'Anse des Cayes',
+        hotel_phone: null,
+        hotel_place_id: null,
+        hotel_website: null,
+        created_at: '',
+      } as HotelStay,
+    });
+
+    expect(screen.getByText('Hotel Manapany')).toBeInTheDocument();
+    expect(screen.getByText('Mon, Dec 21 · 3:00 PM')).toBeInTheDocument();
+    expect(screen.getByText('Mon, Dec 28 · 11:00 AM')).toBeInTheDocument();
+  });
+
+  it('renders transportation with both endpoints', () => {
+    renderDialog({
+      kind: 'transportation',
+      data: {
+        id: 't1',
+        trip_id: 'trip-1',
+        type: 'flight',
+        provider: 'Air France',
+        details: null,
+        confirmation_number: 'XR7T2P',
+        start_date: '2026-12-21',
+        start_time: '06:15',
+        end_date: '2026-12-21',
+        end_time: '14:40',
+        departure_location: 'JFK',
+        arrival_location: 'SXM',
+        cost: null,
+        currency: null,
+        is_paid: false,
+        created_at: '',
+      } as Transportation,
+    });
+
+    expect(screen.getByText('JFK → SXM')).toBeInTheDocument();
+    expect(screen.getByText('Air France')).toBeInTheDocument();
+    expect(screen.getByText('XR7T2P')).toBeInTheDocument();
+    expect(screen.getByText('JFK · Mon, Dec 21 · 6:15 AM')).toBeInTheDocument();
+    expect(screen.getByText('SXM · Mon, Dec 21 · 2:40 PM')).toBeInTheDocument();
+  });
+
+  it('renders a reservation and pluralises the party correctly', () => {
+    const base = {
+      id: 'r1',
+      day_id: 'd1',
+      trip_id: 'trip-1',
+      restaurant_name: 'Bonito',
+      reservation_time: '19:30',
+      number_of_people: 1,
+      notes: null,
+      confirmation_number: null,
+      cost: null,
+      currency: null,
+      is_paid: false,
+      address: null,
+      phone_number: null,
+      place_id: null,
+      rating: null,
+      created_at: '',
+      order_index: 0,
+    } as RestaurantReservation;
+
+    const { unmount } = render(
+      <EventDetailDialog
+        event={{ kind: 'dining', data: base }}
+        open
+        onOpenChange={vi.fn()}
+        tripId="trip-1"
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('1 guest')).toBeInTheDocument();
+    unmount();
+
+    renderDialog({ kind: 'dining', data: { ...base, number_of_people: 4 } });
+    expect(screen.getByText('4 guests')).toBeInTheDocument();
+  });
+});

--- a/src/components/trip/day/components/EventDetailDialog.tsx
+++ b/src/components/trip/day/components/EventDetailDialog.tsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import { ExternalLink, Star as StarIcon, Pencil } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
+import { formatTransportationType } from '@/utils/transportationUtils';
+import TravelerAvatars from '../../timeline/TravelerAvatars';
+import HotelPhotoThumb from './HotelPhotoThumb';
+import type { TimelineRowData } from './timeline-utils';
+import {
+  formatCostCompact,
+  formatTime12,
+  getEventCategory,
+  getTimelineIcon,
+  CATEGORY_ICON_CLASS,
+} from './timeline-utils';
+
+/** The four things a day can hold, tagged so one dialog can read all of them. */
+export type EventDetail =
+  | { kind: 'activity'; data: DayActivity }
+  | { kind: 'hotel'; data: HotelStay }
+  | { kind: 'transportation'; data: Transportation }
+  | { kind: 'dining'; data: RestaurantReservation };
+
+type Props = {
+  event: EventDetail | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tripId: string;
+  canEdit?: boolean;
+  onEdit: (event: EventDetail) => void;
+};
+
+type Fact = { label: string; value: React.ReactNode };
+type Link = { label: string; href: string };
+
+/** Dates are floating wall-clock, so build them locally rather than via Date.parse. */
+const formatDateLong = (iso?: string | null): string => {
+  if (!iso) return '';
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return '';
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }).format(d);
+};
+
+const joinParts = (...parts: (string | null | undefined)[]): string =>
+  parts.filter(Boolean).join(' · ');
+
+const money = (
+  cost: number | null | undefined,
+  currency: string | null | undefined,
+  isPaid?: boolean,
+): string => {
+  if (typeof cost !== 'number') return '';
+  return joinParts(formatCostCompact(cost, currency || 'USD'), isPaid ? 'Paid' : undefined);
+};
+
+const timeSpan = (start?: string | null, end?: string | null): string => {
+  const s = formatTime12(start || undefined);
+  const e = formatTime12(end || undefined);
+  if (s && e) return `${s} – ${e}`;
+  return s || e || '';
+};
+
+const rating = (value?: number | null): React.ReactNode =>
+  typeof value === 'number' ? (
+    <span className="inline-flex items-center gap-1 tabular-nums">
+      <StarIcon className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+      {value}
+    </span>
+  ) : null;
+
+/** Per-type field mapping. Empty values are dropped, so a sparse event stays short. */
+const buildFacts = (event: EventDetail): { facts: Fact[]; notes?: string | null; links: Link[] } => {
+  const links: Link[] = [];
+
+  if (event.kind === 'activity') {
+    const a = event.data;
+    if (a.location_website) links.push({ label: 'Website', href: a.location_website });
+    return {
+      facts: [
+        { label: 'Time', value: timeSpan(a.start_time, a.end_time) },
+        { label: 'Address', value: a.location_address },
+        { label: 'Phone', value: a.location_phone },
+        { label: 'Rating', value: rating(a.location_rating) },
+        { label: 'Cost', value: money(a.cost, a.currency, a.is_paid) },
+        { label: 'Time zone', value: a.timezone },
+      ],
+      notes: a.description,
+      links,
+    };
+  }
+
+  if (event.kind === 'hotel') {
+    const h = event.data;
+    if (h.hotel_website) links.push({ label: 'Website', href: h.hotel_website });
+    if (h.hotel_url && h.hotel_url !== h.hotel_website) {
+      links.push({ label: 'Booking', href: h.hotel_url });
+    }
+    return {
+      facts: [
+        {
+          label: 'Check in',
+          value: joinParts(formatDateLong(h.hotel_checkin_date), formatTime12(h.checkin_time)),
+        },
+        {
+          label: 'Check out',
+          value: joinParts(formatDateLong(h.hotel_checkout_date), formatTime12(h.checkout_time)),
+        },
+        { label: 'Address', value: h.hotel_address },
+        { label: 'Phone', value: h.hotel_phone },
+        { label: 'Cost', value: money(h.cost, h.currency) },
+        { label: 'Time zone', value: h.timezone },
+      ],
+      notes: h.hotel_details,
+      links,
+    };
+  }
+
+  if (event.kind === 'transportation') {
+    const t = event.data;
+    return {
+      facts: [
+        { label: 'Type', value: formatTransportationType(t.type) },
+        { label: 'Provider', value: t.provider },
+        { label: 'Confirmation', value: t.confirmation_number },
+        {
+          label: 'Departs',
+          value: joinParts(
+            t.departure_location,
+            formatDateLong(t.start_date),
+            formatTime12(t.start_time || undefined),
+            t.departure_timezone,
+          ),
+        },
+        {
+          label: 'Arrives',
+          value: joinParts(
+            t.arrival_location,
+            formatDateLong(t.end_date),
+            formatTime12(t.end_time || undefined),
+            t.arrival_timezone,
+          ),
+        },
+        { label: 'Cost', value: money(t.cost, t.currency, t.is_paid) },
+      ],
+      notes: t.details,
+      links,
+    };
+  }
+
+  const r = event.data;
+  return {
+    facts: [
+      { label: 'Time', value: formatTime12(r.reservation_time || undefined) },
+      {
+        label: 'Party',
+        value: r.number_of_people
+          ? `${r.number_of_people} ${r.number_of_people === 1 ? 'guest' : 'guests'}`
+          : null,
+      },
+      { label: 'Address', value: r.address },
+      { label: 'Phone', value: r.phone_number },
+      { label: 'Rating', value: rating(r.rating) },
+      { label: 'Confirmation', value: r.confirmation_number },
+      { label: 'Cost', value: money(r.cost, r.currency, r.is_paid) },
+      { label: 'Time zone', value: r.timezone },
+    ],
+    notes: r.notes,
+    links,
+  };
+};
+
+const describe = (event: EventDetail): { title: string; typeLabel: string; placeId?: string | null } => {
+  switch (event.kind) {
+    case 'activity':
+      return { title: event.data.title, typeLabel: 'Activity', placeId: event.data.location_place_id };
+    case 'hotel':
+      return { title: event.data.hotel, typeLabel: 'Stay', placeId: event.data.hotel_place_id };
+    case 'transportation':
+      return {
+        title:
+          [event.data.departure_location, event.data.arrival_location].filter(Boolean).join(' → ') ||
+          formatTransportationType(event.data.type),
+        typeLabel: formatTransportationType(event.data.type),
+      };
+    case 'dining':
+      return { title: event.data.restaurant_name, typeLabel: 'Dining', placeId: event.data.place_id };
+  }
+};
+
+/** eventId/eventType the travelers junction tables are keyed on. */
+type TravelerEventType = 'accommodation' | 'transportation' | 'activity' | 'dining';
+
+const travelerTarget = (event: EventDetail): { eventType: TravelerEventType; eventId: string } =>
+  event.kind === 'hotel'
+    ? { eventType: 'accommodation', eventId: event.data.stay_id }
+    : { eventType: event.kind, eventId: event.data.id };
+
+const EventDetailDialog: React.FC<Props> = ({
+  event,
+  open,
+  onOpenChange,
+  tripId,
+  canEdit = true,
+  onEdit,
+}) => {
+  if (!event) return null;
+
+  const { title, typeLabel, placeId } = describe(event);
+  const { facts, notes, links } = buildFacts(event);
+  const shown = facts.filter((f) => f.value !== null && f.value !== undefined && f.value !== '');
+  const iconItem = { type: event.kind, title, data: event.data as unknown as TimelineRowData };
+  const category = getEventCategory(iconItem);
+  const Icon = getTimelineIcon(iconItem) as React.ComponentType<{
+    className?: string;
+    strokeWidth?: number;
+  }>;
+  const { eventType, eventId } = travelerTarget(event);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex items-start gap-3 pr-6 text-left">
+            <div className={cn('mt-0.5 shrink-0', CATEGORY_ICON_CLASS[category])}>
+              <Icon className="h-5 w-5" strokeWidth={1.5} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-ui-sm text-earth-500">{typeLabel}</div>
+              <DialogTitle className="font-display text-xl leading-tight tracking-tight">
+                {title}
+              </DialogTitle>
+            </div>
+            {placeId && (
+              <div className="hidden shrink-0 sm:block">
+                <HotelPhotoThumb placeId={placeId} title={title} size="md" />
+              </div>
+            )}
+          </div>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] overflow-y-auto">
+          {shown.length > 0 && (
+            <dl className="divide-y divide-border">
+              {shown.map((f) => (
+                <div key={f.label} className="grid grid-cols-[6.5rem_1fr] gap-3 py-2.5">
+                  <dt className="text-ui-sm text-earth-500">{f.label}</dt>
+                  <dd className="min-w-0 break-words text-ui-base text-foreground">{f.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          {notes && (
+            <div className="mt-4">
+              <div className="text-ui-sm text-earth-500">Notes</div>
+              <p className="mt-1 whitespace-pre-line text-ui-base leading-relaxed text-foreground">
+                {notes}
+              </p>
+            </div>
+          )}
+
+          {links.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-4">
+              {links.map((l) => (
+                <a
+                  key={l.href}
+                  href={l.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-ui-base font-medium text-primary transition-colors hover:text-primary/80"
+                >
+                  {l.label}
+                  <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
+                </a>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-4 flex items-center gap-3">
+            <div className="text-ui-sm text-earth-500">Travelers</div>
+            <TravelerAvatars tripId={tripId} eventType={eventType} eventId={eventId} maxShow={6} />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          {canEdit && (
+            <Button onClick={() => onEdit(event)}>
+              <Pencil className="mr-1.5 h-4 w-4" strokeWidth={1.75} />
+              Edit
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EventDetailDialog;

--- a/src/components/trip/day/components/GroupedEventCard.tsx
+++ b/src/components/trip/day/components/GroupedEventCard.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import React, { useId, useState } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
-import { TimelineItem, TimelineType, formatTimeRange, getEventIconComponent } from './timeline-utils';
+import { TimelineItem, TimelineType, formatTimeCompact, getEventCategory, getTimelineIcon, CATEGORY_ICON_CLASS, CATEGORY_ROW_CLASS } from './timeline-utils';
+import { cn } from '@/lib/utils';
 import TravelerAvatars from '../../timeline/TravelerAvatars';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 
 type Props = {
   items: TimelineItem[];
@@ -29,8 +30,11 @@ const GroupedEventCard: React.FC<Props> = ({
   onReservationClick,
 }) => {
   const [isExpanded, setIsExpanded] = useState(true);
+  const panelId = useId();
+  const titleId = useId();
+  const prefersReducedMotion = useReducedMotion();
 
-  const handleEventClick = (item: typeof items[0]) => {
+  const handleEventClick = (item: TimelineItem) => {
     if (item.type === 'activity' && onActivityClick && item.data) {
       onActivityClick(item.data);
     } else if (item.type === 'hotel' && onHotelClick && item.data) {
@@ -43,131 +47,117 @@ const GroupedEventCard: React.FC<Props> = ({
   };
 
   const firstItem = items[0];
-
-  // Get icon component based on event type
-  const IconComponent = getEventIconComponent(groupType, firstItem?.data?.type) as React.ComponentType<{ className?: string; size?: number | string }>;
+  const category = firstItem ? getEventCategory(firstItem) : 'sage';
+  const IconComponent = (firstItem ? getTimelineIcon(firstItem) : getTimelineIcon({ type: groupType, title: '' })) as React.ComponentType<{ className?: string; strokeWidth?: number }>;
 
   return (
-    <div className="pb-3 sm:pb-4">
-      {/* Unified Layout: Rail + Content */}
-      <div className="grid grid-cols-[24px_1fr] sm:grid-cols-[40px_1fr] gap-2 sm:gap-3">
-        {/* Column 1: Timeline Rail - Node */}
-        <div className="relative flex flex-col items-center">
-          <div className="relative w-3 h-3 rounded-full flex-shrink-0 mt-1 bg-card border-2 border-sand-500 z-10" />
+    <div>
+      {/* Group header row — same geometry as a plain event row */}
+      <div
+        className={cn(
+          'group/row tl-row min-h-row cursor-pointer select-none transition-colors duration-150',
+          CATEGORY_ROW_CLASS[category],
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+        )}
+        role="button"
+        aria-expanded={isExpanded}
+        aria-controls={panelId}
+        tabIndex={0}
+        onClick={() => setIsExpanded(!isExpanded)}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setIsExpanded(!isExpanded); } }}
+      >
+        {/* Gutter weight marks a top-level moment in the day, same as a plain row. */}
+        <div className="py-3 text-right">
+          {formatTimeCompact(firstItem?.time) && (
+            <div className="text-ui-base font-medium tabular-nums text-earth-600 leading-5">
+              {formatTimeCompact(firstItem?.time)}
+            </div>
+          )}
         </div>
 
-        {/* Column 2: Time Label + Grouped Card */}
-        <div className="flex flex-col gap-1.5 min-w-0">
-          {/* Time Range Label */}
-          {timeRange && (
-            <span className="text-[11px] sm:text-xs font-medium text-muted-foreground uppercase tracking-[0.12em] leading-none">
-              {timeRange}
-            </span>
-          )}
+        {/* Rail: hollow node, because this one contains other nodes. */}
+        <div aria-hidden className="relative flex justify-center">
+          <div className="absolute inset-y-0 w-px bg-border" />
+          <div className="relative mt-[1.0625rem] h-2.5 w-2.5 shrink-0 rounded-full border-2 border-earth-400 bg-background ring-4 ring-background" />
+        </div>
 
-          {/* Grouped Event Row */}
-          <div className="relative flex-1 min-w-0">
-            <div
-              className="-mx-2 px-2 py-1.5 sm:py-2 cursor-pointer rounded-md hover:bg-secondary/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-              role="button"
-              tabIndex={0}
-              onClick={() => setIsExpanded(!isExpanded)}
-              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setIsExpanded(!isExpanded); } }}
-            >
-              {/* Main Content: Icon + Title */}
-              <div className="flex items-start gap-3">
-                {/* Icon */}
-                <div className="flex-shrink-0 mt-0.5 text-earth-600">
-                  <IconComponent className="h-5 w-5" strokeWidth={1.5} />
-                </div>
-
-                {/* Text Content */}
-                <div className="flex-1 min-w-0">
-                  {/* Group Title */}
-                  <div className="text-base font-display font-normal text-foreground leading-snug">
-                    {title}
-                  </div>
-
-                  {/* Count */}
-                  <div className="text-xs text-muted-foreground mt-1">
-                    {items.length} {groupType === 'transportation' ? 'flights' : 'events'}
-                  </div>
-                </div>
-
-                {/* Expand/Collapse Icon */}
-                <div className="flex-shrink-0 ml-2 text-muted-foreground">
-                  {isExpanded ? (
-                    <ChevronDown className="h-4 w-4" strokeWidth={1.5} />
-                  ) : (
-                    <ChevronRight className="h-4 w-4" strokeWidth={1.5} />
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Expanded Individual Events */}
-            <AnimatePresence>
-              {isExpanded && (
-                <motion.div
-                  initial={{ height: 0, opacity: 0 }}
-                  animate={{ height: 'auto', opacity: 1 }}
-                  exit={{ height: 0, opacity: 0 }}
-                  transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
-                  className="overflow-hidden mt-2"
-                >
-                  <div className="space-y-1 pl-4 border-l border-border">
-                    {items.map((item) => (
-                      <div key={item.id} className="relative">
-                        {/* Individual event row - typographic */}
-                        <div
-                          className="-mx-2 px-2 py-1.5 cursor-pointer rounded-md hover:bg-secondary/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                          role="button"
-                          tabIndex={0}
-                          onClick={(e) => { e.stopPropagation(); handleEventClick(item); }}
-                          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); handleEventClick(item); } }}
-                        >
-                          <div>
-                            {/* Time range on one row */}
-                            {item.time && (
-                              <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.12em] mb-1">
-                                {formatTimeRange(item.time, item.endTime, item.type === 'transportation')}
-                              </div>
-                            )}
-
-                            {/* Title + Avatars */}
-                            <div className="flex items-start gap-3">
-                              <div className="flex-1 min-w-0">
-                                <div className="text-sm font-medium text-foreground line-clamp-1">
-                                  {item.title}
-                                </div>
-                                {item.description && (
-                                  <div className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-                                    {item.description}
-                                  </div>
-                                )}
-                              </div>
-
-                              {/* Traveler Avatars */}
-                              <div className="flex-shrink-0">
-                                <TravelerAvatars
-                                  tripId={tripId}
-                                  eventType={item.type === 'hotel' ? 'accommodation' : item.type}
-                                  eventId={item.type === 'hotel' ? item.data?.stay_id : item.id}
-                                  maxShow={3}
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </motion.div>
+        <div className="flex min-w-0 items-start gap-3 py-3 pr-1">
+          <div className={cn('mt-0.5 shrink-0', CATEGORY_ICON_CLASS[category])}>
+            <IconComponent className="h-5 w-5" strokeWidth={1.5} />
+          </div>
+          <div className="min-w-0 flex-1">
+            {/* The title already leads with the count ("2 flights into SXM"), so it
+                carries the "there is more folded up here" cue on its own. */}
+            <div id={titleId} className="text-ui-md font-medium text-foreground line-clamp-1">{title}</div>
+            {timeRange && (
+              <div className="mt-0.5 text-ui-sm tabular-nums text-earth-500 line-clamp-1">{timeRange}</div>
+            )}
+          </div>
+          {/* One chevron that rotates: the movement is the affordance. */}
+          <div
+            aria-hidden
+            className="-mr-1 mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-full text-earth-500 transition-colors duration-150 group-hover/row:bg-earth-100/70 group-hover/row:text-earth-700"
+          >
+            <ChevronRight
+              className={cn(
+                'h-4 w-4 transition-transform duration-200 ease-out motion-reduce:transition-none',
+                isExpanded && 'rotate-90',
               )}
-            </AnimatePresence>
+              strokeWidth={1.75}
+            />
           </div>
         </div>
       </div>
+
+      {/* Expanded children — text indented to sit under the parent title, not under its icon */}
+      <AnimatePresence initial={false}>
+        {isExpanded && (
+          <motion.div
+            id={panelId}
+            role="group"
+            aria-labelledby={titleId}
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+            className="overflow-hidden"
+          >
+            {items.map((item) => (
+              <div key={item.id} className="tl-row">
+                <div className="py-2 text-right text-ui-sm tabular-nums leading-5 text-earth-500">
+                  {formatTimeCompact(item.time)}
+                </div>
+                <div aria-hidden className="relative flex justify-center">
+                  <div className="absolute inset-y-0 w-px bg-border" />
+                  <div className="relative mt-[0.9375rem] h-1.5 w-1.5 shrink-0 rounded-full bg-earth-300 ring-4 ring-background" />
+                </div>
+                <div
+                  className="flex min-w-0 items-center gap-3 py-2 pl-8 pr-1 cursor-pointer transition-colors duration-150 hover:bg-secondary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                  role="button"
+                  tabIndex={0}
+                  onClick={(e) => { e.stopPropagation(); handleEventClick(item); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); handleEventClick(item); } }}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-ui-base font-medium text-foreground line-clamp-1">{item.title}</div>
+                    {item.description && (
+                      <div className="text-ui-sm text-earth-500 line-clamp-1">{item.description}</div>
+                    )}
+                  </div>
+                  <div className="shrink-0">
+                    <TravelerAvatars
+                      tripId={tripId}
+                      eventType={item.type === 'hotel' ? 'accommodation' : item.type}
+                      eventId={item.type === 'hotel' ? (item.data?.stay_id as string) : item.id}
+                      maxShow={3}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/components/trip/day/components/LayoverHintRow.tsx
+++ b/src/components/trip/day/components/LayoverHintRow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Plane, Clock, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { HintType } from './timeline-utils';
 
@@ -8,46 +7,29 @@ type Props = {
   hintType?: HintType;
 };
 
+/**
+ * A gap in the day. Deliberately not a card: a dashed segment of the rail plus
+ * one line of text, so empty time reads as absence rather than as another
+ * event competing for attention.
+ */
 const LayoverHintRow: React.FC<Props> = ({ text, hintType = 'layover' }) => {
-  const config = {
-    layover: {
-      icon: Plane,
-      bg: 'bg-accent/40',
-      border: 'border-border',
-      iconColor: 'text-earth-500',
-      textColor: 'text-earth-600',
-      dotColor: 'bg-sand-400',
-    },
-    'free-time': {
-      icon: Clock,
-      bg: 'bg-secondary/50',
-      border: 'border-border',
-      iconColor: 'text-earth-400',
-      textColor: 'text-muted-foreground',
-      dotColor: 'bg-sand-300',
-    },
-    overlap: {
-      icon: AlertTriangle,
-      bg: 'bg-destructive/10',
-      border: 'border-destructive/30',
-      iconColor: 'text-destructive',
-      textColor: 'text-destructive',
-      dotColor: 'bg-destructive/60',
-    },
-  }[hintType];
-
-  const Icon = config.icon;
+  const isOverlap = hintType === 'overlap';
 
   return (
-    <div className="pb-2 sm:pb-3">
-      <div className="grid grid-cols-[24px_1fr] sm:grid-cols-[40px_1fr] gap-2 sm:gap-3">
-        <div className="relative flex flex-col items-center">
-          <div className={cn("w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full flex-shrink-0 mt-2.5 z-10", config.dotColor)} />
-        </div>
-        <div className={cn("flex items-center gap-2 px-3 py-2 rounded-md border", config.bg, config.border)}>
-          <Icon className={cn("h-3.5 w-3.5 flex-shrink-0", config.iconColor)} strokeWidth={1.5} />
-          <span className={cn("text-xs", config.textColor)}>{text}</span>
-        </div>
+    <div className="tl-row">
+      <div />
+      <div aria-hidden className="relative flex justify-center">
+        <div
+          className={cn(
+            'absolute inset-y-0 w-px border-l border-dashed',
+            isOverlap ? 'border-destructive/50' : 'border-border',
+          )}
+        />
+      </div>
+      <div className="py-2">
+        <span className={cn('text-ui-sm tabular-nums', isOverlap ? 'text-destructive' : 'text-earth-500')}>
+          {text}
+        </span>
       </div>
     </div>
   );

--- a/src/components/trip/day/components/NowIndicator.tsx
+++ b/src/components/trip/day/components/NowIndicator.tsx
@@ -1,21 +1,23 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 
 const NowIndicator: React.FC = () => {
   const [now, setNow] = useState(new Date());
-  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Align to the next minute boundary
-    const msToNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+    // Align to the next minute boundary, then tick every 60s.
+    let interval: ReturnType<typeof setInterval>;
+    const start = new Date();
+    const msToNextMinute = (60 - start.getSeconds()) * 1000 - start.getMilliseconds();
     const timeout = setTimeout(() => {
       setNow(new Date());
-      // Then update every 60s
-      const interval = setInterval(() => setNow(new Date()), 60000);
-      return () => clearInterval(interval);
+      interval = setInterval(() => setNow(new Date()), 60000);
     }, msToNextMinute);
 
-    return () => clearTimeout(timeout);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    return () => {
+      clearTimeout(timeout);
+      if (interval) clearInterval(interval);
+    };
+  }, []);
 
   const timeStr = now.toLocaleTimeString('en-US', {
     hour: 'numeric',
@@ -24,18 +26,16 @@ const NowIndicator: React.FC = () => {
   });
 
   return (
-    <div ref={ref} className="relative py-1">
-      <div className="grid grid-cols-[24px_1fr] sm:grid-cols-[40px_1fr] gap-2 sm:gap-3 items-center">
-        <div className="flex justify-center">
-          <div className="w-2.5 h-2.5 rounded-full bg-destructive z-10 sm:w-3 sm:h-3 sm:ring-2 sm:ring-destructive/25" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="flex-1 h-px bg-destructive/70" />
-          <span className="text-[10px] font-semibold text-destructive whitespace-nowrap uppercase tracking-[0.16em]">
-            Now · {timeStr}
-          </span>
-          <div className="flex-1 h-px bg-destructive/70" />
-        </div>
+    <div className="tl-row">
+      <div className="py-1 text-right text-ui-xs font-semibold tabular-nums leading-5 text-destructive">
+        {timeStr}
+      </div>
+      <div aria-hidden className="relative flex justify-center">
+        <div className="absolute inset-y-0 w-px bg-border" />
+        <div className="relative mt-2 h-2 w-2 shrink-0 rounded-full bg-destructive ring-4 ring-background" />
+      </div>
+      <div className="flex items-center py-1">
+        <div className="h-px flex-1 bg-destructive/70" />
       </div>
     </div>
   );

--- a/src/components/trip/day/components/SortableTimelineRow.tsx
+++ b/src/components/trip/day/components/SortableTimelineRow.tsx
@@ -68,7 +68,7 @@ const SortableTimelineRow: React.FC<Props> = (props) => {
         {...(isCoarsePointer ? {} : listeners)}
         aria-label={`Reorder ${props.item.title}`}
         className={cn(
-          "absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1 z-20 p-1 rounded cursor-grab active:cursor-grabbing",
+          "absolute left-0 top-1/2 -translate-y-1/2 z-20 p-0.5 rounded cursor-grab active:cursor-grabbing",
           "hidden sm:block sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 transition-opacity",
           "text-earth-400 hover:text-earth-600"
         )}

--- a/src/components/trip/day/components/TimePeriodHeader.tsx
+++ b/src/components/trip/day/components/TimePeriodHeader.tsx
@@ -30,12 +30,12 @@ const TimePeriodHeader: React.FC<Props> = ({ label, isFirst = false, isExpanded,
       </div>
 
       {/* Period Label */}
-      <h4 className="text-[11px] sm:text-xs font-medium text-foreground uppercase tracking-[0.16em] group-hover:text-primary transition-colors">
+      <h4 className="text-ui-xs font-medium text-earth-600 uppercase tracking-[0.1em] group-hover:text-primary transition-colors">
         {label}
       </h4>
 
       {/* Event Count */}
-      <span className="flex-shrink-0 text-[11px] text-muted-foreground tabular-nums">
+      <span className="flex-shrink-0 text-ui-xs tabular-nums text-earth-500">
         {eventCount}
       </span>
 

--- a/src/components/trip/day/components/TimelineRow.tsx
+++ b/src/components/trip/day/components/TimelineRow.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { ExternalLink, MapPin, Phone, Clock, ShieldCheck, Star as StarIcon } from 'lucide-react';
+import { ExternalLink, Star as StarIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DayActivity, HotelStay, Transportation, RestaurantReservation } from '@/types/trip';
 import HotelPhotoThumb from './HotelPhotoThumb';
-import { formatCurrencyWithSymbol } from '../../budget/utils/budgetCalculations';
 import TravelerAvatars from '../../timeline/TravelerAvatars';
-import { TimelineItem, TimelineType, formatTimeRange, getEventIconComponent, parseTimeToHM } from './timeline-utils';
+import {
+  TimelineItem,
+  formatTimeCompact,
+  getEventCategory,
+  getTimelineIcon,
+  CATEGORY_ICON_CLASS,
+  CATEGORY_ROW_CLASS,
+  parseTimeToHM,
+} from './timeline-utils';
 
 type Props = {
   item: TimelineItem;
@@ -34,87 +41,39 @@ const computeDuration = (startTime?: string, endTime?: string): string | null =>
   return `${m}m`;
 };
 
-/** Type-specific metadata badges rendered between description and footer */
-const EventMetadata: React.FC<{ item: TimelineItem }> = ({ item }) => {
-  const badges: React.ReactNode[] = [];
+/**
+ * The single meta line under the title. Everything that used to be its own
+ * badge row collapses into one clamped sentence joined by middots, so every
+ * row is exactly two lines tall regardless of how much metadata it carries.
+ */
+const buildMetaParts = (item: TimelineItem): string[] => {
+  const parts: string[] = [];
+  if (item.description) parts.push(item.description);
 
-  if (item.type === 'dining') {
-    if (item.data?.address) {
-      badges.push(
-        <div key="address" className="flex items-center gap-1 text-xs text-earth-500">
-          <MapPin className="h-3 w-3 flex-shrink-0" />
-          <span className="line-clamp-1">{item.data.address}</span>
-        </div>
-      );
-    }
-    if (item.data?.rating) {
-      badges.push(
-        <div key="rating" className="flex items-center gap-1 text-xs text-amber-600">
-          <StarIcon className="h-3 w-3 flex-shrink-0 fill-amber-400 text-amber-400" />
-          <span>{item.data.rating}</span>
-        </div>
-      );
-    }
-  }
-
-  if (item.type === 'activity') {
-    const duration = computeDuration(item.data?.start_time, item.data?.end_time);
-    if (duration) {
-      badges.push(
-        <div key="duration" className="flex items-center gap-1 text-xs text-earth-500">
-          <Clock className="h-3 w-3 flex-shrink-0" />
-          <span>{duration}</span>
-        </div>
-      );
-    }
-  }
-
+  if (item.type === 'dining' && item.data?.address) parts.push(String(item.data.address));
+  if (item.type === 'hotel' && item.data?.hotel_phone) parts.push(String(item.data.hotel_phone));
   if (item.type === 'transportation') {
-    if (item.data?.confirmation_number) {
-      badges.push(
-        <div key="confirmation" className="flex items-center gap-1 text-xs text-earth-500">
-          <ShieldCheck className="h-3 w-3 flex-shrink-0" />
-          <span className="font-sans tabular-nums tracking-wide">{item.data.confirmation_number}</span>
-        </div>
-      );
-    }
-    if (item.data?.provider) {
-      badges.push(
-        <div key="provider" className="text-xs text-earth-500">
-          {item.data.provider}
-        </div>
-      );
-    }
+    if (item.data?.provider) parts.push(String(item.data.provider));
+    if (item.data?.confirmation_number) parts.push(String(item.data.confirmation_number));
   }
 
-  if (item.type === 'hotel') {
-    if (item.data?.hotel_phone) {
-      badges.push(
-        <div key="phone" className="flex items-center gap-1 text-xs text-earth-500">
-          <Phone className="h-3 w-3 flex-shrink-0" />
-          <span>{item.data.hotel_phone}</span>
-        </div>
-      );
-    }
-  }
-
-  if (badges.length === 0) return null;
-
-  return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
-      {badges}
-    </div>
+  const duration = computeDuration(
+    item.time,
+    item.endTime || (item.data?.__arrive_time_on_this_day as string | undefined),
   );
+  if (duration) parts.push(duration);
+
+  return parts;
 };
 
 /** Build footer links for any event type */
 const getFooterLink = (item: TimelineItem): { href: string; label: string } | null => {
   if (item.type === 'hotel') {
     const url = item.data?.hotel_website || item.data?.hotel_url;
-    if (url) return { href: url, label: 'Hotel Website' };
+    if (url) return { href: String(url), label: 'Hotel Website' };
   }
   if (item.type === 'dining' && item.data?.website) {
-    return { href: item.data.website, label: 'Website' };
+    return { href: String(item.data.website), label: 'Website' };
   }
   return null;
 };
@@ -131,117 +90,120 @@ const TimelineRow: React.FC<Props> = ({
   };
 
   const footerLink = getFooterLink(item);
-  const hasFooter = !!(item.data?.cost || footerLink);
-
-  // Build the time label
-  const timeLabel = item.time
-    ? formatTimeRange(item.time, item.endTime, item.type === 'transportation', item.tzSuffix ?? '', item.endTzSuffix ?? '')
-    : '';
+  const metaParts = buildMetaParts(item);
+  const startLabel = formatTimeCompact(item.time);
+  const endLabel = formatTimeCompact(
+    item.endTime || (item.data?.__arrive_time_on_this_day as string | undefined),
+  );
+  const category = getEventCategory(item);
+  const Icon = getTimelineIcon(item) as React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  const placeId =
+    (item.type === 'hotel' && item.data?.hotel_place_id) ||
+    (item.type === 'activity' && item.data?.location_place_id) ||
+    (item.type === 'dining' && item.data?.place_id) ||
+    null;
 
   return (
-    <div className={cn("pb-3 sm:pb-4 last:pb-0", isPast && "opacity-50")}>
-      {/* Unified Layout: Rail + Content */}
-      <div className="grid grid-cols-[24px_1fr] sm:grid-cols-[40px_1fr] gap-2 sm:gap-3">
-        {/* Column 1: Timeline Rail - Node */}
-        <div className="relative flex flex-col items-center">
-          <div className="relative w-3 h-3 rounded-full flex-shrink-0 mt-1 bg-card border-2 border-sand-500 z-10" />
+    <div
+      className={cn(
+        // The rail lives inside the row, so consecutive rows draw one
+        // continuous line with no global offset to keep in sync.
+        'group/row tl-row min-h-row cursor-pointer transition-colors duration-150',
+        CATEGORY_ROW_CLASS[category],
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+        'touch-manipulation',
+        isPast && 'opacity-50',
+      )}
+      role="button"
+      tabIndex={0}
+      onClick={handleItemClick}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleItemClick(); } }}
+    >
+      {/* Gutter: start stacked over finish, right-aligned, tabular so digits stack.
+          Weight carries the pair: bold start, quiet finish. */}
+      <div className="py-3 text-right">
+        {startLabel && (
+          <>
+            <div className="text-ui-base font-medium tabular-nums text-earth-600 leading-5">
+              <span className="sr-only">Starts </span>
+              {startLabel}
+            </div>
+            {item.tzSuffix && (
+              <div className="text-ui-xs tabular-nums text-earth-500 leading-4">{item.tzSuffix}</div>
+            )}
+            {endLabel ? (
+              <div className="text-ui-base tabular-nums text-earth-500 leading-5">
+                <span className="sr-only">Ends </span>
+                {endLabel}
+              </div>
+            ) : (
+              <div className="text-ui-base text-earth-400 leading-5">
+                <span className="sr-only">End time </span>tbd
+              </div>
+            )}
+            {endLabel && item.endTzSuffix && (
+              <div className="text-ui-xs tabular-nums text-earth-500 leading-4">{item.endTzSuffix}</div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Rail: continuous hairline with a filled node */}
+      <div aria-hidden className="relative flex justify-center">
+        <div className="absolute inset-y-0 w-px bg-border" />
+        <div className="relative mt-[1.125rem] h-2 w-2 shrink-0 rounded-full bg-earth-400 ring-4 ring-background" />
+      </div>
+
+      {/* Content */}
+      <div className="flex min-w-0 items-start gap-3 py-3 pr-1">
+        <div className={cn('mt-0.5 shrink-0', CATEGORY_ICON_CLASS[category])}>
+          <Icon className="h-5 w-5" strokeWidth={1.5} />
         </div>
 
-        {/* Column 2: Time Label + Event Card */}
-        <div className="flex flex-col gap-1.5 min-w-0">
-          {/* Time Range Label */}
-          {timeLabel && (
-            <span className="text-[11px] sm:text-xs font-medium text-muted-foreground uppercase tracking-[0.12em] leading-none">
-              {timeLabel}
-            </span>
-          )}
+        <div className="min-w-0 flex-1">
+          <div className="text-ui-md font-medium text-foreground line-clamp-1">
+            {item.title}
+          </div>
 
-          {/* Event Row */}
-          <div
-            className="group/row relative flex-1 min-w-0 -mx-2 px-2 py-1.5 sm:py-2 cursor-pointer rounded-md hover:bg-secondary/40 active:bg-secondary/60 touch-manipulation transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-            role="button"
-            tabIndex={0}
-            onClick={handleItemClick}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleItemClick(); } }}
-          >
-            {/* Top-right: Avatar Stack */}
-            <div className="absolute top-1.5 right-2 sm:top-2 sm:right-2">
+          {/* Meta row: one clamped line, avatars pinned right */}
+          <div className="mt-0.5 flex items-center gap-3">
+            <div className="min-w-0 flex-1 text-ui-sm text-earth-500 line-clamp-1">
+              {metaParts.join(' · ')}
+              {item.type === 'dining' && item.data?.rating ? (
+                <span className="ml-2 inline-flex items-center gap-1 align-baseline tabular-nums text-amber-600">
+                  <StarIcon className="h-3 w-3 fill-amber-400 text-amber-400" />
+                  {String(item.data.rating)}
+                </span>
+              ) : null}
+              {footerLink && (
+                <a
+                  href={footerLink.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="ml-2 inline-flex items-center gap-1 align-baseline font-medium text-primary hover:text-primary/80 transition-colors"
+                >
+                  {footerLink.label}
+                  <ExternalLink className="h-3 w-3" strokeWidth={1.75} />
+                </a>
+              )}
+            </div>
+            <div className="shrink-0">
               <TravelerAvatars
                 tripId={tripId}
                 eventType={item.type === 'hotel' ? 'accommodation' : item.type}
-                eventId={item.type === 'hotel' ? item.data.stay_id : item.id}
+                eventId={item.type === 'hotel' ? (item.data?.stay_id as string) : item.id}
                 maxShow={3}
               />
             </div>
-
-            {/* Main Content: Icon + Title/Subtitle + Optional Hotel Thumb */}
-            <div className="flex items-start gap-3">
-              {/* Icon */}
-              <div className="flex-shrink-0 mt-0.5 text-earth-600">
-                {React.createElement(
-                  getEventIconComponent(item.type as TimelineType, item.data?.type) as React.ComponentType<{ className?: string; strokeWidth?: number }>,
-                  { className: 'h-5 w-5', strokeWidth: 1.5 }
-                )}
-              </div>
-
-              {/* Text Content */}
-              <div className="flex-1 min-w-0 pr-8">
-                {/* Event Title */}
-                <div className="text-base font-display font-normal text-foreground leading-snug line-clamp-2">
-                  {item.title}
-                </div>
-
-                {/* Subtitle/Details */}
-                {item.description && (
-                  <div className="text-xs text-muted-foreground mt-1 line-clamp-2 leading-relaxed">
-                    {item.description}
-                  </div>
-                )}
-
-                {/* Type-specific metadata */}
-                <EventMetadata item={item} />
-              </div>
-
-              {/* Place photo thumbnail — hidden on mobile to prevent layout overflow */}
-              <div className="hidden sm:block flex-shrink-0">
-                {item.type === 'hotel' && item.data?.hotel_place_id && (
-                  <HotelPhotoThumb placeId={item.data.hotel_place_id} title={item.data.hotel} size="md" />
-                )}
-                {item.type === 'activity' && item.data?.location_place_id && (
-                  <HotelPhotoThumb placeId={item.data.location_place_id} title={item.title} size="md" />
-                )}
-                {item.type === 'dining' && item.data?.place_id && (
-                  <HotelPhotoThumb placeId={item.data.place_id} title={item.title} size="md" />
-                )}
-              </div>
-            </div>
-
-            {/* Footer Section */}
-            {hasFooter && (
-              <div className="mt-2 pt-2 flex items-center justify-between">
-                {item.data?.cost ? (
-                  <span className="text-xs font-medium text-earth-600 tabular-nums">
-                    {formatCurrencyWithSymbol(item.data.cost, item.data.currency || 'USD')}
-                  </span>
-                ) : (
-                  <div />
-                )}
-                {footerLink && (
-                  <a
-                    href={footerLink.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="text-xs font-medium text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
-                  >
-                    {footerLink.label}
-                    <ExternalLink className="h-3 w-3" strokeWidth={1.75} />
-                  </a>
-                )}
-              </div>
-            )}
           </div>
         </div>
+
+        {placeId && (
+          <div className="hidden shrink-0 sm:block">
+            <HotelPhotoThumb placeId={String(placeId)} title={item.title} size="md" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/trip/day/components/timeline-utils.test.ts
+++ b/src/components/trip/day/components/timeline-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTimeRange } from './timeline-utils';
+import { formatTimeRange, groupSimilarEvents, generateGroupTitle, type TimelineItem } from './timeline-utils';
 
 describe('formatTimeRange with zone suffixes', () => {
   it('is unchanged with no suffixes', () => {
@@ -14,5 +14,70 @@ describe('formatTimeRange with zone suffixes', () => {
   });
   it('appends only the end suffix when start suffix is empty', () => {
     expect(formatTimeRange('09:00', '14:30', false, '', 'EDT')).toBe('9:00 AM – 2:30 PM EDT');
+  });
+});
+
+describe('groupSimilarEvents', () => {
+  const DAY = '2026-06-14';
+
+  const item = (over: Partial<TimelineItem> & { id: string }): TimelineItem => ({
+    type: 'activity',
+    title: over.id,
+    icon: null,
+    ...over,
+  });
+
+  const flight = (id: string, time: string, from: string, to: string): TimelineItem =>
+    item({ id, type: 'transportation', time, data: { type: 'flight', departure_location: from, arrival_location: to } as TimelineItem['data'] });
+
+  it('does not group a true connection, which shares no common endpoint', () => {
+    // JFK -> SJU -> SXM is one journey, but the rule matches on a shared arrival
+    // or a shared departure, and a connection has neither: SJU is the first
+    // flight's arrival and the second's departure. Documents current behaviour.
+    const groups = groupSimilarEvents(
+      [flight('a', '08:00', 'JFK (JFK)', 'SJU (SJU)'), flight('b', '11:30', 'SJU (SJU)', 'SXM (SXM)')],
+      DAY,
+    );
+    expect(groups).toHaveLength(2);
+  });
+
+  it('groups two flights arriving at the same airport within the window', () => {
+    const groups = groupSimilarEvents(
+      [flight('a', '08:00', 'JFK (JFK)', 'SXM (SXM)'), flight('b', '10:00', 'BOS (BOS)', 'SXM (SXM)')],
+      DAY,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(2);
+    expect(generateGroupTitle(groups[0])).toBe('2 flights into SXM');
+  });
+
+  it('never groups activities, however close together', () => {
+    const groups = groupSimilarEvents(
+      [item({ id: 'a', time: '10:00' }), item({ id: 'b', time: '10:30' }), item({ id: 'c', time: '11:00' })],
+      DAY,
+    );
+    expect(groups.map((g) => g.length)).toEqual([1, 1, 1]);
+  });
+
+  it('never groups dining', () => {
+    const groups = groupSimilarEvents(
+      [item({ id: 'a', type: 'dining', time: '12:00' }), item({ id: 'b', type: 'dining', time: '13:00' })],
+      DAY,
+    );
+    expect(groups.map((g) => g.length)).toEqual([1, 1]);
+  });
+
+  it('does not group flights more than four hours apart', () => {
+    const groups = groupSimilarEvents(
+      [flight('a', '06:00', 'JFK (JFK)', 'SXM (SXM)'), flight('b', '14:00', 'BOS (BOS)', 'SXM (SXM)')],
+      DAY,
+    );
+    expect(groups).toHaveLength(2);
+  });
+
+  it('does not group different transport modes', () => {
+    const a = flight('a', '08:00', 'JFK (JFK)', 'SXM (SXM)');
+    const b = item({ id: 'b', type: 'transportation', time: '09:00', data: { type: 'train', departure_location: 'BOS (BOS)', arrival_location: 'SXM (SXM)' } as TimelineItem['data'] });
+    expect(groupSimilarEvents([a, b], DAY)).toHaveLength(2);
   });
 });

--- a/src/components/trip/day/components/timeline-utils.ts
+++ b/src/components/trip/day/components/timeline-utils.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Plane, Train, Car, Bus, Ship, Hotel, Utensils, Star } from 'lucide-react';
+import { Plane, Train, Car, Bus, Ship, Bed, Utensils, Mountain, Anchor } from 'lucide-react';
+import { CURRENCY_SYMBOLS } from '@/utils/currencyConstants';
 
 /** ----------------------------- Types & shapes ---------------------------- */
 
@@ -50,6 +51,19 @@ export const formatTimeRange = (
   return useArrow ? `${start} → ${end}` : `${start} – ${end}`;
 };
 
+// Cost for a timeline row: no trailing ".00", cents kept when they carry
+// meaning. Budget surfaces keep formatCurrencyWithSymbol's fixed 2 decimals;
+// a row of prices reads faster without the dead zeros.
+export const formatCostCompact = (amount: number, currency = 'USD'): string => {
+  const symbol = CURRENCY_SYMBOLS[currency as keyof typeof CURRENCY_SYMBOLS] ?? currency;
+  const decimals = currency === 'JPY' || Number.isInteger(amount) ? 0 : 2;
+  const value = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(amount);
+  return symbol === currency ? `${value} ${currency}` : `${symbol}${value}`;
+};
+
 // time -> "h:mm AM/PM"
 export const formatTime12 = (time?: string) => {
   if (!time) return '';
@@ -58,6 +72,16 @@ export const formatTime12 = (time?: string) => {
   const ampm = hour >= 12 ? 'PM' : 'AM';
   const displayHour = hour % 12 || 12;
   return `${displayHour}:${minutes} ${ampm}`;
+};
+
+// time -> "9:30a" / "2:00p". The gutter shows a start time and nothing else,
+// so it wants the shortest form that still reads unambiguously.
+export const formatTimeCompact = (time?: string): string => {
+  if (!time) return '';
+  const [hours, minutes] = time.split(':');
+  const hour = parseInt(hours, 10);
+  if (Number.isNaN(hour)) return '';
+  return `${hour % 12 || 12}:${minutes}${hour >= 12 ? 'p' : 'a'}`;
 };
 
 // time -> { time: "h:mm", meridiem: "AM/PM" } for stacked display
@@ -195,26 +219,68 @@ export const getTransportationIconComponent = (type: string): React.ComponentTyp
   return iconMap[type] || Bus;
 };
 
+export type EventCategory = 'ocean' | 'clay' | 'sage' | 'slate' | 'lodging';
+
+/*
+ * Water shows up in this product as ordinary activities and ferries, with no
+ * column to distinguish it, so it is inferred from the title. The list is
+ * deliberately narrow: a false positive only changes an icon and a 4% tint.
+ * If activities ever gain a real category column, read that instead.
+ */
+const WATER_WORDS = /\b(boat|sail|sailing|cruise|kayak|snorkel|dive|diving|yacht|catamaran|ferry|paddle|surf|surfing|canoe|raft|rafting|marina|swim|swimming)\b/i;
+
+export const getEventCategory = (item: Pick<TimelineItem, 'type' | 'title' | 'data'>): EventCategory => {
+  if (item.type === 'hotel') return 'lodging';
+  if (item.type === 'dining') return 'clay';
+  if (item.type === 'transportation') {
+    return item.data?.type === 'ferry' ? 'ocean' : 'slate';
+  }
+  return WATER_WORDS.test(item.title || '') ? 'ocean' : 'sage';
+};
+
+/** Icon colour per category. Shape already differentiates types, so colour
+ *  is reinforcement rather than the only signal. */
+export const CATEGORY_ICON_CLASS: Record<EventCategory, string> = {
+  ocean: 'text-category-ocean',
+  clay: 'text-category-clay',
+  sage: 'text-category-sage',
+  slate: 'text-category-slate',
+  lodging: 'text-earth-500',
+};
+
+/**
+ * Hover wash per category. There is deliberately no resting tint: at 4% over
+ * cream these hues are too faint to read as colour and only muddy the paper.
+ * Category is carried at full strength by the row icon instead.
+ */
+export const CATEGORY_ROW_CLASS: Record<EventCategory, string> = {
+  ocean: 'hover:bg-category-ocean/[0.08]',
+  clay: 'hover:bg-category-clay/[0.08]',
+  sage: 'hover:bg-category-sage/[0.08]',
+  slate: 'hover:bg-category-slate/[0.08]',
+  lodging: 'hover:bg-secondary/40',
+};
+
 // icon per event type
 export const getEventIconComponent = (eventType: TimelineType, transportType?: string): React.ComponentType<{ className?: string }> => {
   switch (eventType) {
     case 'transportation':
       return transportType ? getTransportationIconComponent(transportType) : Plane;
     case 'hotel':
-      return Hotel;
+      return Bed;
     case 'dining':
       return Utensils;
     case 'activity':
-      return Star;
+      return Mountain;
     default:
-      return Star;
+      return Mountain;
   }
 };
 
-// Unified warm neutral for all event types.
-// The icon shape (Hotel, Plane, Star, Utensils) already differentiates types visually.
-export const getEventColors = (_type: TimelineType) => {
-  return { node: 'bg-earth-400', line: 'bg-earth-200', icon: 'text-earth-600' };
+/** Water activities get an anchor regardless of entity type. */
+export const getTimelineIcon = (item: Pick<TimelineItem, 'type' | 'title' | 'data'>): React.ComponentType<{ className?: string }> => {
+  if (item.type === 'activity' && getEventCategory(item) === 'ocean') return Anchor;
+  return getEventIconComponent(item.type, item.data?.type as string | undefined);
 };
 
 // Group similar events that occur within a timeframe
@@ -246,10 +312,14 @@ export const groupSimilarEvents = (items: TimelineItem[], dateISO: string): Time
   return groups;
 };
 
-// Determine if two consecutive events should be grouped together
+// Determine if two consecutive events should be grouped together.
+//
+// Only transportation groups. A shared airport inside a few hours means one
+// journey with a connection, which is worth folding into a single row. For every
+// other type, closeness in time is coincidence rather than a relationship, so
+// activities, dining and hotels always render as rows of their own.
 const shouldGroupEvents = (prev: TimelineItem, curr: TimelineItem, dateISO: string): boolean => {
-  // Must be same type
-  if (prev.type !== curr.type) return false;
+  if (prev.type !== 'transportation' || curr.type !== 'transportation') return false;
 
   // Both must have times
   if (!prev.time || !curr.time) return false;
@@ -265,27 +335,17 @@ const shouldGroupEvents = (prev: TimelineItem, curr: TimelineItem, dateISO: stri
 
   if (timeDiffMinutes > TIME_WINDOW_MINUTES) return false;
 
-  // For transportation events, check if same type and similar location pattern
-  if (prev.type === 'transportation' && curr.type === 'transportation') {
-    const prevData = prev.data;
-    const currData = curr.data;
+  // Same transportation type (e.g., both flights)
+  if (prev.data?.type !== curr.data?.type) return false;
 
-    // Same transportation type (e.g., both flights)
-    if (prevData?.type !== currData?.type) return false;
+  // Group only when they share an endpoint: same arrival, or same departure.
+  const prevArrival = extractIata(prev.data?.arrival_location);
+  const currArrival = extractIata(curr.data?.arrival_location);
+  const prevDeparture = extractIata(prev.data?.departure_location);
+  const currDeparture = extractIata(curr.data?.departure_location);
 
-    // Check if arrivals at same location or departures from same location
-    const prevArrival = extractIata(prevData?.arrival_location);
-    const currArrival = extractIata(currData?.arrival_location);
-    const prevDeparture = extractIata(prevData?.departure_location);
-    const currDeparture = extractIata(currData?.departure_location);
-
-    // Group if arriving at same place or departing from same place
-    return (prevArrival && prevArrival === currArrival) ||
-           (prevDeparture && prevDeparture === currDeparture);
-  }
-
-  // For activities and dining, just group by type and time
-  return true;
+  return (!!prevArrival && prevArrival === currArrival) ||
+         (!!prevDeparture && prevDeparture === currDeparture);
 };
 
 const transportTypeLabel = (transportType: unknown): string => {
@@ -316,25 +376,12 @@ const generateTransportGroupTitle = (items: TimelineItem[]): string => {
   return `${items.length} ${typeLabel}`;
 };
 
-const summarizeNames = (items: TimelineItem[]): string => {
-  const names = items.map(i => i.title).filter(Boolean);
-  if (names.length <= 3) return names.join(', ');
-  return `${names.slice(0, 2).join(', ')}, +${names.length - 2} more`;
-};
-
-// Generate a group title for a set of grouped events
+// Generate a group title for a set of grouped events. Only transportation groups,
+// and every transport title leads with the count, so the title itself says how
+// many rows are folded up.
 export const generateGroupTitle = (items: TimelineItem[]): string => {
   if (items.length === 0) return '';
-
-  const type = items[0].type;
-
-  switch (type) {
-    case 'transportation': return generateTransportGroupTitle(items);
-    case 'activity': return summarizeNames(items);
-    case 'dining': return summarizeNames(items);
-    case 'hotel': return `${items.length} Hotel Events`;
-    default: return `${items.length} Events`;
-  }
+  return generateTransportGroupTitle(items);
 };
 
 // Generate time range for grouped events

--- a/src/components/trip/day/components/useDayTimeline.ts
+++ b/src/components/trip/day/components/useDayTimeline.ts
@@ -370,7 +370,7 @@ export function useDayTimeline({
 }: UseDayTimelineInput): UseDayTimelineOutput {
 
   const normalizedDay = useMemo(() => getNormalizedDay(dateISO), [dateISO]);
-  const formattedDate = useMemo(() => format(parseISO(dateISO), 'MMM d'), [dateISO]);
+  const formattedDate = useMemo(() => format(parseISO(dateISO), 'EEEE, MMM do yyyy'), [dateISO]);
   const isTodayFlag = isToday(parseISO(dateISO));
 
   // Filter hotel stays for this day

--- a/src/components/trip/timeline/TimelineContent.tsx
+++ b/src/components/trip/timeline/TimelineContent.tsx
@@ -7,6 +7,7 @@ import AccommodationDialog from '@/components/trip/accommodation/AccommodationDi
 import TransportationDialog from '@/components/trip/transportation/TransportationDialog';
 import ActivityDialog from '@/components/trip/day/activities/ActivityDialog';
 import RestaurantReservationDialog from '@/components/trip/dining/RestaurantReservationDialog';
+import EventDetailDialog, { EventDetail } from '@/components/trip/day/components/EventDetailDialog';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
@@ -103,6 +104,9 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
   const [editingTransportation, setEditingTransportation] = useState<Transportation | null>(null);
   const [editingReservation, setEditingReservation] = useState<RestaurantReservation | null>(null);
 
+  // Clicking a row opens a read-only detail view; editing is a deliberate second step.
+  const [viewingEvent, setViewingEvent] = useState<{ detail: EventDetail; dayDate: string } | null>(null);
+
   const [newActivity, setNewActivity] = useState<ActivityFormData>({ ...EMPTY_ACTIVITY });
   const [activityEdit, setActivityEdit] = useState<ActivityFormData>({ ...EMPTY_ACTIVITY });
 
@@ -142,6 +146,24 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
     invalidateTripQueries();
     queryClient.invalidateQueries({ queryKey: ['transportation', tripId] });
     setSelectedDayId(null);
+  };
+
+  const openEditorFor = (detail: EventDetail, dayDate: string): void => {
+    setViewingEvent(null);
+    if (detail.kind === 'activity') {
+      setEditingActivity(detail.data);
+      setActivityEdit(buildActivityFormData(detail.data, dayDate));
+      setActivityOpen(false);
+    } else if (detail.kind === 'hotel') {
+      setEditingHotel(detail.data);
+      setAccommodationOpen(true);
+    } else if (detail.kind === 'transportation') {
+      setEditingTransportation(detail.data);
+      setTransportationOpen(true);
+    } else {
+      setEditingReservation(detail.data);
+      setReservationOpen(true);
+    }
   };
 
   const handleActivityDialogClose = (): void => {
@@ -375,23 +397,18 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
                 setPreselectedDate(day.date.split('T')[0]);
                 setReservationOpen(true);
               }}
-              onActivityClick={(activity) => {
-                setEditingActivity(activity);
-                setActivityEdit(buildActivityFormData(activity, day.date));
-                setActivityOpen(false);
-              }}
-              onHotelClick={(hotel) => {
-                setEditingHotel(hotel);
-                setAccommodationOpen(true);
-              }}
-              onTransportationClick={(transportation) => {
-                setEditingTransportation(transportation);
-                setTransportationOpen(true);
-              }}
-              onReservationClick={(reservation) => {
-                setEditingReservation(reservation);
-                setReservationOpen(true);
-              }}
+              onActivityClick={(activity) =>
+                setViewingEvent({ detail: { kind: 'activity', data: activity }, dayDate: day.date })
+              }
+              onHotelClick={(hotel) =>
+                setViewingEvent({ detail: { kind: 'hotel', data: hotel }, dayDate: day.date })
+              }
+              onTransportationClick={(transportation) =>
+                setViewingEvent({ detail: { kind: 'transportation', data: transportation }, dayDate: day.date })
+              }
+              onReservationClick={(reservation) =>
+                setViewingEvent({ detail: { kind: 'dining', data: reservation }, dayDate: day.date })
+              }
               canEdit={canEdit}
               />
             </div>
@@ -400,6 +417,17 @@ const TimelineContent: React.FC<TimelineContentProps> = ({
       </div>
 
       {/* Dialogs */}
+      <EventDetailDialog
+        event={viewingEvent?.detail ?? null}
+        open={!!viewingEvent}
+        onOpenChange={(open) => { if (!open) setViewingEvent(null); }}
+        tripId={tripId}
+        canEdit={canEdit}
+        onEdit={(detail) => {
+          if (viewingEvent) openEditorFor(detail, viewingEvent.dayDate);
+        }}
+      />
+
       <AccommodationDialog
         tripId={tripId}
         open={accommodationOpen}

--- a/src/index.css
+++ b/src/index.css
@@ -132,6 +132,29 @@
   }
 }
 
+@layer components {
+  /* Single source of truth for timeline row geometry. Every row type
+     (event, grouped, layover hint, now marker) uses this grid so the rail
+     column stays aligned and the hairline reads as one continuous line.
+     Declared in @layer components, not utilities, so Tailwind utilities
+     still win against it. */
+  .tl-row {
+    display: grid;
+    grid-template-columns: 4rem 1.25rem 1fr;
+    column-gap: 0.5rem;
+    /* Padding lives inside the row so hover/focus bleeds the full card width. */
+    padding-inline: 0.75rem;
+  }
+
+  @media (min-width: 640px) {
+    .tl-row {
+      grid-template-columns: 5rem 1.5rem 1fr;
+      column-gap: 0.75rem;
+      padding-inline: 1rem;
+    }
+  }
+}
+
 @layer base {
   /* iOS Safe Area Support */
   /* Set up CSS custom properties for safe viewport heights */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,6 +25,19 @@ export default {
         sans: ['"DM Sans"', 'system-ui', 'sans-serif'],
         mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
       },
+      fontSize: {
+        // Dense product-UI ramp for timeline rows, headers and metadata.
+        // Steps sit close together on purpose: roles that are adjacent in the
+        // layout (title vs. meta = 15/13) clear a 1.15 ratio and are further
+        // separated by weight and ink level, while same-size roles (time,
+        // price) never share a column. See DESIGN.md section 3.
+        'ui-xs':   ['0.75rem',   { lineHeight: '1rem' }],      // 12 - overlines, badges
+        'ui-sm':   ['0.8125rem', { lineHeight: '1.125rem' }],  // 13 - metadata, descriptions
+        'ui-base': ['0.875rem',  { lineHeight: '1.25rem' }],   // 14 - times, prices, labels
+        'ui-md':   ['0.9375rem', { lineHeight: '1.375rem' }],  // 15 - row titles
+        'ui-lg':   ['1.0625rem', { lineHeight: '1.5rem' }],    // 17 - subsection titles
+        'ui-day':  ['1.375rem',  { lineHeight: '1.75rem', letterSpacing: '-0.015em' }], // 22 - day title (serif)
+      },
       typography: {
         earth: {
           css: {
@@ -51,6 +64,15 @@ export default {
             },
           },
         },
+      },
+      spacing: {
+        // Timeline row rhythm: 72px two-line row, 56px sticky day bar,
+        // 36px pinned accommodation strip, 80px time gutter.
+        'row': '4.5rem',
+        'daybar': '4.5rem',
+        'strip': '2.25rem',
+        'gutter': '5rem',
+        'gutter-sm': '4rem',
       },
       borderRadius: {
         'card': '0.75rem',
@@ -127,6 +149,16 @@ export default {
           400: '#FB923C',
           500: '#F97316',
           600: '#EA580C',
+        },
+        // Timeline category hues. All sit at OKLCH L .47 / chroma <= .075 so
+        // they read as ink rather than as brand colour, and each clears 6.5:1
+        // on cream paper. Applied to the type icon at full strength and to the
+        // row as a 4-10% wash, which composites over cream and stays warm.
+        category: {
+          ocean: '#366172',
+          clay: '#7E4D36',
+          sage: '#476348',
+          slate: '#535B6C',
         },
         navy: {
           800: '#1E293B',


### PR DESCRIPTION
## What changed

Two areas: the day timeline's visual hierarchy, and the AI assistant's wording.

### Timeline

- **Day header** drops the activity/hotel counts, which restated the rows directly below them. The full date (`Thursday, Aug 20th 2026`) now sits under the day name, left-aligned. `daybar` grows 3.5rem → 4.5rem to hold two lines, which also puts it on the same 72px rhythm as the timeline rows.
- **Rows** lose the price to reclaim width, and the gutter now shows **start over finish**. No end time renders a greyed `tbd`. Screen readers get "Starts"/"Ends" prefixes, because two stacked numbers are ambiguous read aloud.
- **Grouped rows** now read as collapsible: one chevron that *rotates* instead of two that swap, a hover well around it, a hollow rail node for the container and smaller nodes for its children.
- **Expanded children indent to sit under the parent title.** They previously started at 0px in the content column, which is the parent's *icon* slot, so children rendered further left than their own parent and the hierarchy read inverted.
- **The resting category wash is gone** (hover keeps it). Those hues sit at chroma ≤0.075, so a 4% tint over cream is too faint to read as colour and only muddied the paper. Category is already carried at full strength by the row icon.

### Event detail dialog (new)

Clicking any event opened the editor directly. It now opens a **read-only view of every populated field**, with an explicit **Edit** button.

One tagged union covers activities, stays, transport and dining. Empty fields drop out, so a sparse event stays short rather than showing a wall of blank labels. Dates are built from their parts rather than `Date.parse`, since these are floating wall-clock values and UTC parsing would shift them a day.

### Assistant copy

Audited **all 174 user-facing strings**. The wins were redundancy, not length:

- The empty state enumerated "Recommendations, scheduling, packing tips" directly above chips reading *Restaurant ideas / Packing tips / Day trip ideas*.
- Attaching a booking was taught in three separate places.
- "Something went wrong" was restated by "The assistant ran into an unexpected error."
- Removed the **"Optimize schedule"** prompt chip.

Net **-101/+35** lines across the assistant.

## Bugs found on the way

- `handlePaste` in `ChatFileAttachment` was **dead code** — the paste listener defines its own handler, so both of its toasts were unreachable. Removed the callback, not just the strings.
- Party size rendered **"1 guests"** for solo bookings.
- `ExtractedItemCard` said `Car Rental` against the test-locked canonical `Rental Car` in `transportationUtils.ts`.

## Reviewer notes

- **Grouping is narrower than it looks.** `shouldGroupEvents` requires *all* of: both items transportation, both timed, within 4 hours, same transport type, and sharing an IATA endpoint. Activities and dinners never group. The only output is "2 flights into SXM".
- **Child traveler avatars were kept deliberately.** The group header does not aggregate travelers, so removing them would erase that information from grouped events entirely. The cost is 32px off the child title box.
- **Two things left open**: duration is still in the meta line though it's now derivable from the two gutter times, and group headers still show only a start time plus a range in the meta line, so they don't match standalone rows' start/finish pair.
- **The calendar view still clicks straight to edit** (`TripCalendarView.tsx:91`). Scoped to the timeline here; routing it through the same dialog is a small follow-up.

## Verification

- `npx vitest run` — **679 tests / 64 files pass**, including 7 new ones covering the detail dialog's four types, field omission, Edit routing, and the `canEdit={false}` case. Two of those failed on first run because my fixtures had the wrong weekday, not because the component was wrong.
- `npx eslint src/ tailwind.config.ts` — clean.
- `tsc -p tsconfig.app.json` — 297 errors against the repo's 315-error baseline, **no new errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)