### PR TITLE
Polish the day card down to its details (v7.0.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "6.0.1",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "6.0.1",
+      "version": "7.0.1",
       "dependencies": {
         "@anthropic-ai/claude-code": "^2.1.178",
         "@anthropic-ai/sdk": "^0.104.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "6.0.1",
+  "version": "7.0.1",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"NODE_ENV=development npx tsx server/index.ts\"",

--- a/src/components/trip/day/CompactDayCard.tsx
+++ b/src/components/trip/day/CompactDayCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useId } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -107,6 +107,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
   const isPastDay = dayDate < today;
 
   const [isExpanded, setIsExpanded] = useState(!isPastDay);
+  const bodyId = useId();
 
   // Track which periods are expanded (all expanded by default)
   const [expandedPeriods, setExpandedPeriods] = useState<Set<string>>(new Set());
@@ -177,6 +178,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
   // build view-model
   const {
     normalizedDay,
+    weekdayLabel,
     formattedDate,
     isTodayFlag,
     allDayHotels,
@@ -196,7 +198,12 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
     tripTimezone,
   });
 
-  const dayTitle = title || new Date(date).toLocaleDateString('en-US', { timeZone: 'UTC', weekday: 'long' });
+  // The weekday is the headline unless the day has been named. Repeating it in
+  // the line underneath ("Friday" over "Friday, Oct 24th 2025") spent the card's
+  // two most prominent lines saying one thing, so the date line carries the
+  // weekday only when the headline has given it up.
+  const dayTitle = title || weekdayLabel;
+  const dateLine = title ? `${weekdayLabel}, ${formattedDate}` : formattedDate;
 
   const addActivityForThisDay = () => {
     onActivityAdd?.({ dayId: id, date: getNormalizedDay(date) });
@@ -208,65 +215,73 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
   const PERIOD_SECTION_THRESHOLD = 5;
   const showPeriodSections = totalEvents >= PERIOD_SECTION_THRESHOLD;
 
-  // Toggle period expansion
   // One dispatcher for both layouts: below the section threshold rows render
   // flat, above it they render inside time-of-day sections.
+  //
+  // railStart / railEnd let the first and last rows draw the hairline from
+  // their own node instead of from the edge of the row, so the day's timeline
+  // begins and ends where the day does. Hint rows have no node and are never
+  // handed the flags — their dashes simply meet the neighbouring solid line.
   const renderRow = (row: TimelineRenderRow, i: number, rowCount: number) => {
+    const railStart = i === 0;
+    const railEnd = i === rowCount - 1;
 
-        // Check if event has passed (for today only)
-        const isItemPast = isTodayFlag && row.kind === 'item' && (() => {
-          const endTime = row.item.endTime || row.item.time;
-          if (!endTime) return false;
-          const eventEnd = combineDateAndTime(normalizedDay, endTime);
-          return eventEnd ? eventEnd < new Date() : false;
-        })();
+    // Check if event has passed (for today only)
+    const isItemPast = isTodayFlag && row.kind === 'item' && (() => {
+      const endTime = row.item.endTime || row.item.time;
+      if (!endTime) return false;
+      const eventEnd = combineDateAndTime(normalizedDay, endTime);
+      return eventEnd ? eventEnd < new Date() : false;
+    })();
 
-        return row.kind === 'item' ? (
-          canEdit ? (
-            <SortableTimelineRow
-              key={row.item.id}
-              item={row.item}
-              idx={i}
-              isLast={i >= rowCount - 1}
-              tripId={tripId}
-              isPast={isItemPast || false}
-              onActivityClick={onActivityClick}
-              onHotelClick={onHotelClick}
-              onTransportationClick={onTransportationClick}
-              onReservationClick={onReservationClick}
-            />
-          ) : (
-            <TimelineRow
-              key={row.item.id}
-              item={row.item}
-              idx={i}
-              isLast={i >= rowCount - 1}
-              tripId={tripId}
-              isPast={isItemPast || false}
-              onActivityClick={onActivityClick}
-              onHotelClick={onHotelClick}
-              onTransportationClick={onTransportationClick}
-              onReservationClick={onReservationClick}
-            />
-          )
-        ) : row.kind === 'grouped' ? (
-          <GroupedEventCard
-            key={row.id}
-            items={row.items}
-            groupType={row.groupType}
-            title={row.title}
-            timeRange={row.timeRange}
-            tripId={tripId}
-            onActivityClick={onActivityClick}
-            onHotelClick={onHotelClick}
-            onTransportationClick={onTransportationClick}
-            onReservationClick={onReservationClick}
-          />
-        ) : row.kind === 'now' ? (
-          <NowIndicator key="now-indicator" />
-        ) : row.kind === 'hint' ? (
-          <LayoverHintRow key={row.id} text={row.text} hintType={row.hintType} />
-        ) : null;
+    if (row.kind === 'item') {
+      const RowComponent = canEdit ? SortableTimelineRow : TimelineRow;
+      return (
+        <RowComponent
+          key={row.item.id}
+          item={row.item}
+          idx={i}
+          isLast={railEnd}
+          railStart={railStart}
+          railEnd={railEnd}
+          tripId={tripId}
+          isPast={isItemPast || false}
+          onActivityClick={onActivityClick}
+          onHotelClick={onHotelClick}
+          onTransportationClick={onTransportationClick}
+          onReservationClick={onReservationClick}
+        />
+      );
+    }
+
+    if (row.kind === 'grouped') {
+      return (
+        <GroupedEventCard
+          key={row.id}
+          items={row.items}
+          groupType={row.groupType}
+          title={row.title}
+          timeRange={row.timeRange}
+          tripId={tripId}
+          railStart={railStart}
+          railEnd={railEnd}
+          onActivityClick={onActivityClick}
+          onHotelClick={onHotelClick}
+          onTransportationClick={onTransportationClick}
+          onReservationClick={onReservationClick}
+        />
+      );
+    }
+
+    if (row.kind === 'now') {
+      return <NowIndicator key="now-indicator" railStart={railStart} railEnd={railEnd} />;
+    }
+
+    if (row.kind === 'hint') {
+      return <LayoverHintRow key={row.id} text={row.text} hintType={row.hintType} />;
+    }
+
+    return null;
   };
 
   const togglePeriod = (period: string) => {
@@ -339,7 +354,9 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1], delay: index * 0.05 }}
+      // Capped: an unbounded stagger left day 20 of a long trip waiting a full
+      // second to appear, which reads as lag rather than as choreography.
+      transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1], delay: Math.min(index, 6) * 0.05 }}
     >
       <Card
         id={`day-${index}`}
@@ -351,7 +368,8 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
         {/* Header */}
         <DayHeader
           dayTitle={dayTitle}
-          formattedDate={formattedDate}
+          formattedDate={dateLine}
+          bodyId={bodyId}
           index={index}
           isTodayFlag={isTodayFlag}
           isCheckInDay={isCheckInDay}
@@ -369,6 +387,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
         <AnimatePresence>
           {isExpanded && (
             <motion.div
+              id={bodyId}
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: 'auto', opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
@@ -391,7 +410,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                       <div className="py-2">
                         <div>
                           {showPeriodSections ? periodGroups.map((group, groupIdx) => {
-                            const isExpanded = isPeriodExpanded(group.period);
+                            const isPeriodOpen = isPeriodExpanded(group.period);
                             const eventCount = group.rows.filter(row => row.kind !== 'hint' && row.kind !== 'now').length;
 
                             return (
@@ -399,17 +418,17 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                                 {/* Period Header */}
                                 <div className="px-3 sm:px-4">
                                   <TimePeriodHeader
-                                  label={group.label}
-                                  isFirst={groupIdx === 0}
-                                  isExpanded={isExpanded}
-                                  onToggle={() => togglePeriod(group.period)}
-                                  eventCount={eventCount}
+                                    label={group.label}
+                                    isFirst={groupIdx === 0}
+                                    isExpanded={isPeriodOpen}
+                                    onToggle={() => togglePeriod(group.period)}
+                                    eventCount={eventCount}
                                   />
                                 </div>
 
                                 {/* Period Events */}
                                 <AnimatePresence>
-                                  {isExpanded && (
+                                  {isPeriodOpen && (
                                     <motion.div
                                       initial={{ height: 0, opacity: 0 }}
                                       animate={{ height: 'auto', opacity: 1 }}
@@ -433,7 +452,7 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                                 <Button
                                   variant="ghost"
                                   size="sm"
-                                  className="text-xs h-8 px-3 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                                  className="text-ui-sm h-8 px-3 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                                 >
                                   <Plus className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.75} />
                                   Add to this day
@@ -481,19 +500,19 @@ const CompactDayCard: React.FC<CompactDayCardProps> = ({
                     </p>
                     {canEdit && (
                       <div className="grid grid-cols-2 gap-2 max-w-sm mx-auto">
-                        <Button variant="outline" size="sm" onClick={addActivityForThisDay} className="font-normal">
+                        <Button variant="outline" size="sm" onClick={addActivityForThisDay} className="h-11 font-normal sm:h-9">
                           <Star className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.5} />
                           Activity
                         </Button>
-                        <Button variant="outline" size="sm" onClick={onHotelAdd} className="font-normal">
+                        <Button variant="outline" size="sm" onClick={onHotelAdd} className="h-11 font-normal sm:h-9">
                           <Hotel className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.5} />
                           Hotel
                         </Button>
-                        <Button variant="outline" size="sm" onClick={onTransportationAdd} className="font-normal">
+                        <Button variant="outline" size="sm" onClick={onTransportationAdd} className="h-11 font-normal sm:h-9">
                           <Plane className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.5} />
                           Travel
                         </Button>
-                        <Button variant="outline" size="sm" onClick={onReservationAdd} className="font-normal">
+                        <Button variant="outline" size="sm" onClick={onReservationAdd} className="h-11 font-normal sm:h-9">
                           <Utensils className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.5} />
                           Dining
                         </Button>

--- a/src/components/trip/day/components/AllDayHotelsSection.tsx
+++ b/src/components/trip/day/components/AllDayHotelsSection.tsx
@@ -24,7 +24,7 @@ const AllDayHotelsSection: React.FC<Props> = ({ stays, onHotelClick }) => {
           type="button"
           title={stay.hotel_address || undefined}
           onClick={() => onHotelClick?.(stay)}
-          className="flex h-strip w-full items-center gap-2.5 bg-secondary/50 px-3 text-left transition-colors hover:bg-secondary sm:px-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+          className="flex h-11 w-full items-center gap-2.5 bg-secondary/50 px-3 text-left transition-colors hover:bg-secondary sm:h-strip sm:px-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
         >
           <Bed className="h-3.5 w-3.5 shrink-0 text-earth-500" strokeWidth={1.5} />
           <span className="min-w-0 flex-1 truncate text-ui-sm text-earth-600">{stay.hotel}</span>

--- a/src/components/trip/day/components/DayHeader.tsx
+++ b/src/components/trip/day/components/DayHeader.tsx
@@ -9,6 +9,7 @@ import DayWeatherBadge from '@/components/trip/timeline/DayWeatherBadge';
 type Props = {
   dayTitle: string;
   formattedDate: string;
+  bodyId: string;
   index: number;
   isTodayFlag: boolean;
   isCheckInDay: boolean;
@@ -28,6 +29,7 @@ const chipClass =
 const DayHeader: React.FC<Props> = ({
   dayTitle,
   formattedDate,
+  bodyId,
   index,
   isTodayFlag,
   isCheckInDay,
@@ -56,6 +58,7 @@ const DayHeader: React.FC<Props> = ({
       type="button"
       onClick={onToggle}
       aria-expanded={isExpanded}
+      aria-controls={bodyId}
       className={cn(
         // Sticky so the day you're reading stays named while you scroll it.
         'sticky top-0 z-20 flex h-daybar w-full items-center gap-3 bg-card px-3 text-left sm:px-4',
@@ -94,10 +97,13 @@ const DayHeader: React.FC<Props> = ({
         {isTodayFlag && (
           <Badge className={cn(chipClass, 'bg-primary text-primary-foreground hover:bg-primary')}>Today</Badge>
         )}
-        {isCheckInDay && (
+        {/* Only while the day is folded up. Once it is open, "Check-in" the chip
+            and "Check-in: Arty's House" the row say the same thing two inches
+            apart, and the chip is the one that isn't useful. */}
+        {!isExpanded && isCheckInDay && (
           <Badge className={cn(chipClass, 'hidden border-transparent bg-primary/15 text-primary hover:bg-primary/15 sm:inline-flex')}>Check-in</Badge>
         )}
-        {isCheckOutDay && (
+        {!isExpanded && isCheckOutDay && (
           <Badge className={cn(chipClass, 'hidden border-transparent bg-muted text-earth-500 hover:bg-muted sm:inline-flex')}>Check-out</Badge>
         )}
       </span>

--- a/src/components/trip/day/components/GroupedEventCard.tsx
+++ b/src/components/trip/day/components/GroupedEventCard.tsx
@@ -12,6 +12,9 @@ type Props = {
   title: string;
   timeRange: string;
   tripId: string;
+  /** First / last rail-bearing row in its run, so the line stops at the node. */
+  railStart?: boolean;
+  railEnd?: boolean;
   onActivityClick?: (a: DayActivity) => void;
   onHotelClick?: (h: HotelStay) => void;
   onTransportationClick?: (t: Transportation) => void;
@@ -24,6 +27,8 @@ const GroupedEventCard: React.FC<Props> = ({
   title,
   timeRange,
   tripId,
+  railStart,
+  railEnd,
   onActivityClick,
   onHotelClick,
   onTransportationClick,
@@ -75,9 +80,19 @@ const GroupedEventCard: React.FC<Props> = ({
           )}
         </div>
 
-        {/* Rail: hollow node, because this one contains other nodes. */}
+        {/* Rail: hollow node, because this one contains other nodes. When the
+            group is collapsed it is also the run's last node, so the line has
+            to stop here rather than run past the folded-up children. */}
         <div aria-hidden className="relative flex justify-center">
-          <div className="absolute inset-y-0 w-px bg-border" />
+          {!(railStart && railEnd && !isExpanded) && (
+            <div
+              className={cn(
+                'absolute w-px bg-border',
+                railStart ? 'top-[1.375rem]' : 'top-0',
+                railEnd && !isExpanded ? 'h-[1.375rem]' : 'bottom-0',
+              )}
+            />
+          )}
           <div className="relative mt-[1.0625rem] h-2.5 w-2.5 shrink-0 rounded-full border-2 border-earth-400 bg-background ring-4 ring-background" />
         </div>
 
@@ -122,13 +137,18 @@ const GroupedEventCard: React.FC<Props> = ({
             transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
             className="overflow-hidden"
           >
-            {items.map((item) => (
+            {items.map((item, childIdx) => (
               <div key={item.id} className="tl-row">
                 <div className="py-2 text-right text-ui-sm tabular-nums leading-5 text-earth-500">
                   {formatTimeCompact(item.time)}
                 </div>
                 <div aria-hidden className="relative flex justify-center">
-                  <div className="absolute inset-y-0 w-px bg-border" />
+                  <div
+                    className={cn(
+                      'absolute top-0 w-px bg-border',
+                      railEnd && childIdx === items.length - 1 ? 'h-[1.125rem]' : 'bottom-0',
+                    )}
+                  />
                   <div className="relative mt-[0.9375rem] h-1.5 w-1.5 shrink-0 rounded-full bg-earth-300 ring-4 ring-background" />
                 </div>
                 <div

--- a/src/components/trip/day/components/LayoverHintRow.tsx
+++ b/src/components/trip/day/components/LayoverHintRow.tsx
@@ -22,12 +22,12 @@ const LayoverHintRow: React.FC<Props> = ({ text, hintType = 'layover' }) => {
         <div
           className={cn(
             'absolute inset-y-0 w-px border-l border-dashed',
-            isOverlap ? 'border-destructive/50' : 'border-border',
+            isOverlap ? 'border-destructive-ink/40' : 'border-border',
           )}
         />
       </div>
       <div className="py-2">
-        <span className={cn('text-ui-sm tabular-nums', isOverlap ? 'text-destructive' : 'text-earth-500')}>
+        <span className={cn('text-ui-sm tabular-nums', isOverlap ? 'text-destructive-ink' : 'text-earth-500')}>
           {text}
         </span>
       </div>

--- a/src/components/trip/day/components/NowIndicator.tsx
+++ b/src/components/trip/day/components/NowIndicator.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
 
-const NowIndicator: React.FC = () => {
+type Props = {
+  /** First / last rail-bearing row in its run, so the line stops at the node. */
+  railStart?: boolean;
+  railEnd?: boolean;
+};
+
+const NowIndicator: React.FC<Props> = ({ railStart, railEnd }) => {
   const [now, setNow] = useState(new Date());
 
   useEffect(() => {
@@ -27,11 +34,19 @@ const NowIndicator: React.FC = () => {
 
   return (
     <div className="tl-row">
-      <div className="py-1 text-right text-ui-xs font-semibold tabular-nums leading-5 text-destructive">
+      <div className="py-1 text-right text-ui-xs font-semibold tabular-nums text-destructive-ink">
         {timeStr}
       </div>
       <div aria-hidden className="relative flex justify-center">
-        <div className="absolute inset-y-0 w-px bg-border" />
+        {!(railStart && railEnd) && (
+          <div
+            className={cn(
+              'absolute w-px bg-border',
+              railStart ? 'top-3' : 'top-0',
+              railEnd ? 'h-3' : 'bottom-0',
+            )}
+          />
+        )}
         <div className="relative mt-2 h-2 w-2 shrink-0 rounded-full bg-destructive ring-4 ring-background" />
       </div>
       <div className="flex items-center py-1">

--- a/src/components/trip/day/components/SortableTimelineRow.tsx
+++ b/src/components/trip/day/components/SortableTimelineRow.tsx
@@ -14,6 +14,8 @@ type Props = {
   isLast: boolean;
   tripId: string;
   isPast?: boolean;
+  railStart?: boolean;
+  railEnd?: boolean;
   onActivityClick?: (a: DayActivity) => void;
   onHotelClick?: (h: HotelStay) => void;
   onTransportationClick?: (t: Transportation) => void;

--- a/src/components/trip/day/components/TimelineRow.tsx
+++ b/src/components/trip/day/components/TimelineRow.tsx
@@ -6,6 +6,7 @@ import HotelPhotoThumb from './HotelPhotoThumb';
 import TravelerAvatars from '../../timeline/TravelerAvatars';
 import {
   TimelineItem,
+  formatTime12,
   formatTimeCompact,
   getEventCategory,
   getTimelineIcon,
@@ -20,6 +21,9 @@ type Props = {
   isLast: boolean;
   tripId: string;
   isPast?: boolean;
+  /** First / last rail-bearing row in its run, so the line stops at the node. */
+  railStart?: boolean;
+  railEnd?: boolean;
   onActivityClick?: (a: DayActivity) => void;
   onHotelClick?: (h: HotelStay) => void;
   onTransportationClick?: (t: Transportation) => void;
@@ -79,7 +83,7 @@ const getFooterLink = (item: TimelineItem): { href: string; label: string } | nu
 };
 
 const TimelineRow: React.FC<Props> = ({
-  item, tripId, isPast,
+  item, tripId, isPast, railStart, railEnd,
   onActivityClick, onHotelClick, onTransportationClick, onReservationClick
 }) => {
   const handleItemClick = () => {
@@ -91,10 +95,11 @@ const TimelineRow: React.FC<Props> = ({
 
   const footerLink = getFooterLink(item);
   const metaParts = buildMetaParts(item);
+  const endValue = item.endTime || (item.data?.__arrive_time_on_this_day as string | undefined);
   const startLabel = formatTimeCompact(item.time);
-  const endLabel = formatTimeCompact(
-    item.endTime || (item.data?.__arrive_time_on_this_day as string | undefined),
-  );
+  const endLabel = formatTimeCompact(endValue);
+  // A single-row day needs a node, not a line to nowhere.
+  const showRail = !(railStart && railEnd);
   const category = getEventCategory(item);
   const Icon = getTimelineIcon(item) as React.ComponentType<{ className?: string; strokeWidth?: number }>;
   const placeId =
@@ -112,7 +117,6 @@ const TimelineRow: React.FC<Props> = ({
         CATEGORY_ROW_CLASS[category],
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
         'touch-manipulation',
-        isPast && 'opacity-50',
       )}
       role="button"
       tabIndex={0}
@@ -120,48 +124,71 @@ const TimelineRow: React.FC<Props> = ({
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleItemClick(); } }}
     >
       {/* Gutter: start stacked over finish, right-aligned, tabular so digits stack.
-          Weight carries the pair: bold start, quiet finish. */}
+          Weight carries the pair: bold start, quiet finish. An event with no
+          finish time simply has no second line — a placeholder there reads as
+          a broken value rather than as an open end.
+          The compact labels ("6:23p") are spoken badly, so each one carries an
+          unabbreviated screen-reader twin. */}
       <div className="py-3 text-right">
         {startLabel && (
           <>
-            <div className="text-ui-base font-medium tabular-nums text-earth-600 leading-5">
-              <span className="sr-only">Starts </span>
-              {startLabel}
+            <div className="text-ui-base font-medium tabular-nums text-earth-600">
+              <span className="sr-only">
+                Starts {formatTime12(item.time)}{item.tzSuffix ? ` ${item.tzSuffix}` : ''}
+              </span>
+              <span aria-hidden>{startLabel}</span>
             </div>
             {item.tzSuffix && (
-              <div className="text-ui-xs tabular-nums text-earth-500 leading-4">{item.tzSuffix}</div>
+              <div aria-hidden className="text-ui-xs tabular-nums text-earth-500">{item.tzSuffix}</div>
             )}
-            {endLabel ? (
-              <div className="text-ui-base tabular-nums text-earth-500 leading-5">
-                <span className="sr-only">Ends </span>
-                {endLabel}
-              </div>
-            ) : (
-              <div className="text-ui-base text-earth-400 leading-5">
-                <span className="sr-only">End time </span>tbd
-              </div>
-            )}
-            {endLabel && item.endTzSuffix && (
-              <div className="text-ui-xs tabular-nums text-earth-500 leading-4">{item.endTzSuffix}</div>
+            {endLabel && (
+              <>
+                <div className="text-ui-base tabular-nums text-earth-500">
+                  <span className="sr-only">
+                    Ends {formatTime12(endValue)}{item.endTzSuffix ? ` ${item.endTzSuffix}` : ''}
+                  </span>
+                  <span aria-hidden>{endLabel}</span>
+                </div>
+                {item.endTzSuffix && (
+                  <div aria-hidden className="text-ui-xs tabular-nums text-earth-500">{item.endTzSuffix}</div>
+                )}
+              </>
             )}
           </>
         )}
       </div>
 
-      {/* Rail: continuous hairline with a filled node */}
+      {/* Rail: hairline with a filled node. The line stops at the first and
+          last node of a run so the day doesn't appear to continue past its
+          own ends. */}
       <div aria-hidden className="relative flex justify-center">
-        <div className="absolute inset-y-0 w-px bg-border" />
-        <div className="relative mt-[1.125rem] h-2 w-2 shrink-0 rounded-full bg-earth-400 ring-4 ring-background" />
+        {showRail && (
+          <div
+            className={cn(
+              'absolute w-px bg-border',
+              railStart ? 'top-[1.375rem]' : 'top-0',
+              railEnd ? 'h-[1.375rem]' : 'bottom-0',
+            )}
+          />
+        )}
+        <div
+          className={cn(
+            'relative mt-[1.125rem] h-2 w-2 shrink-0 rounded-full ring-4 ring-background',
+            isPast ? 'bg-earth-300' : 'bg-earth-400',
+          )}
+        />
       </div>
 
       {/* Content */}
       <div className="flex min-w-0 items-start gap-3 py-3 pr-1">
-        <div className={cn('mt-0.5 shrink-0', CATEGORY_ICON_CLASS[category])}>
+        {/* A past event recedes by dropping an ink level, not by fading the
+            whole row: at 50% opacity the meta line fell to 2.1:1. */}
+        <div className={cn('mt-0.5 shrink-0', isPast ? 'text-earth-400' : CATEGORY_ICON_CLASS[category])}>
           <Icon className="h-5 w-5" strokeWidth={1.5} />
         </div>
 
         <div className="min-w-0 flex-1">
-          <div className="text-ui-md font-medium text-foreground line-clamp-1">
+          <div className={cn('text-ui-md font-medium line-clamp-1', isPast ? 'text-earth-500' : 'text-foreground')}>
             {item.title}
           </div>
 

--- a/src/components/trip/day/components/useDayTimeline.ts
+++ b/src/components/trip/day/components/useDayTimeline.ts
@@ -32,6 +32,7 @@ type UseDayTimelineInput = {
 
 type UseDayTimelineOutput = {
   normalizedDay: string;
+  weekdayLabel: string;
   formattedDate: string;
   isTodayFlag: boolean;
   filteredHotelStays: HotelStay[];
@@ -286,10 +287,20 @@ function buildLayoverHint(
   };
 }
 
+/**
+ * A hotel check-in or check-out is a window you pass through, not an
+ * appointment you attend, so it cannot conflict with anything. Flagging a
+ * 7pm drinks reservation as overlapping an 8pm check-in is a false alarm —
+ * and a false alarm in red teaches people to ignore the real ones.
+ */
+const isLodgingMoment = (item: TimelineItem) => item.type === 'hotel';
+
 function buildGapHint(
   groupIdx: number,
   currEnd: Date,
   nextStart: Date,
+  lastItem: TimelineItem,
+  nextFirst: TimelineItem,
 ): TimelineRenderRow | null {
   const gapMs = nextStart.getTime() - currEnd.getTime();
   const gapMins = Math.round(gapMs / 60000);
@@ -303,7 +314,7 @@ function buildGapHint(
     };
   }
 
-  if (gapMins < -5) {
+  if (gapMins < -5 && !isLodgingMoment(lastItem) && !isLodgingMoment(nextFirst)) {
     return {
       kind: 'hint',
       id: `overlap-${groupIdx}`,
@@ -337,7 +348,7 @@ function buildGapOrLayoverHint(
   const layover = buildLayoverHint(lastItem, nextFirst, currEnd, nextStart);
   if (layover) return layover;
 
-  return buildGapHint(groupIdx, currEnd, nextStart);
+  return buildGapHint(groupIdx, currEnd, nextStart, lastItem, nextFirst);
 }
 
 function insertNowIndicator(result: TimelineRenderRow[]): void {
@@ -370,8 +381,14 @@ export function useDayTimeline({
 }: UseDayTimelineInput): UseDayTimelineOutput {
 
   const normalizedDay = useMemo(() => getNormalizedDay(dateISO), [dateISO]);
-  const formattedDate = useMemo(() => format(parseISO(dateISO), 'EEEE, MMM do yyyy'), [dateISO]);
-  const isTodayFlag = isToday(parseISO(dateISO));
+
+  // Format from the normalized YYYY-MM-DD, not the raw column value. A stored
+  // "2025-10-24T00:00:00+00:00" parses to an instant, and west of UTC that
+  // instant lands on the 23rd — the day card would name the wrong day.
+  const dayStart = useMemo(() => (normalizedDay ? parseISO(normalizedDay) : null), [normalizedDay]);
+  const weekdayLabel = useMemo(() => (dayStart ? format(dayStart, 'EEEE') : ''), [dayStart]);
+  const formattedDate = useMemo(() => (dayStart ? format(dayStart, 'MMMM d, yyyy') : ''), [dayStart]);
+  const isTodayFlag = dayStart ? isToday(dayStart) : false;
 
   // Filter hotel stays for this day
   const filteredHotelStays = useMemo(() => {
@@ -519,6 +536,7 @@ export function useDayTimeline({
 
   return {
     normalizedDay,
+    weekdayLabel,
     formattedDate,
     isTodayFlag,
     filteredHotelStays,

--- a/src/index.css
+++ b/src/index.css
@@ -291,6 +291,10 @@
     /* Destructive: warm red */
     --destructive: 4 80% 58%;
     --destructive-foreground: 40 33% 97%;
+    /* Destructive as *text* on cream. The 58% lightness above is tuned for
+       filled buttons and clears only 3.7:1 as ink, so small red copy needs
+       its own darker step. */
+    --destructive-ink: 6 54% 43%;
 
     /* Borders: warm */
     --border: 30 18% 87%;
@@ -328,6 +332,7 @@
     --accent-foreground: 36 25% 90%;
     --destructive: 4 80% 45%;
     --destructive-foreground: 36 25% 90%;
+    --destructive-ink: 6 65% 68%;
     --border: 25 10% 22%;
     --input: 25 10% 22%;
     --ring: 28 50% 55%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,6 +100,10 @@ export default {
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
+          // Red as ink. `destructive` itself is a fill colour and only reaches
+          // 3.7:1 on cream paper, so any red *text* smaller than a heading
+          // uses this darker step to clear AA.
+          ink: "hsl(var(--destructive-ink))",
         },
         muted: {
           DEFAULT: "hsl(var(--muted))",


### PR DESCRIPTION
A polish pass over the timeline day card. Everything here was already
functionally complete — this fixes what the surface was saying badly
rather than adding to it.

The trigger was this card:

> **Friday**
> Friday, Oct 24th 2025 · `CHECK-IN`
> 6:23p / 6:51p — Grand Central → Bronxville
> 7:00p / 10:00p — Welcome Cocktail
> *Overlaps by 2h*
> 8:00p / **tbd** — Check-in: Arty's House

Four separate defects visible in six lines.

## What changed

### Copy and content

- **The weekday was said twice.** `title` is null for every
  auto-generated day, so the headline fell back to the weekday and the
  date line repeated it — the card's two most prominent lines spent on
  one word. The weekday is now the headline and the date line gives it
  up: *Friday* / *October 24, 2025*. A day with a real title keeps the
  weekday below it: *Departure day* / *Sunday, October 26, 2025*. Also
  drops the `do` ordinal and restores the missing comma before the year.
- **"tbd" is gone.** It filled the gutter whenever an event had no end
  time, in the same size and column as a real time. A hotel check-in has
  no end, so the row read as a broken value rather than an open one.
- **Overlap hints no longer fire on lodging rows.** A check-in is a
  window you pass through, not an appointment you attend. Flagging 7pm
  drinks as overlapping an 8pm check-in is a false alarm, and a false
  alarm in red teaches people to ignore the real ones. Genuine
  double-bookings still flag.
- **Check-in / Check-out chips only show while the day is collapsed**,
  where they are the only signal. Expanded, "Check-in" the chip and
  "Check-in: Arty's House" the row said the same thing two inches apart.

### Contrast

- **New `--destructive-ink` token.** `--destructive` is tuned as a fill
  colour and reaches only **3.7:1** on cream paper, so every small red
  text on this card was below AA. The token adds a darker ink step at
  **5.6:1**, used by the overlap hint and the now-marker's time. Fills
  (buttons, the now dot) are untouched.
- **Past events recede by ink level, not opacity.** `opacity-50` on the
  whole row had crushed the meta line to **2.1:1** and the title to
  **3.2:1**. Now the title drops to `earth-500` (5.6:1) and the icon and
  rail node mute, so the row still reads as past while every text
  element clears AA.

### Geometry

- **The rail terminates at its endpoints.** It previously ran from the
  row edge to the row edge, so the line dangled above the first node and
  below the last — the day looked cut off at both ends. `railStart` /
  `railEnd` now stop the hairline at the node, threaded through
  `TimelineRow`, `GroupedEventCard`, and `NowIndicator`. A single-row day
  draws a node and no line at all. Hint rows have no node and are never
  handed the flags, so their dashes meet the neighbouring solid line
  without a seam.

### Touch targets

- The pinned hotel strip (`h-strip`, 36px) and the four empty-state
  buttons (`size="sm"`, 36px) were under the 44px mobile floor in
  DESIGN.md §6. Both are `h-11` below `sm`, desktop density above.

### Accessibility and housekeeping

- `aria-controls` wires the day header button to the body it toggles.
- The compact gutter times (`6:23p`) were spoken as "six twenty three
  p". Each now carries an unabbreviated screen-reader twin while the
  visual label is `aria-hidden`.
- Date formatting reads the normalized `YYYY-MM-DD` instead of the raw
  column value. A stored `2025-10-24T00:00:00+00:00` parses to an
  instant, and west of UTC that instant lands on the 23rd — the card
  could name the wrong day. `isTodayFlag` had the same exposure.
- The per-day entry stagger is capped at 6 steps. Unbounded, day 20 of a
  long trip waited a full second to appear, which reads as lag rather
  than choreography.
- `isExpanded` was shadowed inside the period map; renamed to
  `isPeriodOpen`. `renderRow`'s nested ternary is flattened to early
  returns.

## Reviewer notes

Two calls go slightly past pure surface polish, both deliberate:

1. **Lodging overlap suppression is a behaviour change**, not a style
   change. The screenshot above is the false positive it removes. If you
   would rather keep flagging every overlap, it is one condition in
   `useDayTimeline.ts` (`buildGapHint`).
2. **The year stays in the date line.** *October 24* would be cleaner and
   the trip hero already carries the range, but dropping information that
   wasn't asked about felt like the wrong default. Easy to revisit.

`--destructive-ink` is now available system-wide and worth a follow-up
sweep — any small red text elsewhere, form validation especially, has
the same 3.7:1 problem this fixed here.

## Release

Ships as **v7.0.1** (from 6.0.1). `vite.config.ts` reads `pkg.version`
into the emitted `dist/version.json`, which `useVersionCheck()` polls, so
this bump is what prompts installed clients to pick up the new build.
Only the two root entries in `package-lock.json` move — `entities`,
`postcss-load-config` and `unist-util-is` are all coincidentally on 6.0.1
and keep their own versions.

Note that a major bump would conventionally reset to 7.0.0; 7.0.1 is what
was asked for and is what shipped.

## Verification

- `npx vitest run` — **679 tests / 64 files pass**
- `npx tsc -p tsconfig.app.json --noEmit` — **302 errors before, 302
  after**; no new errors (all pre-existing backlog)
- `npx eslint src/components/trip/day tailwind.config.ts` — clean
- Rendered against a Tailwind build of the real `tailwind.config.ts` in a
  static harness to confirm rail terminations, hint continuity, the
  single-row case, and past-row contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

